### PR TITLE
Stop shipping line numbers in .po source references

### DIFF
--- a/cps/translations/ar/LC_MESSAGES/messages.po
+++ b/cps/translations/ar/LC_MESSAGES/messages.po
@@ -19,261 +19,259 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=0 && n%100<=2 ? 4 : 5);\n"
 "Generated-By: Babel 2.15.0\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "الإحصائيات"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 msgid "Server restarted, please reload page."
 msgstr "تم إعادة تشغيل الخادم، يرجى إعادة تحميل الصفحة."
 
-#: cps/admin.py:210
+#: cps/admin.py
 msgid "Performing Server shutdown, please close window."
 msgstr "جاري إيقاف تشغيل الخادم، الرجاء إغلاق النافذة."
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "تم بنجاح! تم إعادة ربط قاعدة البيانات"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "أمر غير معروف"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 "تم بنجاح! الكتب في قائمة انتظار النسخ الاحتياطي للبيانات الوصفية، يُرجى "
 "مراجعة \"المهام\" لمعرفة النتيجة"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr ""
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 
-#: cps/admin.py:414
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover ID applied successfully"
 msgstr "تم حذف {} مستخدم(ين) بنجاح"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr ""
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr ""
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr ""
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr ""
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr ""
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "صفحة المسؤول"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "إعدادات OAuth"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "الاعدادات الأساسية"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "إعدادات واجهة المستخدم"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr "لا يوجد عمود مخصص رقم %(column)d في قاعدة بيانات Calibre"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "تحرير المستخدمين"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "الكل"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "لم يتم العثور على المستخدم"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "تم حذف {} مستخدم(ين) بنجاح"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "إظهار الكل"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "طلب مشوه"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "لا يمكن تغيير اسم الضيف"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "لا يمكن للضيف الحصول على هذا الدور"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr "لم يتبق مستخدم مسؤول، ولا يمكن إزالة دور المسؤول"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "القيمة يجب أن تكون صحيحة أو خاطئة"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "دور غير صالح"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "لا يمكن للضيف الحصول على هذا العرض"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "عرض غير صالح"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr "يتم تحديد موقع الضيف تلقائيًا ولا يمكن تعيينه"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "لم يتم تحديد موقع صالح"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "لم يتم تقديم لغة الكتاب الصالحة"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "لم يتم العثور على المُتغير"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "قاعدة بيانات الإعدادات غير قابلة للكتابة"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "عمود قراءة خاطئ"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "عمود مقيد خاطئ"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "هل تريد حقًا حذف رمز Kobo؟"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "هل تريد حقًا حذف هذا النطاق؟"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "هل تريد حقًا حذف هذا المستخدم؟"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "هل أنت متأكد أنك تريد حذف هذا الرف؟"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr ""
 "هل أنت متأكد أنك تريد تغيير الإعدادات المحلية للمستخدم (المستخدمين) "
 "المحدد(ين)؟"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "هل أنت متأكد أنك تريد تغيير لغات الكتاب المرئية للمستخدم (للمستخدمين) "
 "المحدد(ين)؟"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 "هل أنت متأكد أنك تريد تغيير الدور المحدد للمستخدم (المستخدمين) المحدد(ين)؟"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
 msgstr "هل أنت متأكد أنك تريد تغيير القيود المحددة للمستخدم(ين) المحدد(ين)؟"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -281,14 +279,14 @@ msgstr ""
 "هل أنت متأكد أنك تريد تغيير قيود الرؤية المحددة للمستخدم (المستخدمين) "
 "المحدد(ين)؟"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "هل أنت متأكد أنك تريد تغيير سلوك مزامنة الرف للمستخدم (المستخدمين) "
 "المحدد(ين)؟"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
@@ -296,148 +294,138 @@ msgstr ""
 "هل أنت متأكد أنك تريد تغيير سلوك مزامنة الرف للمستخدم (المستخدمين) "
 "المحدد(ين)؟"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "هل أنت متأكد أنك تريد تغيير موقع مكتبة Calibre؟"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "منع"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "سماح"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "تم حذف {} إدخالات المزامنة"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "لم يتم العثور على الرمز"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "لم يتم العثور على العلامة"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "إجراء غير صالح"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "لم يتم تكوين ملف client_secrets.json لتطبيق الويب"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "موقع ملف السجل غير صالح، يرجى إدخال المسار الصحيح"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "موقع ملف سجل الوصول غير صالح، يرجى إدخال المسار الصحيح"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr "الرجاء إدخال موفر LDAP والمنفذ والاسم المميز ومعرف كائن المستخدم"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "الرجاء إدخال حساب خدمة LDAP وكلمة المرور"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "الرجاء إدخال حساب خدمة LDAP"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr "يجب أن يحتوي مرشح كائن مجموعة LDAP على معرف تنسيق \"%s\" واحد"
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "مرشح كائن مجموعة LDAP يحتوي على أقواس غير متطابقة"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr "يجب أن يحتوي مرشح كائن مستخدم LDAP على معرف تنسيق \"%s\" واحد"
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "مرشح كائن مستخدم LDAP يحتوي على أقواس غير متطابقة"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr "يجب أن يحتوي مرشح مستخدم عضو LDAP على معرف تنسيق \"%s\" واحد"
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "مرشح مستخدم عضو LDAP لديه أقواس غير متطابقة"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
 msgstr ""
 "شهادة LDAP CAC أو الشهادة أو موقع المفتاح غير صالح، يرجى إدخال المسار الصحيح"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "إضافة مستخدم جديد"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "تعديل إعدادات خادم البريد الإلكتروني"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "تم التحقق بنجاح! تم التحقق من حساب Gmail."
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "عفواً! خطأ في قاعدة البيانات: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -445,53 +433,53 @@ msgstr ""
 "تم وضع البريد الإلكتروني التجريبي في قائمة الانتظار لإرساله إلى %(email)s، "
 "يرجى التحقق من المهام للحصول على النتيجة"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "حدث خطأ أثناء إرسال البريد الإلكتروني الاختباري: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "يرجى تكوين عنوان بريدك الإلكتروني أولاً..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "تم تحديث إعدادات خادم البريد الإلكتروني"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "تحرير المستخدمين"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "يرجى تهيئة إعدادات بريد SMTP أولاً..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "يرجى تكوين عنوان بريدك الإلكتروني أولاً..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "تم إرسال كلمة مرور جديدة إلى عنوان بريدك الإلكتروني"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -499,7 +487,7 @@ msgstr ""
 "تم وضع البريد الإلكتروني التجريبي في قائمة الانتظار لإرساله إلى %(email)s، "
 "يرجى التحقق من المهام للحصول على النتيجة"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -508,921 +496,906 @@ msgstr ""
 "تم وضع البريد الإلكتروني التجريبي في قائمة الانتظار لإرساله إلى %(email)s، "
 "يرجى التحقق من المهام للحصول على النتيجة"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "تحرير إعدادات المهام المجدولة"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "وقت بدء غير صالح للمهمة المحددة"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "مدة غير صالحة للمهمة المحددة"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "تم تحديث إعدادات المهام المجدولة"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "عفواً! حدث خطأ غير معروف. يُرجى المحاولة لاحقًا."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "العنوان"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "تعديل المستخدم %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "تم بنجاح! تم إعادة تعيين كلمة المرور للمستخدم %(user)s"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "عفواً! يُرجى ضبط إعدادات بريد SMTP."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "عارض ملف السجل"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "طلب حزمة التحديث"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "تنزيل حزمة التحديث"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "فك ضغط حزمة التحديث"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "استبدال الملفات"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "تم إغلاق اتصالات قاعدة البيانات"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "إيقاف الخادم"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr ""
 "إيقاف الخادم تم الانتهاء من التحديث، الرجاء الضغط على موافق وإعادة تحميل "
 "الصفحة"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "فشل التحديث:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "خطأ HTTP"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "خطأ في الاتصال"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "انتهاء المهلة أثناء إنشاء الاتصال"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "خطأ عام"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr "لم يتم حفظ ملف التحديث في الدليل المؤقت"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "لم يكن من الممكن استبدال الملفات أثناء التحديث"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "فشل استخراج مستخدم LDAP واحد على الأقل"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "فشل إنشاء مستخدم LDAP واحد على الأقل"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "خطأ: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "خطأ: لم يتم إرجاع أي مستخدم استجابةً لخادم LDAP"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "لم يتم العثور على مستخدم LDAP واحد على الأقل في قاعدة البيانات"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} تم استيراد المستخدم بنجاح"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr "مسار الكتب غير صالح"
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "موقع قاعدة البيانات غير صالح، يرجى إدخال المسار الصحيح"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "قاعدة البيانات غير قابلة للكتابة"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "موقع الملف الرئيسي غير صالح، يرجى إدخال المسار الصحيح"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr "موقع ملف الشهادة غير صالح، يرجى إدخال المسار الصحيح"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr "يجب أن يكون طول كلمة المرور بين 1 و 40"
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "تم تحديث إعدادات قاعدة البيانات"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "تكوين قاعدة البيانات"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "عفواً! الرجاء تعبئة جميع الحقول."
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "البريد الإلكتروني ليس من نطاق صالح"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "إضافة مستخدم جديد"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "تم إنشاء المستخدم '%(user)s'"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "عفواً! يوجد حساب بالفعل لهذا البريد الإلكتروني أو الاسم."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "تم حذف المستخدم '%(nick)s'"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "لا يمكن حذف المستخدم الضيف"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "لم يتبق مستخدم مسؤول، لا يمكن حذف المستخدم"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr ""
 "لا يمكن أن يكون البريد الإلكتروني فارغًا ويجب أن يكون بريدًا إلكترونيًا صالحًا"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "تم تحديث المستخدم '%(nick)s'"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr ""
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr ""
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "خطأ في الاتصال"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr ""
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "لا توجد معلومات إصدار متاحة"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr ""
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr ""
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr ""
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "حدث خطأ غير معروف. يرجى المحاولة مرة أخرى لاحقًا."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "خطأ في الاتصال"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "خطأ في الاتصال"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "تم تحميل الملف %(file)s"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr ""
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr ""
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr ""
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr ""
 
-#: cps/constants.py:265
+#: cps/constants.py
 #, fuzzy
 msgid "Finnish"
 msgstr "انتهى"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr ""
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr ""
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr ""
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr ""
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr ""
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr ""
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr ""
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr ""
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr ""
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr ""
 
-#: cps/constants.py:276
+#: cps/constants.py
 #, fuzzy
 msgid "Polish"
 msgstr "الناشر"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr ""
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr ""
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr ""
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr ""
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr ""
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr ""
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr ""
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr ""
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr ""
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr ""
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "غير مثبت"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "أذونات التنفيذ مفقودة"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, fuzzy, python-format
 msgid "Change cover — %(title)s"
 msgstr "تبديل المؤلف والعنوان"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "حدث خطأ غير معروف. يرجى المحاولة مرة أخرى لاحقًا."
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Could not render the e-reader preview."
 msgstr "تعذر العثور على الدليل المحدد"
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Book ID"
 msgstr "الكتب"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "عنوان الكتاب"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "المؤلف"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr ""
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "تنسيقات الملفات"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filename"
 msgstr "الاسم"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr ""
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr ""
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "تحميل التنسيق"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "غير معروف"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr ""
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "دور غير صالح"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 msgid "Selected book has no EPUB format."
 msgstr ""
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "لم يتم العثور على تنسيق %(format)s على القرص"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 msgid "EPUB Fixer started for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr ""
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr ""
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid image data format."
 msgstr "تنسيق عنوان البريد الإلكتروني غير صالح"
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Profile picture updated successfully."
 msgstr "تم حذف {} مستخدم(ين) بنجاح"
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "غير موجود"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "حذف الكتاب"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "حذف الكتاب"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "حذف الكتاب"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "لم يتم العثور على نتائج"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 #, fuzzy
 msgid "Invalid resolution strategy"
 msgstr "دور غير صالح"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "تم التحميل، جاري المعالجة، يرجى الانتظار..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 #, fuzzy
 msgid "Failed to queue upload for processing"
 msgstr "فشل في إنشاء مسار الغلاف"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "تنسيق المصدر أو الوجهة للتحويل مفقود"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "تم وضع الكتاب في قائمة الانتظار بنجاح للتحويل إلى %(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "حدث خطأ أثناء تحويل هذا الكتاب: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "لا يُسمح بتحميل نوع الملف إلى هذا الخادم"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr "لا يُسمح بتحميل ملحق الملف '%(ext)s' إلى هذا الخادم"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "يجب أن يكون للملف المراد تحميله امتداد"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr "عفواً! الكتاب المحدد غير متوفر. الملف غير موجود أو غير قابل للوصول"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "ليس لدى المستخدم الحق في تحميل الغلاف"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr "المعرفات ليست حساسة لحالة الأحرف، مما يؤدي إلى استبدال المعرف القديم"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "'%(langname)s' ليست لغة صالحة"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "تم تحديث البيانات الوصفية بنجاح"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "خطأ في تحرير الكتاب: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "غير معروف"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1430,103 +1403,103 @@ msgstr ""
 "من المحتمل أن يكون الكتاب الذي تم تحميله موجودًا في المكتبة، لذا فكر في "
 "التغيير قبل تحميل كتاب جديد: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "لم يتم حفظ الملف %(filename)s في الدليل المؤقت"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "فشل نقل ملف الغلاف %(file)s: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "تم حذف تنسيق الكتاب بنجاح"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "تم حذف الكتاب بنجاح"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "أنت تفتقد الأذونات اللازمة لحذف الكتب"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "تحرير البيانات الوصفية"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "مؤشر السلسلة: %(seriesindex)s ليس رقمًا صالحًا، تخطي"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr "ليس للمستخدم الحق في تحميل تنسيقات ملفات إضافية"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "فشل إنشاء المسار %(path)s (تم رفض الإذن)."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "فشل تخزين الملف %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "تمت إضافة تنسيق الملف %(ext)s إلى %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "لم يتم العثور على الرمز"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "لم يتم العثور على تنسيق %(format)s على القرص"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
 msgstr ""
 "لم يكتمل إعداد Google Drive، حاول إلغاء تنشيط Google Drive ثم تنشيطه مرة أخرى"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1534,99 +1507,98 @@ msgstr ""
 "لم يتم التحقق من نطاق الاتصال، يرجى اتباع الخطوات للتحقق من النطاق في وحدة "
 "تحكم مطوري Google"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "لم يتم العثور على تنسيق %(format)s لمعرف الكتاب: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "لم يتم العثور على %(format)s على Google Drive: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "لم يتم العثور على %(format)s: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "إرسال إلى القارئ الإلكتروني"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "لم يتم العثور على تنسيق %(format)s لمعرف الكتاب: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "لم يتم العثور على تنسيق %(format)s لمعرف الكتاب: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 msgid "Test Email"
 msgstr "اختبار البريد الإلكتروني"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "البريد الإلكتروني للتسجيل للمستخدم: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "تحويل %(orig)s إلى %(format)s وإرساله إلى القارئ الإلكتروني"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, python-format
 msgid "Send %(format)s to eReader"
 msgstr "إرسال %(format)s إلى القارئ الإلكتروني"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s إرسال إلى القارئ الإلكتروني"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "لم تتم قراءة الملف المطلوب. ربما الأذونات خاطئة؟"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "لم يتم ضبط حالة القراءة: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
 msgstr ""
 "فشلت عملية حذف مجلد الكتاب %(id)s، المسار يحتوي على مجلدات فرعية: %(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "حذف الكتاب  %(id)s فشل %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1635,7 +1607,7 @@ msgstr ""
 "حذف الكتاب %(id)s من قاعدة البيانات فقط، مسار الكتاب في قاعدة البيانات غير "
 "صالح: %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
@@ -1643,192 +1615,192 @@ msgstr ""
 "فشلت عملية إعادة تسمية المؤلف من: '%(src)s' إلى '%(dest)s' مع الخطأ: "
 "%(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "لم يتم العثور على الملف %(file)s على Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "فشلت عملية إعادة تسمية العنوان من: '%(src)s' إلى '%(dest)s' مع الخطأ: "
 "%(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "لم يتم العثور على مسار الكتاب %(path)s على Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr "تم العثور على حساب موجود لعنوان البريد الإلكتروني هذا"
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "اسم المستخدم هذا مستخدم بالفعل"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr "تنسيق عنوان البريد الإلكتروني غير صالح"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr "كلمة المرور لا تتوافق مع قواعد التحقق من صحة كلمة المرور"
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr "لم يتم تثبيت وحدة Python 'advocate' ولكنها ضرورية لتحميلات الغلاف"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "خطأ في تنزيل الغلاف"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr "ملف الغلاف ليس ملف صورة صالحًا، أو لا يمكن تخزينه"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "خطأ في تنسيق الغلاف"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
 msgstr "لا يُسمح لك بالوصول إلى localhost أو الشبكة المحلية لتحميل الغلاف"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "فشل في إنشاء مسار الغلاف"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "ملفات jpg/jpeg/png/webp/bmp فقط مدعومة كملفات غلاف"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "محتوى ملف الغلاف غير صالح"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "ملفات jpg/jpeg فقط مدعومة كملفات غلاف"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr "الغلاف"
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "ملف UnRar الثنائي غير موجود"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr "خطأ في تنفيذ UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr "تعذر العثور على الدليل المحدد"
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr "الرجاء تحديد دليل، وليس ملف"
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr "ملفات Calibre الثنائية غير قابلة للاستخدام"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr "ملفات Calibre الثنائية مفقودة: %(missing)s"
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "أذونات التنفيذ مفقودة: %(missing)s"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr "خطأ في تنفيذ Calibre"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr "وضع جميع الكتب في قائمة الانتظار لنسخ البيانات الوصفية احتياطيًا"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "إعداد Kobo"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "التسجيل باستخدام %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "عفوًا! خادم البريد الإلكتروني غير مهيأ، يرجى الاتصال بمسؤول النظام."
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1836,35 +1808,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "تم بنجاح! أنت الآن مسجل الدخول باسم: %(nickname)s"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "تم ربط %(oauth)s بنجاح"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1872,4469 +1844,4399 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr "عفوًا! خادم البريد الإلكتروني غير مهيأ، يرجى الاتصال بمسؤول النظام."
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "تم إلغاء ربط %(oauth)s بنجاح"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "فشل إلغاء ربط %(oauth)s"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "غير مرتبط بـ %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "فشل تسجيل الدخول باستخدام GitHub."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "فشل جلب معلومات المستخدم من GitHub."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "فشل تسجيل الدخول باستخدام Google."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "فشل جلب معلومات المستخدم من Google."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "Failed to log in with Generic OAuth."
 msgstr "فشل تسجيل الدخول باستخدام GitHub."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "خطأ في OAuth الخاص بـ GitHub، يرجى المحاولة لاحقًا."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "خطأ في OAuth الخاص بـ GitHub: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "خطأ في OAuth الخاص بـ Google، يرجى المحاولة لاحقًا."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "خطأ في OAuth الخاص بـ Google: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, fuzzy, python-brace-format
 msgid "OAuth error: {}"
 msgstr "خطأ في OAuth الخاص بـ GitHub: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "الكتب الأبجدية"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "الكتب مرتبة أبجديًا"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "الكتب الرائجة"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "المنشورات الشائعة من هذا الكتالوج بناءً على التنزيلات."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "الكتب الأعلى تقييمًا"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "المنشورات الشائعة من هذا الكتالوج بناءً على التقييم."
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "الكتب المحملة"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "أحدث الكتب"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "كتب عشوائية"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "عرض الكتب العشوائية"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "الكتب المقروءة"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "الإصدار الحالي"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "الكتب غير المقروءة"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "المؤلفون"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "الكتب مرتبة حسب المؤلف"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "الناشرون"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "الكتب مرتبة حسب الناشر"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "الفئات"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "الكتب مرتبة حسب الفئة"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "السلاسل"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "الكتب مرتبة حسب السلسلة"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "اللغات"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "الكتب مرتبة حسب اللغات"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "التقييمات"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "الكتب مرتبة حسب التقييم"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "تنسيقات الملفات"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "الكتب مرتبة حسب تنسيقات الملفات"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "الأرفف"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "الكتب منظمة في أرفف"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "مزامنة الرفوف المختارة مع Kobo"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "الكتب منظمة في أرفف"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "الوصف"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} نجوم"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "بحث"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "تسجيل الدخول"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "لم يتم العثور على الرمز"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "انتهت صلاحية الرمز"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "نجاح! يرجى العودة إلى جهازك"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "الكتب"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "عرض الكتب الحديثة"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "عرض الكتب الرائجة"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "الكتب المحملة"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "عرض الكتب المحملة"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "عرض الكتب الأعلى تقييمًا"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 msgid "Show Read and Unread"
 msgstr "عرض المقروء وغير المقروء"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "عرض غير المقروء"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "اكتشف"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Category Section"
 msgstr "عرض قسم الفئات"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Series Section"
 msgstr "عرض قسم السلاسل"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Author Section"
 msgstr "عرض قسم المؤلفين"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Publisher Section"
 msgstr "عرض قسم الناشرين"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Language Section"
 msgstr "عرض قسم اللغات"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Ratings Section"
 msgstr "عرض قسم التقييمات"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show File Formats Section"
 msgstr "عرض قسم تنسيقات الملفات"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "الكتب المؤرشفة"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Archived Books"
 msgstr "عرض الكتب المؤرشفة"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "قائمة الكتب"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "عرض قائمة الكتب"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr ""
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "عرض الكتب الأعلى تقييمًا"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "نشر بعد "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "نشر قبل "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "التقييم <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "التقييم >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "حالة القراءة = '%(status)s'"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr "خطأ في البحث عن الأعمدة المخصصة، يرجى إعادة تشغيل Calibre-Web"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "بحث متقدم"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "تم تحديد رف غير صالح"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "عذرًا، لا يُسمح لك بإضافة كتاب إلى هذا الرف"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "الكتاب جزء بالفعل من الرف: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr "%(book_id)s معرف كتاب غير صالح. لا يمكن إضافته إلى الرف"
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "تمت إضافة الكتاب إلى الرف: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "لا يُسمح لك بإضافة كتاب إلى الرف"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "الكتب جزء بالفعل من الرف: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "تمت إضافة الكتب إلى الرف: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "تعذر إضافة الكتب إلى الرف: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "تم تحديد رف غير صالح"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "تعذر إضافة الكتب إلى الرف: %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "الكتب جزء بالفعل من الرف: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "تمت إضافة الكتب إلى الرف: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "تمت إزالة الكتاب من الرف: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "عذرًا، لا يُسمح لك بإزالة كتاب من هذا الرف"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "إنشاء رف"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "عذرًا، لا يُسمح لك بتحرير هذا الرف"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "تحرير رف"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "خطأ في حذف الرف"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "تم حذف الرف بنجاح"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "تغيير ترتيب الرف: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "عذرًا، لا يُسمح لك بإنشاء رف عام"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "تم إنشاء الرف %(title)s"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "تم تغيير الرف %(title)s"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "حدث خطأ"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "رف عام بالاسم '%(title)s' موجود بالفعل."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "رف خاص بالاسم '%(title)s' موجود بالفعل."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "الرف: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "خطأ في فتح الرف. الرف غير موجود أو غير قابل للوصول"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "استبعاد الرفوف"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "مجهول"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "غير مصادق عليه"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "نعم"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "لا"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "حالة القراءة"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "السمة"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "فاتح"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "داكن"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "بني داكن"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "إضافة إلى الرف"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "المؤلف"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "تصفح"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "إغلاق"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "حذف"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "دمج"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "الناشر"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "قراءة"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "العنوان"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "تحميل"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "الحساب"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "المسؤول"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "تاريخ النشر"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "المصدر"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "حول"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr "أي"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr "أرشفة"
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "مؤرشف"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "تحويل"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "الوصف"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "تنزيل"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "تحرير"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "البريد الإلكتروني"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "تمكين مزامنة Kobo"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "التشفير"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "إخفاء"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "المعرفات"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "اللغة"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "كلمة المرور"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "المنفذ"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "التقدم"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "التقييم"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "حفظ"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "تحديد"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "الحالة"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "العلامات"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "المهمة"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "المهام"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "المستخدم"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "اسم المستخدم"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "عرض"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "في انتظار"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "فشل"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "بدأ"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "انتهى"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "انتهى"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "ألغيت"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "حالة غير معروفة"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "بيانات غير متوقعة أثناء قراءة معلومات التحديث"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr "لا يوجد تحديث متاح. لديك بالفعل أحدث إصدار مثبت"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
 msgstr "يتوفر تحديث جديد. انقر على الزر أدناه للتحديث إلى أحدث إصدار."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "تعذر جلب معلومات التحديث"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr "انقر على الزر أدناه للتحديث إلى أحدث إصدار مستقر."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
 "%(version)s"
 msgstr "يتوفر تحديث جديد. انقر على الزر أدناه للتحديث إلى الإصدار: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "لا توجد معلومات إصدار متاحة"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "اكتشف (كتب عشوائية)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "الكتب الرائجة (الأكثر تحميلًا)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "الكتب المحملة بواسطة %(user)s"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "المؤلف: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "الناشر: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "السلسلة: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "التقييم: لا يوجد"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "التقييم: %(rating)s نجوم"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "تنسيق الملف: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "الفئة: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "اللغة: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "الكتب الرائجة"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "كتاب مخفي"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "خطأ في حذف الرف"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "تنسيق عنوان البريد الإلكتروني غير صالح"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 #, fuzzy
 msgid "Invalid request"
 msgstr "دور غير صالح"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr ""
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 #, fuzzy
 msgid "Error creating shelf"
 msgstr "خطأ في حذف الرف"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "إنشاء رف"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 #, fuzzy
 msgid "Shelf name is required"
 msgstr "هذا الحقل مطلوب"
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "خطأ في حذف الرف"
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "تحرير رف"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "لم يتم العثور على المستخدم"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "تم حذف {} مستخدم(ين) بنجاح"
 
-#: cps/web.py:1710
+#: cps/web.py
 #, fuzzy
 msgid "Error duplicating shelf"
 msgstr "خطأ في حذف الرف"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 #, fuzzy
 msgid "Error deleting shelf"
 msgstr "خطأ في حذف الرف"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "خطأ في حذف الرف"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 #, fuzzy
 msgid "Error unhiding shelf"
 msgstr "خطأ في حذف الرف"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "التحميلات"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "قائمة تنسيقات الملفات"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr "يرجى تهيئة إعدادات بريد SMTP أولاً..."
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr "عفوًا! يرجى تحديث ملفك الشخصي ببريد إلكتروني صالح للقارئ الإلكتروني."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "نجاح! تم وضع الكتاب في قائمة الانتظار للإرسال إلى %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "عفوًا! حدث خطأ أثناء إرسال الكتاب: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "نجاح! تم وضع الكتاب في قائمة الانتظار للإرسال إلى %(eReadermail)s"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr "يرجى الانتظار دقيقة واحدة لتسجيل مستخدم آخر"
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "تسجيل"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr "خطأ في الاتصال بالواجهة الخلفية للمُحدد، يرجى الاتصال بمسؤول النظام"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr "عفوًا! خادم البريد الإلكتروني غير مهيأ، يرجى الاتصال بمسؤول النظام."
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "عفوًا! بريدك الإلكتروني غير مسموح به."
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "نجاح! تم إرسال بريد إلكتروني للتأكيد."
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
 msgstr "مثيل Calibre-Web غير مهيأ، يرجى الاتصال بمسؤول النظام"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "عفوًا! خادم البريد الإلكتروني غير مهيأ، يرجى الاتصال بمسؤول النظام."
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr "لا يمكن تفعيل مصادقة LDAP"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr "يرجى الانتظار دقيقة واحدة قبل تسجيل الدخول التالي"
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "لقد قمت الآن بتسجيل الدخول باسم: '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "تم بنجاح! أنت الآن مسجل الدخول باسم: %(nickname)s"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
 msgstr "مثيل Calibre-Web غير مهيأ، يرجى الاتصال بمسؤول النظام"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6343,705 +6245,675 @@ msgstr ""
 "تسجيل دخول احتياطي باسم: '%(nickname)s'، خادم LDAP غير قابل للوصول، أو "
 "المستخدم غير معروف"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr "تعذر تسجيل الدخول: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 msgid "Wrong Username or Password"
 msgstr "اسم المستخدم أو كلمة المرور خاطئة"
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr "تم إرسال كلمة مرور جديدة إلى عنوان بريدك الإلكتروني"
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr "حدث خطأ غير معروف. يرجى المحاولة مرة أخرى لاحقًا."
 
-#: cps/web.py:2838
+#: cps/web.py
 msgid "Please enter valid username to reset password"
 msgstr "يرجى إدخال اسم مستخدم صالح لإعادة تعيين كلمة المرور"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "لقد قمت الآن بتسجيل الدخول باسم: '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 msgid "Success! Profile Updated"
 msgstr "نجاح! تم تحديث الملف الشخصي"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "عفوًا! يوجد حساب بالفعل لهذا البريد الإلكتروني."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 #, fuzzy
 msgid "Invalid book ID."
 msgstr "دور غير صالح"
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr ""
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "لم يتم العثور على ملف gmail.json صالح بمعلومات OAuth"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "%(book)s إرسال إلى القارئ الإلكتروني"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "إرسال إلى القارئ الإلكتروني"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-send completed successfully"
 msgstr "تم حذف {} مستخدم(ين) بنجاح"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr ""
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr "حذف محتويات المجلد المؤقت"
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "تم إرسال %(book)s إلى القارئ الإلكتروني"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "لم يتم العثور على Calibre ebook-convert %(tool)s"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "لم يتم العثور على تنسيق %(format)s على القرص"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "فشل محول الكتب الإلكترونية بخطأ غير معروف"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "فشل محول Kepubify: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "لم يتم العثور على الملف المحول أو أكثر من ملف واحد في المجلد %(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "فشل Calibre مع الخطأ: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "فشل محول الكتب الإلكترونية: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "إعادة الاتصال بقاعدة بيانات Calibre"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "حذف الكتاب"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "حذف الكتاب"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "فك ضغط حزمة التحديث"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "لم يتم العثور على نتائج"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "تمكين مزامنة Kobo"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "بريد إلكتروني"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr "جارٍ نسخ البيانات الوصفية احتياطيًا"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "في المكتبة"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "تم إنشاء %(count)s صور مصغرة للغلاف"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "صور الغلاف المصغرة"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "تم إنشاء {0} صور مصغرة للمسلسلات"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "مسح ذاكرة التخزين المؤقت لصور الغلاف المصغرة"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "الكتب منظمة في أرفف"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "تغيير كلمة المرور"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "إنشاء رف"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "إعدادات الأمان"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "الإعدادات"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "اختر خيارًا"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "إضافة إلى الرف"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(عام)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 msgid "Downloads, fewest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "تنزيل"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "الفرز حسب تاريخ الكتاب، الأحدث أولاً"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "الفرز حسب تاريخ الكتاب، الأقدم أولاً"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "المؤلف"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "المؤلف"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "نشر قبل "
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "نشر قبل "
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "الفرز حسب تاريخ إضافة الكتاب إلى الرف، الأحدث أولاً"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "الفرز حسب تاريخ إضافة الكتاب إلى الرف، الأقدم أولاً"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "إرسال إلى بريد قارئ الكتب الإلكترونية"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "إرسال إلى القارئ الإلكتروني"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "عرض الكتب"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "رف عام"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr ""
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "استيراد مستخدمي LDAP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "إعدادات خادم البريد الإلكتروني"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "اسم مضيف SMTP"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "منفذ SMTP"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "تسجيل الدخول إلى SMTP"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "من البريد الإلكتروني"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr "خدمة البريد الإلكتروني"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail عبر Oauth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "دليل قاعدة بيانات Calibre"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "مستوى السجل"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "المنفذ الخارجي"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "الكتب لكل صفحة"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "التحميلات"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "التصفح المجهول"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "التسجيل العام"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "تسجيل الدخول عن بعد بالرابط السحري"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "تسجيل الدخول بالوكيل العكسي"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "اسم رأس الوكيل العكسي"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "تحرير التهيئة الأساسية"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "تحرير تهيئة واجهة المستخدم"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "تحرير تهيئة قاعدة بيانات Calibre"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "المهام المجدولة"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "وقت البدء"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "الحد الأقصى للمدة"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "إنشاء صور مصغرة لأغلفة السلاسل"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "إعادة الاتصال بقاعدة بيانات Calibre"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr "إنشاء ملفات النسخ الاحتياطي للبيانات الوصفية"
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "تحديث ذاكرة التخزين المؤقت للصور المصغرة"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Setup KOReader Sync"
 msgstr "قارئ epub"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr ""
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "الإدارة"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "تنزيل حزمة التصحيح"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "عرض السجلات"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "إعادة تشغيل"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "إيقاف التشغيل"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "معلومات الإصدار"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "الإصدار"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "التفاصيل"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "فشل التحديث:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "قناة التحديث"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "الإصدار الحالي"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "التحقق من التحديث"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "إجراء التحديث"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "هل أنت متأكد أنك تريد إعادة التشغيل؟"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "موافق"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "هل أنت متأكد أنك تريد إيقاف التشغيل؟"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "جاري التحديث، يرجى عدم إعادة تحميل هذه الصفحة"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7049,613 +6921,590 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "الكتب في هذه المكتبة"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "جاري التحميل..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "فشل التحديث:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "خطأ في الاتصال"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "السلسلة: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "عبر"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "في المكتبة"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "تقليل"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "المزيد بواسطة"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "حذف الكتاب"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "حذف التنسيقات:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "تحويل تنسيق الكتاب:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "تحويل من:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr "اختر خيارًا"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "تحويل إلى:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "تحويل الكتاب"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "خطأ"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "تحميل التنسيق"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "معرف السلسلة"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "تاريخ النشر"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "نوع المعرف"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "قيمة المعرف"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "إزالة"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "إضافة معرف"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "جلب الغلاف من الرابط (JPEG - سيتم تنزيل الصورة وتخزينها في قاعدة البيانات)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "تحميل الغلاف من القرص المحلي"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "تمكين مزامنة Kobo"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "عرض الكتاب عند الحفظ"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "جلب البيانات الوصفية"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "كلمة مفتاحية"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "كلمة البحث"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "جاري التحميل..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "خطأ في البحث!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "لم يتم العثور على نتائج! يرجى تجربة كلمة مفتاحية أخرى."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "هذا الحقل مطلوب"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 #, fuzzy
 msgid " Exchange author & title"
 msgstr "تبديل المؤلف والعنوان"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "تحديد"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr ""
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Update Title Sort automatically  "
 msgstr "تحديث ترتيب العنوان تلقائيًا"
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "تحديث ترتيب المؤلف تلقائيًا"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "أدخل العنوان"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "أدخل ترتيب العنوان"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "ترتيب العنوان"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "أدخل ترتيب المؤلف"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "ترتيب المؤلف"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "أدخل المؤلفين"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "أدخل الفئات"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "أدخل السلاسل"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "أدخل اللغات"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "تاريخ النشر"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "أدخل الناشرين"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "أدخل التعليقات"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Comments"
 msgstr "التعليقات"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Archived?"
 msgstr "مؤرشف"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Read?"
 msgstr "قراءة"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "أدخل "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "هل أنت متأكد حقًا؟"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "سيتم دمج الكتب ذات العنوان من:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "إلى الكتاب ذي العنوان:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr ""
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr ""
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr ""
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr ""
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr ""
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "تحرير البيانات الوصفية"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "إنشاء رف"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr ""
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "إضافة"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr "عفوًا! خادم البريد الإلكتروني غير مهيأ، يرجى الاتصال بمسؤول النظام."
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr "الرسالة"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "تم إرسال كلمة مرور جديدة إلى عنوان بريدك الإلكتروني"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "إرسال إلى القارئ الإلكتروني"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "رجوع"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "موقع قاعدة بيانات Calibre"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7671,13 +7520,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7688,7 +7537,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7699,43 +7548,43 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr ""
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
 "can be wherever you desire"
 msgstr ""
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "استخدام جوجل درايف؟"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "مصادقة جوجل درايف"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "مجلد Calibre في جوجل درايف"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "معرف قناة مراقبة البيانات الوصفية"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "إلغاء"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "إعادة الاتصال بقاعدة بيانات Calibre"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7745,90 +7594,90 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "هل أنت متأكد أنك تريد إيقاف التشغيل؟"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "إعادة الاتصال بقاعدة بيانات Calibre"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr "موقع قاعدة البيانات الجديدة غير صالح، يرجى إدخال مسار صالح"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "استخدام المصادقة القياسية"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "استخدام مصادقة LDAP"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "استخدام OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "تهيئة الخادم"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "منفذ الخادم"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "موقع ملف شهادة SSL (اتركه فارغًا للخوادم غير SSL)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "موقع ملف مفتاح SSL (اتركه فارغًا للخوادم غير SSL)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "قناة التحديث"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "مستقر"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "ليلي"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "المضيفون الموثوق بهم (مفصولة بفاصلة)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "تهيئة ملف السجل"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "موقع واسم ملف سجل الوصول (access.log لعدم وجود إدخال)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "تمكين سجل الوصول"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "موقع واسم ملف سجل الوصول (access.log لعدم وجود إدخال)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 msgid "Feature Configuration"
 msgstr "تهيئة الميزات"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr "تحويل الأحرف غير الإنجليزية في العنوان والمؤلف أثناء الحفظ إلى القرص"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
@@ -7836,39 +7685,39 @@ msgstr ""
 "تضمين البيانات الوصفية في ملف الكتاب الإلكتروني عند التنزيل/التحويل/البريد "
 "الإلكتروني (يتطلب ملفات Calibre/Kepubify الثنائية)"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "تمكين التحميلات"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr "(يرجى التأكد من أن المستخدمين لديهم أذونات التحميل أيضًا)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "تنسيقات الملفات المسموح بتحميلها"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "تمكين التصفح المجهول"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "تمكين التسجيل العام"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "استخدام البريد الإلكتروني كاسم مستخدم"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "تمكين تسجيل الدخول عن بعد بالرابط السحري"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7876,154 +7725,154 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "وكيل الطلبات غير المعروفة إلى متجر Kobo"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "المنفذ الخارجي للخادم (لمكالمات API المعاد توجيهها عبر المنفذ)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "استخدام Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "مفتاح API لـ Goodreads"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Hardcover Sync"
 msgstr "تمكين مزامنة Kobo"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "انتهت صلاحية الرمز"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "مفتاح API لـ Goodreads"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8031,412 +7880,412 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "السماح بمصادقة الوكيل العكسي"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "نوع تسجيل الدخول"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "اسم مضيف خادم LDAP أو عنوان IP"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "منفذ خادم LDAP"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "تشفير LDAP"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr "مسار شهادة LDAP CA (مطلوب فقط لمصادقة شهادة العميل)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr "مسار شهادة LDAP (مطلوب فقط لمصادقة شهادة العميل)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr "مسار ملف مفتاح LDAP (مطلوب فقط لمصادقة شهادة العميل)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "مصادقة LDAP"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "بسيط"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "اسم مستخدم مسؤول LDAP"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "كلمة مرور مسؤول LDAP"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "الاسم المميز لـ LDAP (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "مرشح كائن مستخدم LDAP"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "هل خادم LDAP هو OpenLDAP؟"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr "الإعدادات التالية مطلوبة لاستيراد المستخدمين"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "مرشح كائن مجموعة LDAP"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "اسم مجموعة LDAP"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "حقل أعضاء مجموعة LDAP"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "اكتشاف مرشح مستخدم عضو LDAP"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "اكتشاف تلقائي"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "مرشح مخصص"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "مرشح مستخدم عضو LDAP"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "جلب البيانات الوصفية"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
 msgstr ""
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "تحرير تهيئة واجهة المستخدم"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "لم يتم العثور على الرمز"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "خطأ في الاتصال"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "إعدادات OAuth"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Id"
 msgstr "معرف عميل OAuth لـ %(provider)s"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Secret"
 msgstr "سر عميل OAuth لـ %(provider)s"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "تهيئة العرض"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "اسم المستخدم"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr ""
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "خدمة البريد الإلكتروني"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr ""
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "اسم مجموعة LDAP"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr ""
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "الإعدادات الافتراضية للمستخدمين الجدد"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "السماح بالتحميلات"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "السماح بعارض الكتب الإلكترونية"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "السماح بالتحميلات"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "السماح بالتحرير"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "السماح بحذف الكتب"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "السماح بتغيير كلمة المرور"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "السماح بتحرير الرفوف العامة"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr ""
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "الحصول على بيانات اعتماد OAuth لـ %(provider)s"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "معرف عميل OAuth لـ %(provider)s"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "سر عميل OAuth لـ %(provider)s"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "الملفات الثنائية الخارجية"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr "مسار ملفات Calibre الثنائية"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 msgid "Calibre E-Book Converter Settings"
 msgstr "إعدادات محول الكتب الإلكترونية Calibre"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "مسار محول الكتب الإلكترونية Kepubify"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 msgid "Location of Unrar binary"
 msgstr "موقع ملف Unrar الثنائي"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 msgid "Security Settings"
 msgstr "إعدادات الأمان"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8444,337 +8293,332 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr "تحديد محاولات تسجيل الدخول الفاشلة"
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr "تهيئة الواجهة الخلفية للمُحدد"
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr "خيارات الواجهة الخلفية للمُحدد"
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr "التحقق مما إذا كانت امتدادات الملفات تتطابق مع محتوى الملف عند التحميل"
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 msgid "Session protection"
 msgstr "حماية الجلسة"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr "أساسي"
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr "قوي"
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 msgid "User Password policy"
 msgstr "سياسة كلمة مرور المستخدم"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr "الحد الأدنى لطول كلمة المرور"
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr "فرض الأرقام"
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr "فرض الأحرف الصغيرة"
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr "فرض الأحرف الكبيرة"
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr "فرض الأحرف (مطلوب للأحرف الصينية/اليابانية/الكورية)"
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr "فرض الأحرف الخاصة"
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "تهيئة العرض"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "عدد الكتب العشوائية للعرض"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr "عدد المؤلفين للعرض قبل الإخفاء (0=تعطيل الإخفاء)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "افتراضي"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "caliBlur! السمة الداكنة"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "تعبير عادي لتجاهل الأعمدة"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "ربط حالة المقروء/غير المقروء بعمود Calibre"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "ربط حالة المقروء/غير المقروء بعمود Calibre"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "قيود العرض بناءً على عمود Calibre"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "تعبير عادي لترتيب العنوان"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "تهيئة العرض"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Custom CSS"
 msgstr "مرشح مخصص"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "الإعدادات الافتراضية للمستخدمين الجدد"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "الإصدار"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "مستخدم مسؤول"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "عرض صفحة واحدة"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "اللغة الافتراضية"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "الإعدادات الافتراضية للمستخدمين الجدد"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "اللغة المرئية الافتراضية للكتب"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "الرؤى الافتراضية للمستخدمين الجدد"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "الرؤى الافتراضية للمستخدمين الجدد"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "عرض الكتب العشوائية في عرض التفاصيل"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "إضافة علامات مسموح بها/مرفوضة"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "إضافة قيم أعمدة مخصصة مسموح بها/مرفوضة"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "تحميل"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "أرشفة"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "تنزيل"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "بدء"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8783,14 +8627,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8798,93 +8642,92 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on selected book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "تم حذف {} مستخدم(ين) بنجاح"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "خطأ في حذف الرف"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "لم يتم العثور على نتائج"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "أدخل اسم المستخدم"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "البحث في المكتبة"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "إنشاء رف"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer started for selected book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "خطأ في حذف الرف"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8892,11 +8735,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -8907,11 +8750,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -8921,162 +8764,162 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "الكتب المؤرشفة"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9084,11 +8927,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9096,110 +8939,108 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "تم تحديث البيانات الوصفية بنجاح"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "المعرفات"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "الغلاف"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
 "investigation."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9207,157 +9048,157 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "إعدادات OAuth"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "الإعدادات"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "إعدادات OAuth"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9365,103 +9206,102 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "مزامنة الرفوف المختارة مع Kobo"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "إعدادات OAuth"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9469,44 +9309,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "اختر سمة أدناه:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9514,989 +9354,971 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "تمكين التسجيل العام"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "إعدادات OAuth"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "تمكين التسجيل العام"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "تمكين التسجيل العام"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "حذف التنسيقات:"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "جلب البيانات الوصفية"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "التقييم"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "التالي"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "وضع علامة كـ غير مقروء"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "وضع علامة كـ مقروء"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "وضع علامة كـ غير مقروء"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "وضع علامة كـ غير مقروء"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "إضافة إلى الأرشيف"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "استعادة من الأرشيف"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "استعادة من الأرشيف"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "إضافة إلى الأرشيف"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "استعادة من الأرشيف"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "البحث في المكتبة"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "تم تحديث إعدادات قاعدة البيانات"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "التقييم أعلى من"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "كتاب %(index)s من %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 #, fuzzy
 msgid "File sizes"
 msgstr "أحجام الخطوط"
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "الوصف:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "إرسال إلى بريد قارئ الكتب الإلكترونية"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "إرسال إلى بريد قارئ الكتب الإلكترونية"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "تحديد"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "حذف التنسيقات:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "فشل في إنشاء مسار الغلاف"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "فشل في إنشاء مسار الغلاف"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr ""
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "حذف الكتاب"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "عرض الكتب الأعلى تقييمًا"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "تحديد"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "حذف هذا الرف"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "حذف الكتاب"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "السابق"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "دمج الكتب المختارة"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "تفاصيل الكتاب"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "تحرير البيانات الوصفية"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "الكتب المؤرشفة"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "لم يتم العثور على نتائج"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr ""
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "حذف التنسيقات:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be permanently deleted:"
 msgstr "سيتم مسح هذا الكتاب بشكل دائم من قاعدة البيانات"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "الكتب غير المقروءة"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "سيتم مسح هذا الكتاب بشكل دائم من قاعدة البيانات"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "سيتم مسح هذا الكتاب بشكل دائم من قاعدة البيانات"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr ""
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr ""
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr ""
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "نوع حساب البريد الإلكتروني"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr "حساب بريد إلكتروني قياسي"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr "حساب Gmail"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr "إعداد حساب Gmail"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "إلغاء الوصول إلى Gmail"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "كلمة مرور SMTP"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "حد حجم المرفقات"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 msgid "Save and Send Test Email"
 msgstr "حفظ وإرسال بريد إلكتروني اختباري"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "النطاقات المسموح بها (القائمة البيضاء)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "إضافة نطاق"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "أدخل اسم النطاق"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "النطاقات المرفوضة (القائمة السوداء)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
 msgstr "افتح ملف .kobo/Kobo/Kobo eReader.conf في محرر نصوص وأضف (أو عدّل):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "رمز Kobo:"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "قائمة"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "تحديد"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "مصطلح البحث:"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "عرض الكتاب عند الحفظ"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "تحديد"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "جاري التحميل..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
@@ -10504,1418 +10326,1410 @@ msgid ""
 msgstr ""
 "هل أنت متأكد أنك تريد تغيير الدور المحدد للمستخدم (المستخدمين) المحدد(ين)؟"
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "فشل في إنشاء مسار الغلاف"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr ""
 "هل أنت متأكد أنك تريد تغيير الدور المحدد للمستخدم (المستخدمين) المحدد(ين)؟"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "تحديد"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "فشل في إنشاء مسار الغلاف"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "مثيل Calibre-Web غير مهيأ، يرجى الاتصال بمسؤول النظام"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "إنشاء مشكلة"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "العودة إلى الرئيسية"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "تسجيل خروج المستخدم"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "تحرير رف"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show this shelf in your sidebar"
 msgstr "مزامنة هذا الرف مع جهاز Kobo"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "إظهار الكل"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "رف عام"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "إضافة إلى الرف"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "الرئيسية"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "تبديل التنقل"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "البحث في المكتبة"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "كتالوج الكتب الإلكترونية Calibre-Web"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "تسجيل الخروج"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 msgid "Settings"
 msgstr "الإعدادات"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "البحث في المكتبة"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "لا توجد معلومات إصدار متاحة"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "كتالوج الكتب الإلكترونية Calibre-Web"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "حذف الكتاب"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "يرجى عدم تحديث الصفحة"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "إنشاء رف"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "السابق"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "تفاصيل الكتاب"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "هل أنت متأكد أنك تريد إيقاف التشغيل؟"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "حذف هذا الرف"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "تحميل التنسيق"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "حذف التنسيقات:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "حذف الكتاب"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "لم يتم العثور على نتائج"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "مقياس إلى الأفضل"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "إلى:"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "التهيئة"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "إضافة إلى الرف"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "وضع علامة كـ غير مقروء"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "وضع علامة كـ غير مقروء"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "حذف الكتاب"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "حذف الكتاب"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "إنشاء رف"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "خطأ في الاتصال"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr ""
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "شبكة"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "كلمة مرور SMTP"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "تذكرني"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "هل نسيت كلمة المرور؟"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "تسجيل الدخول بالرابط السحري"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 #, fuzzy
 msgid "Log in with SSO"
 msgstr "تسجيل الدخول بالرابط السحري"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "عرض سجل Calibre-Web: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Calibre-Web Log: "
 msgstr "سجل Calibre-Web: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "إخراج البث، لا يمكن عرضه"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "عرض سجل الوصول: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "تنزيل سجل Calibre-Web"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "تنزيل سجل الوصول"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "مشاركة مع الجميع"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "تحديد العلامات المسموح بها/المرفوضة"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "تحديد قيم الأعمدة المخصصة المسموح بها/المرفوضة"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "تحديد علامات المستخدم المسموح بها/المرفوضة"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr "تحديد قيم الأعمدة المخصصة المسموح بها/المرفوضة للمستخدم"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "أدخل العلامة"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "إضافة قيد العرض"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "سيتم مسح تنسيق الكتاب هذا بشكل دائم من قاعدة البيانات"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "سيتم مسح هذا الكتاب بشكل دائم من قاعدة البيانات"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "والقرص الصلب"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr "ملاحظة Kobo هامة: الكتب المحذوفة ستبقى على أي جهاز Kobo مقترن."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
 msgstr "يجب أولاً أرشفة الكتب ومزامنة الجهاز قبل أن يتم حذف الكتاب بأمان."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "اختر موقع الملف"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "النوع"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "الاسم"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "الحجم"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "الدليل الأصل"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "موافق"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "كتالوج الكتب الإلكترونية Calibre-Web"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "قارئ epub"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "الإجراءات"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "أسود"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "أحجام الخطوط"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "الصفحة التالية"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr "الخط"
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 msgid "Default"
 msgstr "افتراضي"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr "ياهاي"
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr "SimSun"
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 msgid "KaiTi"
 msgstr "KaiTi"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 msgid "Arial"
 msgstr "Arial"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 msgid "Spread"
 msgstr "انتشار"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr "عمودان"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr "عمود واحد"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "إعادة تدفق النص عند فتح الأشرطة الجانبية."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "قارئ القصص المصورة"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "اختصارات لوحة المفاتيح"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "الصفحة السابقة"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "الصفحة التالية"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 msgid "Single Page Display"
 msgstr "عرض صفحة واحدة"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr "عرض شريط طويل"
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "مقياس إلى الأفضل"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "مقياس إلى العرض"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "مقياس إلى الارتفاع"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "مقياس إلى الأصلي"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "تدوير لليمين"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "تدوير لليسار"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "قلب الصورة"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "عرض"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 msgid "Single Page"
 msgstr "صفحة واحدة"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr "شريط طويل"
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "مقياس"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "الأفضل"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "العرض"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "الارتفاع"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "الأصلي"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "تدوير"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "قلب"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "أفقي"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "عمودي"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 msgid "Direction"
 msgstr "الاتجاه"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "من اليسار إلى اليمين"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "من اليمين إلى اليسار"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr "إعادة تعيين إلى الأعلى"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 msgid "Remember Position"
 msgstr "تذكر الموضع"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "شريط التمرير"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "إظهار"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "قارئ DJVU"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "قارئ PDF"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "قارئ txt"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "تسجيل حساب جديد"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "اختر اسم مستخدم"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "بريدك الإلكتروني"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "الرابط السحري - تفويض جهاز جديد"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "على جهاز آخر، سجل الدخول وقم بزيارة:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "بمجرد التحقق، سيتم تسجيل دخولك تلقائيًا على هذا الجهاز."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "سينتهي صلاحية رابط التحقق هذا في غضون 10 دقائق."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "إنشاء صور مصغرة لأغلفة السلاسل"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "لم يتم العثور على نتائج"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "مصطلح البحث:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "نتائج لـ:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "تاريخ النشر من"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "تاريخ النشر إلى"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr "فارغ"
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "استبعاد العلامات"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "استبعاد السلاسل"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "استبعاد الرفوف"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "استبعاد اللغات"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "الامتدادات"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "استبعاد الامتدادات"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "التقييم أعلى من"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "التقييم أقل من"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "من:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "إلى:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "حذف هذا الرف"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "تحرير خصائص الرف"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "كتاب مخفي"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "ترتيب الكتب يدويًا"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "تعطيل تغيير الترتيب"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "تمكين تغيير الترتيب"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "دمج الكتب المختارة"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "الحساب"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "لم يتم العثور على الرمز"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "حذف هذا الرف"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "إضافة إلى الرف"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "البحث في المكتبة"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "البحث في المكتبة"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "مشاركة مع الجميع"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "مزامنة هذا الرف مع جهاز Kobo"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "لم يتم العثور على المستخدم"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "كتاب مخفي"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "إحصائيات المكتبة"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "الكتب في هذه المكتبة"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "المؤلفون في هذه المكتبة"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "الفئات في هذه المكتبة"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "السلاسل في هذه المكتبة"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "إحصائيات النظام"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "البرنامج"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "الإصدار المثبت"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "وقت التشغيل"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr "الإجراءات"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "تدوير"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr "سيتم إلغاء هذه المهمة. سيتم حفظ أي تقدم تم إحرازه بواسطة هذه المهمة."
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
 msgstr ""
 "إذا كانت هذه مهمة مجدولة، فسيتم إعادة تشغيلها خلال الوقت المجدول التالي."
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "تم حذف {} مستخدم(ين) بنجاح"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "كتالوج الكتب الإلكترونية Calibre-Web"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "بريدك الإلكتروني"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "الإعدادات"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "إعادة تعيين كلمة مرور المستخدم"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "تهيئة الخادم"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "إرسال إلى بريد قارئ الكتب الإلكترونية"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "أدخل اللغات"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "لغة الكتب"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "لم يتم تقديم لغة الكتاب الصالحة"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "إعدادات OAuth"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "ربط"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "إلغاء الربط"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "رمز مزامنة Kobo"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "إنشاء/عرض"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "فرض مزامنة Kobo كاملة"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "مزامنة الكتب الموجودة في الرفوف المحددة فقط مع Kobo"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "مزامنة الكتب الموجودة في الرفوف المحددة فقط مع Kobo"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "إعدادات الأمان"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "إضافة قيم أعمدة مخصصة مسموح بها/مرفوضة"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Magic Shelves Order"
 msgstr "مزامنة الرفوف المختارة مع Kobo"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "الكتب المضافة حديثًا"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "تحرير الرفوف العامة"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "حذف المستخدم"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -11923,155 +11737,155 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "تغيير كلمة المرور"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "تغيير كلمة المرور"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "إنشاء/عرض"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "إنشاء رابط مصادقة Kobo"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "اختر..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "إزالة التحديدات"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "تعديل المستخدم"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "أدخل اسم المستخدم"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 msgid "Enter Email"
 msgstr "أدخل البريد الإلكتروني"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "Enter eReader Email"
 msgstr "أدخل بريد القارئ الإلكتروني"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "eReader Email"
 msgstr "بريد القارئ الإلكتروني"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "أدخل بريد القارئ الإلكتروني"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "بريد القارئ الإلكتروني"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "الموقع"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "لغات الكتب المرئية"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "تعديل العلامات المسموح بها"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "العلامات المسموح بها"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "تعديل العلامات المرفوضة"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "العلامات المرفوضة"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "تعديل قيم العمود المسموح بها"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "القيم المسموح بها للعمود"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "تعديل قيم العمود المرفوضة"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "قيم الأعمدة المرفوضة"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "تغيير كلمة المرور"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "تحرير الرفوف العامة"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "مزامنة الرفوف المختارة مع Kobo"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "مزامنة الرفوف المختارة مع Kobo"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 msgid "Show Read/Unread Section"
 msgstr "إظهار قسم المقروء/غير المقروء"
 

--- a/cps/translations/cs/LC_MESSAGES/messages.po
+++ b/cps/translations/cs/LC_MESSAGES/messages.po
@@ -18,1404 +18,1377 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Statistika"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 #, fuzzy
 msgid "Server restarted, please reload page."
 msgstr "Server restartován, znovu načtěte stránku"
 
-#: cps/admin.py:210
+#: cps/admin.py
 #, fuzzy
 msgid "Performing Server shutdown, please close window."
 msgstr "Vypínám server, zavřete okno"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr ""
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Neznámý příkaz"
 
-#: cps/admin.py:232
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr "Kniha byla úspěšně zařazena do fronty pro odeslání na %(eReadermail)s"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr ""
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 
-#: cps/admin.py:414
+#: cps/admin.py
 msgid "Hardcover ID applied successfully"
 msgstr ""
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr ""
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr ""
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr ""
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr ""
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr ""
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Stránka správce"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "Nastavení OAuth"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Základní konfigurace"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Konfigurace uživatelského rozhraní"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, fuzzy, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr "Vlastní sloupec %(column)d neexistuje v databázi"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Edit Users"
 msgstr "Uživatel admin"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Vše"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Uživatel nenalezen"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr ""
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Zobrazit vše"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr ""
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr ""
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr ""
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr "Nezbývá žádný správce, nelze odebrat roli správce"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr ""
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr ""
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr ""
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr ""
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr ""
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr ""
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr ""
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr ""
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr ""
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr ""
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Opravdu chcete odstranit Kobo token?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr ""
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr ""
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Jste si jisti, že chcete odstranit tuto polici?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 #, fuzzy
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr "Jste si jisti, že chcete odstranit tuto polici?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1095
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
 msgstr "Jste si jisti, že chcete odstranit tuto polici?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1100
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr "Jste si jisti, že chcete odstranit tuto polici?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
 msgstr "Jste si jisti, že chcete odstranit tuto polici?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 #, fuzzy
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Opravdu chcete vypnout?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Zakázat"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Povolit"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr ""
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Token nenalezen"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr ""
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr ""
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json není nakonfigurováno pro webové aplikace"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "Umístění zápisového souboru není platné. Určete prosím platnou polohu"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Umístění zápisového souboru pro přístup není platné. Určete prosím platnou "
 "polohu"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 "Prosím zadejte LDAP poskytovatele, port, DN a Identifikátor objektu uživatele"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 #, fuzzy
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Zadejte platné uživatelské jméno pro obnovení hesla"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr ""
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr "Filtr objektů skupiny LDAP musí mít jeden “%s” formátový identifikátor"
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "Filtr objektů skupiny LDAP má nesrovnatelnou závorku"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Filtr uživatelských objektů LDAP musí mít jeden “%s” formátový identifikátor"
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "Filtr uživatelských objektů LDAP má nesrovnatelnou závorku"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
 msgstr ""
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Přidat nového uživatele"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Změnit SMTP nastavení"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr ""
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Chyba databáze: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
 msgstr ""
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Při odesílání zkušebního e-mailu došlo k chybě: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Prvně nastavte svou e-mailovou adresu..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Nastavení e-mailového serveru aktualizováno"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "Uživatel admin"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Nejprve nakonfigurujte nastavení pošty SMTP..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "Prvně nastavte svou e-mailovou adresu..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "Nové heslo bylo zasláno na vaši emailovou adresu"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
 msgstr ""
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
 "delivery."
 msgstr ""
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr ""
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr ""
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr ""
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr ""
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Neznámá chyba. Opakujte prosím později."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "Název"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Upravit uživatele %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Heslo pro uživatele %(user)s resetováno"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Nejprve nakonfigurujte nastavení pošty SMTP..."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Prohlížeč log souborů"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Požadování balíčku aktualizace"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Stahování balíčku aktualizace"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Rozbalování balíčku aktualizace"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Nahrazování souborů"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Databázová připojení jsou uzavřena"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Zastavuji server"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Aktualizace dokončena, klepněte na tlačítko OK a znovu načtěte stránku"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Aktualizace selhala:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "HTTP chyba"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Chyba připojení"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Vypršel časový limit při navazování spojení"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Všeobecná chyba"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 #, fuzzy
 msgid "Update file could not be saved in temp dir"
 msgstr "Aktualizační soubor nemohl být uložen do Temp Dir"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr ""
 
-#: cps/admin.py:2419
+#: cps/admin.py
 #, fuzzy
 msgid "Failed to extract at least One LDAP User"
 msgstr "Nepodařilo se vytvořit nejméně jednoho uživatele LDAP"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Nepodařilo se vytvořit nejméně jednoho uživatele LDAP"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Chyba: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Chyba: Žádná reakce od uživatele LDAP serveru"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "Nejméně jeden uživatel LDAP nenalezen v databázi"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr ""
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr ""
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "Umístění databáze není platné, opravte prosím cestu"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "Databáze není zapisovatelná"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "Umístění souboru klíčů není platné, zadejte prosím správnou cestu"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr "Umístění certifikátu není platné, zadejte prosím správnou cestu"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr ""
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 #, fuzzy
 msgid "Database Settings updated"
 msgstr "Nastavení e-mailového serveru aktualizováno"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 #, fuzzy
 msgid "Database Configuration"
 msgstr "Konfigurace funkcí"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Vyplňte všechna pole!"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "E-mail není z platné domény"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Přidat nového uživatele"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Uživatel '%(user)s' vytvořen"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "Byl nalezen existující účet pro tuto e-mailovou adresu nebo přezdívku."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Uživatel '%(nick)s' smazán"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr ""
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "Nezbývá žádný správce, nemůžete jej odstranit"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr ""
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Uživatel '%(nick)s' aktualizován"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr ""
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr ""
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Chyba připojení"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr ""
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "Nejsou k dispozici žádné informace o verzi"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr ""
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr ""
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr ""
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "Neznámá chyba. Opakujte prosím později."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "Chyba připojení"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Chyba připojení"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "Soubor %(file)s nahrán"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr ""
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr ""
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr ""
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr ""
 
-#: cps/constants.py:265
+#: cps/constants.py
 #, fuzzy
 msgid "Finnish"
 msgstr "Dokončeno"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr ""
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr ""
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr ""
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr ""
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr ""
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr ""
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr ""
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr ""
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr ""
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr ""
 
-#: cps/constants.py:276
+#: cps/constants.py
 #, fuzzy
 msgid "Polish"
 msgstr "Vydavatel"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr ""
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr ""
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr ""
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr ""
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr ""
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr ""
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr ""
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr ""
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr ""
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr ""
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "není nainstalováno"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Chybí povolení k exekuci"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, python-format
 msgid "Change cover — %(title)s"
 msgstr ""
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Chyba připojení"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr ""
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Book ID"
 msgstr "Knihy"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Název knihy"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "Autor"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr ""
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "Formáty souborů"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filename"
 msgstr "Přezdívka"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr ""
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr ""
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "Nahrát formát"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "Neznámý"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr ""
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "Zadána neplatná police"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "Označit jako nepřečtené"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "%(format)s formát nenalezen na disku"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 msgid "EPUB Fixer started for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr ""
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr ""
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 msgid "Invalid image data format."
 msgstr ""
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr ""
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Žádné"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "Smazat knihu"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "Smazat knihu"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "Smazat knihu"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "Nenalezeny žádné výsledky"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 msgid "Invalid resolution strategy"
 msgstr ""
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Nahrávání hotovo, zpracovávám, čekejte prosím..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 #, fuzzy
 msgid "Failed to queue upload for processing"
 msgstr "Vytvoření cesty obalu selhalo"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Chybí zdrojový nebo cílový formát pro převod"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "Kniha byla úspěšně zařazena do fronty pro převod do %(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Při převodu této knihy došlo k chybě: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 #, fuzzy
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "Soubor s příponou '%(ext)s' nelze odeslat na tento server"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr "Soubor s příponou '%(ext)s' nelze odeslat na tento server"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "Soubor, který má být odeslán musí mít příponu"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 "Jejda! Vybraná kniha není k dispozici. Soubor neexistuje nebo není přístupný"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr ""
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "%(langname)s není platným jazykem"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Metadata úspěšně aktualizována"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr ""
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Neznámý"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1423,96 +1396,96 @@ msgstr ""
 "Nahraná kniha pravděpodobně existuje v knihovně, zvažte prosím změnu před "
 "nahráním nové: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "Soubor %(filename)s nemohl být uložen do dočasného adresáře"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Nepodařilo se přesunout soubor obalu %(file)s: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Formát knihy úspěšně smazán"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Kniha úspěšně smazána"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr ""
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "upravit metadata"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr ""
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr ""
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Nepodařilo se vytvořit cestu %(path)s (oprávnění odepřeno)."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Uložení souboru %(file)s se nezdařilo."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Formát souboru %(ext)s přidán do %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Token nenalezen"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "%(format)s formát nenalezen na disku"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1520,7 +1493,7 @@ msgstr ""
 "Google Drive nastavení nebylo dokončeno, zkuste  znovu deaktivovat a "
 "aktivovat Google Drive"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1528,301 +1501,300 @@ msgstr ""
 "Doména zpětného volání není ověřena, postupujte podle pokynů k ověření "
 "domény v konzole pro vývojáře google"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "%(format)s formát pro knihu: %(book)d nenalezen"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(format)s nenalezen na Google Drive: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s nenalezen: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 #, fuzzy
 msgid "Send to eReader"
 msgstr "Poslat do Kindle"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "%(format)s formát pro knihu: %(book)d nenalezen"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "%(format)s formát pro knihu: %(book)d nenalezen"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 #, fuzzy
 msgid "Test Email"
 msgstr "Zkušební e-mail"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Registrační e-mail pro uživatele: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Převést %(orig)s do %(format)s a poslat do Kindle"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Poslat %(format)s do Kindle"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "%(book)s send to eReader"
 msgstr "Poslat do Kindle"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "Požadovaný soubor nelze přečíst. Možná nesprávná oprávnění?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr ""
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
 msgstr ""
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "Mazání knihy selhalo %(id)s failed: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, fuzzy, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
 "%(path)s"
 msgstr "Mazání knihy %(id)s, cesta ke knize není platná %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, fuzzy, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Přejmenování názvu z: '%(src)s' na '%(dest)s'  selhalo chybou: %(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Soubor %(file)s nenalezen na Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Přejmenování názvu z: '%(src)s' na '%(dest)s'  selhalo chybou: %(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Cesta ke knize %(path)s nebyla nalezena na Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr ""
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Zadané uživatelské jméno je již použito"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr ""
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr ""
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Chyba stahování obalu"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr "Soubor obalu není platný, nebo nelze uložit"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Chyba formátu obalu"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
 msgstr ""
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Vytvoření cesty obalu selhalo"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr ""
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr ""
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Pouze jpg/jpeg jsou podporované soubory pro obal"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr ""
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "UnRar binární soubor nenalezen"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing UnRar"
 msgstr "Chyba provádění UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr ""
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr ""
 
-#: cps/helper.py:2125
+#: cps/helper.py
 #, fuzzy
 msgid "Calibre binaries not viable"
 msgstr "Databáze není zapisovatelná"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Chybí povolení k exekuci"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing Calibre"
 msgstr "Chyba provádění UnRar"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr ""
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Kobo nastavení"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Registrovat s %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "E-mailový server není nakonfigurován, kontaktujte svého správce!"
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1830,35 +1802,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "nyní jste přihlášen jako: '%(nickname)s'"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Připojení k %(oauth)s úspěšné"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1866,4149 +1838,4081 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr "E-mailový server není nakonfigurován, kontaktujte svého správce!"
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "Odpojení od %(oauth)s úspěšné"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Odpojení od %(oauth)s selhalo"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr ""
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Přihlášení pomocí GitHub selhalo."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Nepodařilo se načíst informace o uživateli z GitHub."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Přihlášení pomocí Google selhalo."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Nepodařilo se načíst informace o uživateli z Google."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "Failed to log in with Generic OAuth."
 msgstr "Přihlášení pomocí GitHub selhalo."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "GitHub Oauth chyba, prosím opakujte později."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr ""
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Google Oauth chyba, prosím opakujte později."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr ""
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr ""
 
-#: cps/opds.py:164
+#: cps/opds.py
 #, fuzzy
 msgid "Alphabetical Books"
 msgstr "Smazat knihu"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr ""
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Žhavé knihy"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "Oblíbené publikace z tohoto katalogu založené na počtu stažení."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Nejlépe hodnocené knihy"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Oblíbené publikace z tohoto katalogu založené na hodnocení."
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "Přečtené knihy"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Nejnovější knihy"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Náhodné knihy"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Zobrazit náhodné knihy"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Přečtené knihy"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Současná verze"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Nepřečtené knihy"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Autoři"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Knihy seřazené podle autora"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Vydavatelé"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Knihy seřazené podle vydavatele"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Kategorie"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Knihy seřazené podle kategorie"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Série"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Knihy seřazené podle série"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Jazyky"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Knihy seřazené podle jazyků"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Hodnocení"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Knihy řazené podle hodnocení"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Formáty souborů"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Knihy seřazené podle souboru formátů"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Police"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "Knihy organizované v policích"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Veřejná police"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Knihy organizované v policích"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "Popis"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr ""
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Hledat"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Přihlásit"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Token nenalezen"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Token vypršel"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Úspěch! Vraťte se prosím do zařízení"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Knihy"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Zobrazit nedávné knihy"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Zobrazit žhavé knihy"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr ""
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr ""
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Zobrazit nejlépe hodnocené knihy"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Read and Unread"
 msgstr "Zobrazit prečtené a nepřečtené"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Zobrazit nepřečtené"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Objevte"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Category Section"
 msgstr "Zobrazit výběr kategorie"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Series Section"
 msgstr "Zobrazit výběr sérií"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Author Section"
 msgstr "Zobrazit výběr autora"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Publisher Section"
 msgstr "Zobrazit výběr vydavatele"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Language Section"
 msgstr "Zobrazit výběr jazyka"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Ratings Section"
 msgstr "Zobrazit výběr hodnocení"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show File Formats Section"
 msgstr "Zobrazit výběr formátů"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Archivované knihy"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Archived Books"
 msgstr "Zobrazit archivované knihy"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr ""
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr ""
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr ""
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Zobrazit nejlépe hodnocené knihy"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Vydáno po "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Vydáno před "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Hodnocení <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Hodnocení >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr ""
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Rozšířené hledání"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Zadána neplatná police"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 #, fuzzy
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "Lituji, nejste oprávněni přidat knihu do police: %(shelfname)s"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "Kniha je již součástí police: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "Kniha byla přidána do police: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr ""
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Knihy jsou již součástí police: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "Knihy byly přidány do police: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Nelze přidat knihy do police: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "Zadána neplatná police"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Nelze přidat knihy do police: %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Knihy jsou již součástí police: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "Knihy byly přidány do police: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "Kniha byla odebrána z police: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr ""
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Vytvořit polici"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 #, fuzzy
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Lituji, nejste oprávněni odebrat knihu z této police: %(sname)s"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Upravit polici"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr ""
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 #, fuzzy
 msgid "Shelf successfully deleted"
 msgstr "Kniha úspěšně smazána"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Změnit  pořadí Police: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr ""
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Police %(title)s vytvořena"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Police %(title)s změněna"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Došlo k chybě"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "Veřejná police s názvem '%(title)s' již existuje."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "Osobní police s názvem ‘%(title)s’ již existuje."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Police: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Chyba otevírání police. Police neexistuje nebo není přístupná"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Vynechat série"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Anonymní"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Neověřeno"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Ano"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Ne"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr ""
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Motiv"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Světlý"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Tmavý"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr ""
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Přidat do police"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Autor"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Procházet"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Zavřít"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Smazat"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr ""
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Vydavatel"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Přečteno"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Název"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Nahrávat"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Účet"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Správce"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Publikováno"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Zdroj"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "O knihovně"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Archivováno"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Popis"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Stahovat"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Upravovat"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "E-mail"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Povolit Kobo synchronizaci"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Šifrování"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Identifikátory"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Jazyk"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Heslo"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Průběh"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Hodnocení"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Uložit"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr ""
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Stav"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Štítky"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Úkol"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Úlohy"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Uživatel"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Přezdívka"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr ""
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Čekám"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Selhalo"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Spuštěno"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Dokončeno"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr ""
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr ""
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Neznámý stav"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Neočekávaná data při čtení informací o aktualizaci"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr "Aktualizace není k dispozici. Máte nainstalovanou nejnovější verzi"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6016,15 +5920,15 @@ msgstr ""
 "Nová aktualizace k dispozici. Klepnutím na tlačítko níže aktualizujte na "
 "nejnovější verzi."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Nelze získat informace o aktualizaci"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr "Klepnutím na tlačítko níže aktualizujte na nejnovější stabilní verzi."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6033,321 +5937,319 @@ msgstr ""
 "Nová aktualizace k dispozici. Klepnutím na tlačítko níže aktualizujte na "
 "verzi: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Nejsou k dispozici žádné informace o verzi"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Objevte (Náhodné knihy)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Žhavé knihy (Nejstahovanější)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr ""
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Autoři: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Vydavatel: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Série: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr ""
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Hodnocení: %(rating)s stars"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Soubor formátů: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Kategorie: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Jazyky: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Žhavé knihy"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Skrytá kniha"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "Chyba stahování obalu"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "Formáty souborů"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 msgid "Invalid request"
 msgstr ""
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr ""
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 #, fuzzy
 msgid "Error creating shelf"
 msgstr "Chyba stahování obalu"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Vytvořit polici"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 msgid "Shelf name is required"
 msgstr ""
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "Chyba stahování obalu"
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "Upravit polici"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "Uživatel nenalezen"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "Kniha úspěšně smazána"
 
-#: cps/web.py:1710
+#: cps/web.py
 #, fuzzy
 msgid "Error duplicating shelf"
 msgstr "Chyba stahování obalu"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 #, fuzzy
 msgid "Error deleting shelf"
 msgstr "Chyba stahování obalu"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "Chyba stahování obalu"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 #, fuzzy
 msgid "Error unhiding shelf"
 msgstr "Chyba stahování obalu"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Stáhnutí"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Seznam formátů"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 #, fuzzy
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Nejprve nakonfigurujte nastavení pošty SMTP..."
 
-#: cps/web.py:2400
+#: cps/web.py
 #, fuzzy
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr "Nejprve nakonfigurujte vaši kindle e-mailovou adresu.."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "Kniha byla úspěšně zařazena do fronty pro odeslání na %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Při odesílání této knihy došlo k chybě: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "Kniha byla úspěšně zařazena do fronty pro odeslání na %(eReadermail)s"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Registrovat"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 #, fuzzy
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr "E-mailový server není nakonfigurován, kontaktujte svého správce!"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr "E-mailový server není nakonfigurován, kontaktujte svého správce!"
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "Váš e-mail nemá povolení k registraci"
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "Potvrzovací e-mail byl odeslán na váš účet."
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
 msgstr "E-mailový server není nakonfigurován, kontaktujte svého správce!"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "E-mailový server není nakonfigurován, kontaktujte svého správce!"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 #, fuzzy
 msgid "Cannot activate LDAP authentication"
 msgstr "Nelze aktivovat ověření LDAP"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr ""
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, fuzzy, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "nyní jste přihlášen jako: '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "nyní jste přihlášen jako: '%(nickname)s'"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
 msgstr "E-mailový server není nakonfigurován, kontaktujte svého správce!"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6356,718 +6258,688 @@ msgstr ""
 "Záložní přihlášení jako: ‘%(nickname)s’, server LDAP není dosažitelný nebo "
 "neznámý uživatel"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, fuzzy, python-format
 msgid "Could not login: %(message)s"
 msgstr "Nelze se přihlásit: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 #, fuzzy
 msgid "Wrong Username or Password"
 msgstr "Špatné uživatelské jméno nebo heslo"
 
-#: cps/web.py:2832
+#: cps/web.py
 #, fuzzy
 msgid "New Password was sent to your email address"
 msgstr "Nové heslo bylo zasláno na vaši emailovou adresu"
 
-#: cps/web.py:2836
+#: cps/web.py
 #, fuzzy
 msgid "An unknown error occurred. Please try again later."
 msgstr "Neznámá chyba. Opakujte prosím později."
 
-#: cps/web.py:2838
+#: cps/web.py
 #, fuzzy
 msgid "Please enter valid username to reset password"
 msgstr "Zadejte platné uživatelské jméno pro obnovení hesla"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, fuzzy, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "nyní jste přihlášen jako: '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 #, fuzzy
 msgid "Success! Profile Updated"
 msgstr "Profil aktualizován"
 
-#: cps/web.py:3164
+#: cps/web.py
 #, fuzzy
 msgid "Oops! An account already exists for this Email."
 msgstr "Byl nalezen existující účet pro tuto e-mailovou adresu."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr ""
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr ""
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "Poslat do Kindle"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "Poslat do Kindle"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 msgid "Auto-send completed successfully"
 msgstr ""
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr ""
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr ""
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, fuzzy, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "Poslat do Kindle"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Calibre převaděč %(tool)s nenalezen"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "%(format)s formát nenalezen na disku"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 #, fuzzy
 msgid "Ebook converter failed with unknown error"
 msgstr "Převaděč eknih selhal: %(error)s"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Kepubify-převaděč selhal: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "Převedený soubor nebyl nalezen nebo více než jeden soubor ve složce "
 "%(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre selhal s chybou: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Převaděč eknih selhal: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 #, fuzzy
 msgid "Reconnecting Calibre database"
 msgstr "Umístění Calibre databáze"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "Smazat knihu"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Smazat knihu"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Rozbalování balíčku aktualizace"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Nenalezeny žádné výsledky"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Povolit Kobo synchronizaci"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 #, fuzzy
 msgid "E-mail"
 msgstr "E-mail"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 #, fuzzy
 msgid "Backing up Metadata"
 msgstr "upravit metadata"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "V knihovně"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "Knihy organizované v policích"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Povolit změnu hesla"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Vytvořit polici"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "Nastavení OAuth"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Nastavení"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "vyberte možnost"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "Přidat do police"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Veřejné)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "Stáhnutí"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Stáhnutí"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 msgid "Date added, newest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 msgid "Date added, oldest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Autor"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Autor"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Vydáno před "
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Vydáno před "
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Přidat do police"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "Přidat do police"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Send to eReader Email"
 msgstr "Poslat do Kindle e-mailová adresa"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "Poslat do Kindle"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Prohlížení knih"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Veřejná police"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr ""
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "Importovat LDAP uživatele"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Nastavení e-mailového serveru SMTP"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "SMTP hostitel"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "SMTP port"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "SMTP přihlášení"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Z e-mailu"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Service"
 msgstr "Nastavení e-mailového serveru SMTP"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr ""
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Calibre DB adresář"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Úroveň logu"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 #, fuzzy
 msgid "External Port"
 msgstr "Externí binární soubory"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Knihy na stránku"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Nahrávání"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Anonymní prohlížení"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Veřejná registrace"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Magic Link vzdálené přihlášení"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Reverzní proxy přihlášení"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Název záhlaví reverzního proxy"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Upravit základní konfiguraci"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Upravit konfiguraci uživatelského rozhraní"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Edit Calibre Database Configuration"
 msgstr "Upravit základní konfiguraci"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr ""
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Start Time"
 msgstr "Spuštěno"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr ""
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr ""
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 #, fuzzy
 msgid "Reconnect Calibre Database"
 msgstr "Umístění Calibre databáze"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr ""
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr ""
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Setup KOReader Sync"
 msgstr "Čtečka PDF"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr ""
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Správa"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Download Debug Package"
 msgstr "Stahování balíčku aktualizace"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Zobrazit log"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Restartovat"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Vypnout"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr ""
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Verze"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Detaily"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "Aktualizace selhala:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Aktualizační kanál"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Současná verze"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Zkontrolovat aktualizace"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Provést aktualizaci"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Opravdu chcete restartovat?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Opravdu chcete vypnout?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Probíhá aktualizace, prosím nenačítejte stránku znovu"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7075,627 +6947,604 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Knih v této knihovně"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Nahrávání..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "Aktualizace selhala:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Chyba připojení"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Série: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "přes"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "V knihovně"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "redukovat"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Více od"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Smazat knihu"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Smazat formáty:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Převést formát knihy:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Převést z:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "select an option"
 msgstr "vyberte možnost"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Převést do:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Převést knihu"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Chyba"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Nahrát formát"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "ID série"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Datum vydání"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Typy identifikátorů"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Hodnota identifikátorů"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Odstranit"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Přidat identifikátor"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Adresa URL obalu (jpg, obal je stažen a uložen v databázi, pole je potom "
 "opět prázdné)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Nahrát obal z místní jednotky"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "Povolit Kobo synchronizaci"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Zobrazit knihu po uložení"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Získat metadata"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Klíčové slovo"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Search keyword"
 msgstr "Hledat klíčové slovo"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Načítání..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Chyba vyhledávání!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "Nebyly nalezeny žádné výsledky! Zadejte jiné klíčové slovo."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr ""
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr ""
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "Vytvořit polici"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr ""
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 msgid "Update Title Sort automatically  "
 msgstr ""
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr ""
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Title"
 msgstr "Zkušební e-mail"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr ""
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Title Sort"
 msgstr "Název"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr ""
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Author Sort"
 msgstr "Autor"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Authors"
 msgstr "Autoři"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Categories"
 msgstr "Kategorie"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Series"
 msgstr "Vynechat série"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Languages"
 msgstr "Vynechat jazyky"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Datum vydání"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Publishers"
 msgstr "Vydavatelé"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter comments"
 msgstr "Zadejte jméno domény"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Comments"
 msgstr "Zadejte jméno domény"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Archived?"
 msgstr "Archivováno"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Read?"
 msgstr "Přečteno"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter "
 msgstr "Identifikátory"
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Jste si opravdu jisti?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr ""
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Into Book with Title:"
 msgstr "Název knihy"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr ""
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr ""
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr ""
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr ""
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr ""
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Upravit metadata"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "Vytvořit polici"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr ""
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Přidat"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr "E-mailový server není nakonfigurován, kontaktujte svého správce!"
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Nové heslo bylo zasláno na vaši emailovou adresu"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Poslat do Kindle"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Zpět"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Umístění Calibre databáze"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7711,13 +7560,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7728,7 +7577,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7739,43 +7588,43 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr ""
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
 "can be wherever you desire"
 msgstr ""
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Použít Google Drive?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Ověřit Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Google Drive Calibre složka"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "ID kanálu sledování metadat"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Odvolat"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Umístění Calibre databáze"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7785,131 +7634,131 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "Opravdu chcete vypnout?"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Umístění Calibre databáze"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "New db location is invalid, please enter valid path"
 msgstr "Umístění databáze není platné, opravte prosím cestu"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Použít standartní ověření"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Použít ověření LDAP"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Použít OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Nastavení serveru"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Server port"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "Umístění certifikátu SSL (ponechte prázdné pro servery jiné než SSL)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Umístění souboru s klíčem SSL (ponechte prázdné pro servery jiné než SSL)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Aktualizační kanál"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Stabilní"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Noční"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr ""
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Konfigurace log souboru"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "Umístění a jméno logu přístupů (access.log pro žádnou položku)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Povolit log přístupů"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "Umístění a jméno logu přístupů (access.log pro žádnou položku)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "Nastavení serveru"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Povolit nahrávání"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr ""
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Povolené nahrávání formátů souborů"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Povolit anonymní prohlížení"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Povolit veřejnou registraci"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "Použít e-mail jako přezdívku"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Povolit Magic Link vzdálené přihlášení"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7917,154 +7766,154 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Proxy neznámé požadavky na obchod Kobo"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr ""
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Použít Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Goodreads API Klíč"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Hardcover Sync"
 msgstr "Povolit Kobo synchronizaci"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "Token vypršel"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Goodreads API Klíč"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8072,417 +7921,417 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Povolit reverzní ověření proxy"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Typ přihlášení"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "Název hostitele serveru LDAP nebo IP adresa"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "LDAP Server Port"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "LDAP Šifrování"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "LDAP Ověření"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Jednoduché"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "Uživatelské jméno správce LDAP"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "Heslo správce LDAP"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "Rozlišující název LDAP (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "Filtr objektu uživatele LDAP"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "Server LDAP je OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr "Následující nastavení jsou potřeba pro import uživatele"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "Filtr objektů skupiny LDAP"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "Jméno skupiny LDAP"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "Pole členů skupiny LDAP"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr ""
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr ""
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Member User Filter"
 msgstr "Filtr objektu uživatele LDAP"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "Získat metadata"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
 msgstr ""
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "Upravit konfiguraci uživatelského rozhraní"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "Token nenalezen"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "Chyba připojení"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "Nastavení OAuth"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Id"
 msgstr "%(provider)s OAuth Klient Id"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Secret"
 msgstr "%(provider)s OAuth Klient Tajemství"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "Prohlížet konfiguraci"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "Přezdívka"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr ""
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "Nastavení e-mailového serveru SMTP"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr ""
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "Jméno skupiny LDAP"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr ""
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Výchozí nastavení pro nového uživatele"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Povolit stahování"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Povolit prohlížeč knih"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Povolit nahrávání"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Povolit úpravy"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Povolit mazání knih"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Povolit změnu hesla"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Povolit úpravy veřejných polic"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr ""
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Získat %(provider)s OAuth pověření"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "%(provider)s OAuth Klient Id"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "%(provider)s OAuth Klient Tajemství"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Externí binární soubory"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Path to Calibre Binaries"
 msgstr "Cesta k převaděči e-knih Calibre"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Calibre E-Book Converter Settings"
 msgstr "Nastavení převaděče e-knih Calibre"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Cesta k převaděči e-knih Kepubify"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "Umístění UnRar binarních souborů"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Security Settings"
 msgstr "Nastavení OAuth"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8490,340 +8339,335 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr ""
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr ""
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr ""
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Session protection"
 msgstr "vyberte možnost"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr ""
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr ""
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "User Password policy"
 msgstr "Resetovat uživatelské heslo"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr ""
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr ""
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Prohlížet konfiguraci"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Počet náhodných knih k zobrazení"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr "Počet autorů k zobrazení před skrytím (0 = Zakázat skrytí)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "Smazat"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "caliBlur! Tmavý motiv"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Regulární výraz pro ignorování sloupců"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Propojit stav čtení/nepřečtení do sloupce Calibre"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "Propojit stav čtení/nepřečtení do sloupce Calibre"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Zobrazit omezení podle Calibre sloupce"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Regulární výraz pro řazení názvů"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Prohlížet konfiguraci"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 msgid "Custom CSS"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Výchozí nastavení pro nového uživatele"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "Verze"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Uživatel admin"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "Stránka správce"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Language"
 msgstr "Vynechat jazyky"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "Výchozí nastavení pro nového uživatele"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Visible Language of Books"
 msgstr "Zobrazit knihy s jazykem"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "Výchozí zobrazení pro nové uživatele"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Výchozí zobrazení pro nové uživatele"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Zobrazit náhodné knihy v podrobném zobrazení"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Přidat povolené/zakázané štítky"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Přidat povolené/zakázané hodnoty vlastních sloupců"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Nahrávat"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "Archivováno"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "Stahovat"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Start"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8832,14 +8676,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8847,95 +8691,94 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "Archivované knihy"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "Chyba stahování obalu"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "Nenalezeny žádné výsledky"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "Zvolte uživatelské jméno"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "Hledat v knihovně"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "Vytvořit polici"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "Archivované knihy"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "Chyba stahování obalu"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Calibre-Web log: "
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8943,11 +8786,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -8958,11 +8801,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -8972,162 +8815,162 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "Archivované knihy"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9135,11 +8978,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9147,110 +8990,108 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "Metadata úspěšně aktualizována"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identifikátory"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "Objevte"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
 "investigation."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9258,157 +9099,157 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Nastavení OAuth"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "Nastavení"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "Nastavení OAuth"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9416,102 +9257,101 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Nastavení OAuth"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9519,44 +9359,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Převést formát knihy:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9564,875 +9404,863 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Povolit veřejnou registraci"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Nastavení OAuth"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Povolit veřejnou registraci"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Povolit veřejnou registraci"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Smazat formáty:"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Získat metadata"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Hodnocení"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Další"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Označit jako nepřečtené"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Označit jako přečtené"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "Označit jako nepřečtené"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "Označit jako nepřečtené"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Archívovat"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Obnovit z archivu"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Obnovit z archivu"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Archívovat"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "Obnovit z archivu"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "Hledat v knihovně"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "Nastavení e-mailového serveru aktualizováno"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "Hodnoceni více než"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr ""
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr ""
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Popis:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "Poslat do Kindle e-mailová adresa"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "Poslat do Kindle e-mailová adresa"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "Vytvořit polici"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "Smazat formáty:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "Vytvoření cesty obalu selhalo"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "Vytvoření cesty obalu selhalo"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr ""
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Smazat knihu"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "Zobrazit nejlépe hodnocené knihy"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "Vytvořit polici"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "Smazat knihu"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Smazat knihu"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "Předchozí"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "Smazat knihu"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "Podrobnosti o knize"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "upravit metadata"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "Archivované knihy"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "Nenalezeny žádné výsledky"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr ""
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Smazat formáty:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be permanently deleted:"
 msgstr "Tato kniha bude trvale odstraněna z databáze"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "Nepřečtené knihy"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "Tato kniha bude trvale odstraněna z databáze"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "Tato kniha bude trvale odstraněna z databáze"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr ""
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr ""
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr ""
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Email Account Type"
 msgstr "Účet"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Standard Email Account"
 msgstr "Účet"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Gmail Account"
 msgstr "Účet"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Setup Gmail Account"
 msgstr "Účet"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr ""
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "SMTP heslo"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Limit velikosti souboru"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Save and Send Test Email"
 msgstr "Uložit nastavení a odeslat zkušební e-mail"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Povolené domény pro registraci"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Přidat doménu"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Zadejte jméno domény"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Zakázané domény pro registraci"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10440,584 +10268,574 @@ msgstr ""
 "Otevřte soubor .kobo/Kobo/Kobo eReader.conf v textovém editoru a vložte "
 "(nebo upravte):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 #, fuzzy
 msgid "Kobo Token:"
 msgstr "Kobo Sync token"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "Vytvořit polici"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "Termín vyhledávání:"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "Zobrazit knihu po uložení"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "Vytvořit polici"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "Načítání..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "Vytvoření cesty obalu selhalo"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr "Jste si jisti, že chcete odstranit tuto polici?"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "Vytvořit polici"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "Vytvoření cesty obalu selhalo"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "E-mailový server není nakonfigurován, kontaktujte svého správce!"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Vytvořit problém"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Zpět domů"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 #, fuzzy
 msgid "Logout User"
 msgstr "Odhlásit se"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "Upravit polici"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Show this shelf in your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "Zobrazit vše"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "Veřejná police"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Přidat do police"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Domů"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Přepnout navigaci"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Hledat v knihovně"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Calibre-Web katalog eknih"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Odhlásit se"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "Nastavení"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "Hledat v knihovně"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Nejsou k dispozici žádné informace o verzi"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Calibre-Web katalog eknih"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Smazat knihu"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Prosím neobnovujte stránku"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Vytvořit polici"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Předchozí"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Podrobnosti o knize"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Opravdu chcete vypnout?"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Smazat knihu"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Nahrát formát"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Smazat formáty:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Smazat knihu"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nenalezeny žádné výsledky"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Změnit měřítko na nejlepší"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfigurace"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Přidat do police"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Označit jako nepřečtené"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Označit jako nepřečtené"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Smazat knihu"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Smazat knihu"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Vytvořit polici"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Chyba připojení"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr ""
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr ""
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "SMTP heslo"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Zapamatovat si"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Zapomenuté heslo?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Přihlásit se pomocí Magic Link"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 #, fuzzy
 msgid "Log in with SSO"
 msgstr "Přihlásit se pomocí Magic Link"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Zobrazit Calibre-Web log: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Calibre-Web Log: "
 msgstr "Zobrazit Calibre-Web log: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Streamový výstup, nelze zobrazit"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Zobrazit log přístupu: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Download Calibre-Web Log"
 msgstr "Zobrazit Calibre-Web log: "
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Download Access Log"
 msgstr "Povolit log přístupů"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "Sdílet se všemi"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Vybrat povolené/zakázané štítky"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Vybrat povolené/zakázané hodnoty vlastních sloupců"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Vybrat povolené/zakázané uživatelské štítky"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr "Vybrat povolené/zakázané hodnoty vlastních sloupců uživatele"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Vložte štítek"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Přidat omezení náhledu"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "This book format will be permanently erased from database"
 msgstr "Tato kniha bude trvale odstraněna z databáze"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Tato kniha bude trvale odstraněna z databáze"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "a z hard disku"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Důležitá Kobo poznámka: smazané knihy zůstanou na jakémkoli spárovaném "
 "zařízení Kobo."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11025,977 +10843,973 @@ msgstr ""
 "Knihy musí být nejprve archivovány a zařízení musí být synchronizováno, než "
 "bude kniha bezpečně smazána."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Choose File Location"
 msgstr "Zobrazit výběr formátů"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "name"
 msgstr "Přezdívka"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Parent Directory"
 msgstr "Calibre DB adresář"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 #, fuzzy
 msgid "Ok"
 msgstr "Kniha"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Calibre-Web katalog eknih"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 #, fuzzy
 msgid "epub Reader"
 msgstr "Čtečka PDF"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 msgid "Annotations"
 msgstr ""
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 #, fuzzy
 msgid "Black"
 msgstr "Zpět"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr ""
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Následujicí strana"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr ""
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 #, fuzzy
 msgid "Default"
 msgstr "Smazat"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr ""
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr ""
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 #, fuzzy
 msgid "KaiTi"
 msgstr "Čekám"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 #, fuzzy
 msgid "Arial"
 msgstr "Svisle"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 #, fuzzy
 msgid "Spread"
 msgstr "Přečteno"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr ""
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr ""
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Po otevření postranních panelů přeformátujte text."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Comic Reader"
 msgstr "Čtečka PDF"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Klávesové zkratky"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Předchozí strana"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Následujicí strana"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page Display"
 msgstr "Stránka správce"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Změnit měřítko na nejlepší"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Změnit měřítko na šířku"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Změnit měřítko na výšku"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Změnit měřítko na nativní"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Otočit doprava"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Otočit doleva"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Převrátit obrázek"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page"
 msgstr "Stránka správce"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr ""
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Měřítko"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Nejlepší"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Šířka"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Výška"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Nativní"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Otočit"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Převrátit"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Vodorovně"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Svisle"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Direction"
 msgstr "Popis"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Zleva doprava"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Zprava doleva"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Reset to Top"
 msgstr "Zpět domů"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Remember Position"
 msgstr "Zapamatovat si"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr ""
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Show"
 msgstr "Zobrazit vše"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 #, fuzzy
 msgid "DJVU Reader"
 msgstr "Čtečka PDF"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 #, fuzzy
 msgid "PDF Reader"
 msgstr "Čtečka PDF"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 #, fuzzy
 msgid "txt Reader"
 msgstr "Čtečka PDF"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Založit nový účet"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Zvolte uživatelské jméno"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Vaše e-mailová adresa"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Magic Link - Schválit nové zařízení"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "Použijte své druhé zařízení, přihlaste se a navštivte:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "Jakmile tak učiníte, budete automaticky přihlášeni na tomto zařízení."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Tento ověřovací odkaz vyprší za 10 minut."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr ""
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Nenalezeny žádné výsledky"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Termín vyhledávání:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Výsledky pro:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Datum vydání od"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Datum vydání do"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr ""
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Vynechat štítky"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Vynechat série"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Exclude Shelves"
 msgstr "Vynechat série"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Vynechat jazyky"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Přípony"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Vynechat přípony"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Hodnoceni více než"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Hodnocení méně než"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr ""
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr ""
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Smazat tuto polici"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr ""
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Skrytá kniha"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr ""
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr ""
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr ""
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Archivované knihy"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Účet"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Token nenalezen"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Smazat tuto polici"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Přidat do police"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Hledat v knihovně"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Hledat v knihovně"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Sdílet se všemi"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr ""
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Uživatel nenalezen"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Skrytá kniha"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Statistika knihovny"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Knih v této knihovně"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Autorů v této knihovně"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Kategorií v této knihovně"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Sérií v této knihovně"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 #, fuzzy
 msgid "System Statistics"
 msgstr "Statistika"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 #, fuzzy
 msgid "Program"
 msgstr "Průběh"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Nainstalovaná verze"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Doba spuštění"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr ""
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "Otočit"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
 msgstr ""
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 msgid "Scheduled item cancelled successfully"
 msgstr ""
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Calibre-Web katalog eknih"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "Vaše e-mailová adresa"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "Nastavení"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Resetovat uživatelské heslo"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "Nastavení serveru"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "Poslat do Kindle e-mailová adresa"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "Vynechat jazyky"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Zobrazit knihy s jazykem"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "Zobrazit knihy s jazykem"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "Nastavení OAuth"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Připojit"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Odpojit"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Kobo Sync token"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Vytvořit/Prohlížet"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 msgid "Expose only books in selected shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "Nastavení OAuth"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Přidat povolené/zakázané hodnoty vlastních sloupců"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "Nedávno přidané knihy"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "Veřejná police"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Odstranit tohoto uživatele"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12003,171 +11817,171 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Povolit změnu hesla"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Povolit změnu hesla"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Vytvořit/Prohlížet"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Vygenerovat URL pro Kobo Auth"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr ""
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr ""
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit User"
 msgstr "Uživatel admin"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Username"
 msgstr "Zvolte uživatelské jméno"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Email"
 msgstr "Zkušební e-mail"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email"
 msgstr "Poslat do Kindle e-mailová adresa"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email"
 msgstr "Zkušební e-mail"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "Poslat do Kindle e-mailová adresa"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "Zkušební e-mail"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Locale"
 msgstr "Měřítko"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Visible Book Languages"
 msgstr "Zobrazit knihy s jazykem"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Allowed Tags"
 msgstr "Vybrat povolené/zakázané štítky"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Allowed Tags"
 msgstr "Vybrat povolené/zakázané štítky"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Denied Tags"
 msgstr "Vybrat povolené/zakázané štítky"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Denied Tags"
 msgstr "Vybrat povolené/zakázané štítky"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Allowed Column Values"
 msgstr "Přidat povolené/zakázané hodnoty vlastních sloupců"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Allowed Column Values"
 msgstr "Přidat povolené/zakázané hodnoty vlastních sloupců"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Denied Column Values"
 msgstr "Přidat povolené/zakázané hodnoty vlastních sloupců"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Denied Column Values"
 msgstr "Přidat povolené/zakázané hodnoty vlastních sloupců"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Change Password"
 msgstr "Povolit změnu hesla"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Public Shelves"
 msgstr "Veřejná police"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 msgid "Expose selected Shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Read/Unread Section"
 msgstr "Zobrazit výběr sérií"

--- a/cps/translations/de/LC_MESSAGES/messages.po
+++ b/cps/translations/de/LC_MESSAGES/messages.po
@@ -18,44 +18,44 @@ msgstr ""
 "X-Loco-Parser: loco_parse_po\n"
 "X-Loco-Source-Locale: de_DE\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Statistiken"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr "Calibre-Datenbank nicht verfügbar. Bibliothekspfad neu konfigurieren."
 
-#: cps/admin.py:208
+#: cps/admin.py
 msgid "Server restarted, please reload page."
 msgstr "Server neugestartet, bitte die Seite neu laden."
 
-#: cps/admin.py:210
+#: cps/admin.py
 msgid "Performing Server shutdown, please close window."
 msgstr "Server wird heruntergefahren, bitte Fenster schließen."
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "Erfolg! Datenbank wurde erneut verbunden"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Unbekannter Befehl"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 "Erfolg! Bücher wurden für Metadaten-Backup eingereiht, für das Ergebnis "
 "bitte Aufgaben überprüfen"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
@@ -63,45 +63,45 @@ msgstr ""
 "Fehler: Kein Hardcover-Token verfügbar. Umgebungsvariable HARDCOVER_TOKEN "
 "setzen oder in Basiskonfiguration konfigurieren."
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 "Erfolg! Hardcover-Auto-Fetch gestartet. Fortschritt im Aufgaben-Panel prüfen."
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr "Fehler beim Start des Hardcover-Auto-Fetch: %(error)s"
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr "Hardcover-Treffer prüfen"
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr "Fehler beim Laden der Prüfwarteschlange: %(error)s"
 
-#: cps/admin.py:414
+#: cps/admin.py
 msgid "Hardcover ID applied successfully"
 msgstr "Hardcover-ID erfolgreich angewendet"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr "Treffer %(action)s"
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr "Keine ausstehenden Treffer zum Ablehnen"
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr "%(count)s Treffer abgelehnt"
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
@@ -109,120 +109,118 @@ msgstr ""
 "Vorschaubild-Cache-Aktualisierung für {} Buch/Bücher gestartet. Dies kann "
 "einige Minuten dauern."
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr "Keine Bücher mit Covern zum Verarbeiten gefunden."
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr "Vorschaubild-Aktualisierung fehlgeschlagen: {}"
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Admin Seite"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "Hardcover-Token erforderlich"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Basiskonfiguration"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Ansichtseinstellungen"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 "Benutzerdefinierte Spalte Nr. %(column)d ist nicht in Calibre Datenbank "
 "vorhanden"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Benutzer bearbeiten"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Alle"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Benutzer nicht gefunden"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} Benutzer erfolgreich gelöscht"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Zeige alle"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Fehlerhafte Anfrage"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "Name 'Guest' kann nicht geändert werden"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "Benutzer 'Guest' darf diese Rolle nicht besitzen"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr ""
 "Kein verbleibender Admin-Benutzer, Admin-Rolle kann nicht entfernt werden"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "Wert muss true oder false sein"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Ungültige Rolle"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "Benutzer 'Guest' darf diese Ansicht nicht besitzen"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "Ungültige Ansicht"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 "Sprache von 'Guest' wird automatisch bestimmt und kann nicht eingestellt "
 "werden"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Keine gültige Sprache gewählt"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Keine gültige Buchsprache gewählt"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Parameter wurde nicht gefunden"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "Einstellungsdatenbank ist nicht schreibbar"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
@@ -232,53 +230,53 @@ msgstr ""
 "möglicherweise ihre vorherige Reihenfolge bei, bis Sie es erneut "
 "versuchenoder sie bearbeiten."
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Ungültige Gelesen Spalte"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Ungültiger Spaltenname für Einschränkung"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr "Calibre-Web NextGen Konfiguration aktualisiert"
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Möchten Sie den Kobo Token wirklich löschen?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "Möchten Sie diese Domain wirklich löschen?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "Möchten Sie diesen Benutzer wirklich löschen?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Möchten Sie dieses Regal wirklich löschen?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr ""
 "Möchten Sie die Anzeigesprache der ausgewählten Benutzer wirklich ändern?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "Möchten Sie die Büchersprachen für die ausgewählten Benutzer wirklich ändern?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 "Möchten Sie die ausgewählte Rolle für die ausgewählten Benutzer wirklich "
 "verändern?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
@@ -286,7 +284,7 @@ msgstr ""
 "Möchten Sie die ausgewählten Sichtbarkeitsbeschränkungen der ausgewählten "
 "Benutzer wirklich ändern?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -294,14 +292,14 @@ msgstr ""
 "Möchten Sie die Sichtbarkeiten für die ausgewählten Benutzer wirklich "
 "verändern?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "Möchten Sie die Synchronisation von Regalen für die ausgewählten Benutzer "
 "wirklich verändern?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
@@ -309,13 +307,13 @@ msgstr ""
 "Möchten Sie die Synchronisation von Regalen für die ausgewählten Benutzer "
 "wirklich verändern?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr ""
 "Sind Sie sicher, dass Sie den Speicherort für dieCalibre Bibliothek ändern "
 "möchten?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
@@ -323,7 +321,7 @@ msgstr ""
 "Calibre-Web NextGen wird nach aktualisierten Covern suchen und die Cover-"
 "Miniaturansichten aktualisieren. Dies kann eine Weile dauern."
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
@@ -332,29 +330,25 @@ msgstr ""
 "NextGen löschen möchten, um eine vollständige Synchronisation mit Ihrem Kobo-"
 "Reader zu erzwingen?"
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Verbieten"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Erlauben"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "{} Synchronisationseinträge gelöscht"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Buch wurde nicht gefunden."
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
@@ -363,7 +357,7 @@ msgstr ""
 "Synchronisationsstatus für Buch {0} (Benutzer {1}) zurückgesetzt; das Gerät "
 "wird das Buch bei der nächsten Synchronisation erneut einlesen."
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
@@ -373,98 +367,92 @@ msgstr ""
 "Zeitstempel für last_modified wurde erhöht, sodass das Gerät es bei der "
 "nächsten Synchronisation empfangen wird."
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Tag nicht gefunden"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Ungültige Aktion"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json ist nicht für Web Anwendungen konfiguriert"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "Logdatei Pfad ist ungültig, bitte einen gültigen Pfad eingeben"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "Zugriffs-Logdatei Pfad ist ungültig, bitte einen gültigen Pfad angeben"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 "Bitte einen LDAP-Server, -Port, -DN und -Benutzerobjektidentifikator eingeben"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Bitte einen LDAP-Service-Account und Passwort eingeben"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "Bitte einen LDAP-Service-Account eingeben"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP-Gruppenobjektfilter benötigt genau eine \"%s\" Formatkennung"
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "LDAP-Gruppenobjektfilter hat ungleiche Anzahl von Klammern"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP-Benutzerobjektfilter benötigt genau eine \"%s\" Formatkennung"
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "LDAP-Benutzerobjektfilter hat eine ungleiche Anzahl von Klammern"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr "Der LDAP-Mitgliederfilter benötigt genau eine \"%s\" Formatkennung"
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "LDAP-Mitgliederfilter hat eine ungleiche Anzahl von Klammern"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
 msgstr ""
-"Der angegebene Speicherort für LDAP-CA-Zertifikat, -Zertifikat oder -"
-"Schlüsseldatei ist falsch,Bitte den korrekten Pfad eingeben."
+"Der angegebene Speicherort für LDAP-CA-Zertifikat, -Zertifikat oder "
+"-Schlüsseldatei ist falsch,Bitte den korrekten Pfad eingeben."
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Neuen Benutzer hinzufügen"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Einstellungen für den E-Mail-Server"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "Erfolg! G-Mail-Konto verifiziert."
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Ups! Datenbankfehler: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -472,52 +460,52 @@ msgstr ""
 "Test-E-Mail an %(email)s wurde zum Senden in die Warteschlange eingereiht, "
 "für das Ergebnis bitte Aufgaben überprüfen"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Es trat ein Fehler beim Versenden der Test-E-Mail auf: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Bitte zuerst E-Mail-Adresse konfigurieren..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Einstellungen des E-Mail-Servers aktualisiert"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 msgid "Email Your Users"
 msgstr "Schicken Sie Ihren Benutzern eine E-Mail"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr ""
 "Bitte zunächst die SMTP-Einstellungen des E-Mail-Servers konfigurieren..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr "Bitte geben Sie einen Betreff für die Ankündigungs-Email ein."
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr "Bitte geben Sie einen Text in die Ankündigungs-Email ein."
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "Bitte zuerst E-Mail-Adresse konfigurieren..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 msgid "Please select at least one recipient."
 msgstr "Bitte zuerst einen Empfänger auswählen"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr "Keine gültigen Empfänger - es wurde nichts gesendet."
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -525,7 +513,7 @@ msgstr ""
 "Test-E-Mail an %(email)s wurde zum Senden in die Warteschlange eingereiht, "
 "für das Ergebnis bitte Aufgaben überprüfen"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -534,162 +522,160 @@ msgstr ""
 "Test-E-Mail an %(email)s wurde zum Senden in die Warteschlange eingereiht, "
 "für das Ergebnis bitte Aufgaben überprüfen"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr "%(num)s Adresse(n) wurden als ungültig oder doppelt übersprungen."
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "Einstellungen für Geplante Aufgaben"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "Ungültiger Startzeitpunkt für die spezifizierten Aufgaben"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "Ungültige Laufzeit für die spezifizierten Aufgaben"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "Einstellungen für geplante Aufgaben aktualisiert"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr ""
 "Ups! Es ist ein unbekannter Fehler aufgetreten. Bitte später erneut "
 "versuchen."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 msgid "title"
 msgstr "Titel"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Benutzer %(nick)s bearbeiten"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Erfolg! Passwort für Benutzer %(user)s wurde zurückgesetzt"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Ups! Bitte die SMTP-Einstellungen des E-Mail-Server konfigurieren."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Logdatei Anzeige"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Fordere Aktualisierungspaket an"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Lade Update herunter"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Entpacke Aktualisierungspaket"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Ersetze Dateien"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Schließe Datenbankverbindungen"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Stoppe den Server"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr ""
 "Aktualisierung abgeschlossen, bitte okay drücken und die Seite neu laden"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Aktualisierung fehlgeschlagen:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "HTTP Fehler"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Verbindungsfehler"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Zeitüberschreitung beim Verbindungsaufbau"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Allgemeiner Fehler"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr ""
 "Aktualisierungsdatei konnte nicht in temporärem Ordner gespeichert werden"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "Dateien konnten während des Updates nicht ausgetauscht werden"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "Mindestens ein LDAP Benutzer konnte nicht extrahiert werden"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Mindestens ein LDAP Benutzer konnte nicht erzeugt werden"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Fehler: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Fehler: Keine Benutzerinformationen von LDAP Server empfangen"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "Mindestens ein LDAP Benutzer wurde nicht in der Datenbank gefudnen"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} Benutzer erfolgreich importiert"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr "Bücherpfad ungültig"
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "DB Pfad ist nicht gültig, bitte einen gültigen Pfad angeben"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "Datenbank ist nicht beschreibbar"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "Schlüsseldatei ist ungültig, bitte einen gültigen Pfad angeben"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr "Zertifikatsdatei ist ungültig, bitte einen gültigen Pfad angeben"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
@@ -697,12 +683,12 @@ msgstr ""
 "Benutzer-Auto-Erstellung erfordert eine aktivierte Reverse-Proxy-"
 "Authentifizierung"
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 "Benutzer-Auto-Erstellung erfordert einen gültigen Reverse-Proxy-Header-Namen"
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
@@ -710,7 +696,7 @@ msgstr ""
 "Ungültiges Format für OAuth-Redirect-Host. Bitte die vollständige URL mit "
 "Protokoll angeben (z. B. https://deine-domain.de)"
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
@@ -718,77 +704,77 @@ msgstr ""
 "OAuth-Redirect-Host sollte keinen Pfad enthalten. Nur die Basis-URL "
 "verwenden (z. B. https://deine-domain.de)"
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr "Passwortlänge muss zwischen 1 und 40 Zeichen liegen"
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "Datenbankeinstellung aktualisiert"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "Datenbank-Konfiguration"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Ups! Bitte alle Felder ausfüllen."
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "E-Mail bezieht sich nicht auf eine gültige Domain"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Neuen Benutzer hinzufügen"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Benutzer '%(user)s' angelegt"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr ""
 "Ups! Es existiert bereits ein Account für diese E-Mail-Adresse oder diesen "
 "Benutzernamen."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Benutzer '%(nick)s' gelöscht"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "Benutzer 'Guest' kann nicht gelöscht werden"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "Kein verbleibender Admin-Benutzer, Benutzer kann nicht gelöscht werden"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "E-Mail kann nicht leer sein und muss gültig sein"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Benutzer '%(nick)s' aktualisiert"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 "Verbindung erfolgreich! OIDC-Discovery-Endpunkt ist erreichbar.%(endpoints)s"
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
@@ -796,12 +782,12 @@ msgstr ""
 "Verbindung fehlgeschlagen: OIDC-Discovery-Endpunkt nicht gefunden (404). "
 "Prüfen Sie, ob die Basis-URL korrekt ist."
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr "Verbindung fehlgeschlagen: Server lieferte den Status-Code %(code)s"
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
@@ -809,14 +795,14 @@ msgstr ""
 "Verbindung fehlgeschlagen: Verbindung zum Server nicht möglich. Überprüfen "
 "Sie die URL und die Netzwerkverbindung."
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 "Verbindung Fehlgeschlagen: Zeitüberschreitung der Anfrage. Der Server könnte "
 "langsam oder unerreichbar sein."
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
@@ -824,12 +810,12 @@ msgstr ""
 "Verbindung fehlgeschlagen: Ungültiges JSON in der Antwort. Dies ist "
 "möglicherweise kein OIDC."
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Verbindungsfehler: %(error)s"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
@@ -838,27 +824,27 @@ msgstr ""
 "Den Metadaten fehlen erforderliche OIDC-Felder: %(fields)s. Dies ist "
 "möglicherweise kein gültiger OIDC-Metadaten-Endpunkt."
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr "Metadaten-URL ist gültig! %(count)s OAuth-Endpunkte gefunden."
 
-#: cps/admin.py:3322
+#: cps/admin.py
 msgid " User info endpoint is available."
 msgstr " User-Info-Endpunkt ist verfügbar."
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 " Hinweis: User-Info-Endpunkt nicht gefunden – dies kann zu "
 "Authentifizierungsproblemen führen."
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr "Metadaten-URL nicht gefunden (404). Bitte URL auf Korrektheit prüfen."
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
@@ -866,50 +852,50 @@ msgstr ""
 "Verbindung fehlgeschlagen: Verbindung zur Metadaten-URL nicht möglich. "
 "Überprüfen Sie die URL und die Netzwerkverbindung."
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr "Verbindung Fehlgeschlagen: Zeitüberschreitung der Anfrage."
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr "Verbindung fehlgeschlagen: Ungültiges JSON in der Antwort."
 
-#: cps/admin.py:3340
+#: cps/admin.py
 msgid "An unknown error occurred."
 msgstr "Ein unbekannter Fehler ist aufgetreten."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 msgid "Restore already in progress."
 msgstr "Wiederherstellung wird bereits ausgeführt."
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 "Wiederherstellung fehlgeschlagen: Calibre-Bibliothekspfad nicht konfiguriert."
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 "Wiederherstellung fehlgeschlagen: metadata.db unter %(path)s nicht gefunden"
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr "Wiederherstellung fehlgeschlagen: app.db unter %(path)s nicht gefunden"
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Wiederherstellung fehlgeschlagen: %(err)s"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 "Wiederherstellung abgeschlossen, aber app.db-Bereinigung fehlgeschlagen. "
 "Details siehe Protokoll."
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
@@ -918,201 +904,200 @@ msgstr ""
 "Wiederherstellung abgeschlossen. Backups und Log unter %(dir)s gespeichert. "
 "Alle buchverknüpften Daten wurden zurückgesetzt."
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr "Kobo-Anmerkungen importieren"
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 msgid "No file uploaded."
 msgstr "Keine Datei hochgeladen."
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr "Datei übersteigt %(max)d MB."
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr "Hochgeladene Datei ist keine SQLite-Datenbank."
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr "Anmerkungen: %(title)s"
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr "Tschechisch"
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr "Deutsch"
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr "Griechisch"
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr "Spanisch"
 
-#: cps/constants.py:265
+#: cps/constants.py
 msgid "Finnish"
 msgstr "Finnisch"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr "Französisch"
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr "Galizisch"
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr "Ungarisch"
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr "Indonesisch"
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr "Italienisch"
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr "Japanisch"
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr "Khmer"
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr "Koreanisch"
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr "Niederländisch"
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr "Norwegisch"
 
-#: cps/constants.py:276
+#: cps/constants.py
 msgid "Polish"
 msgstr "Polnisch"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr "Portugisisch"
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr "Portugisisch (Brasilien)"
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr "Russisch"
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr "Slowakisch"
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr "Slowenisch"
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr "Schwedisch"
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr "Türkisch"
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr "Ukrainisch"
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr "Vietnamesisch"
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr "Chinesisch (vereinfacht, China)"
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr "Chinesisch (traditionell, Taiwan)"
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "nicht installiert"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Ausführberechtigung fehlt"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr "zurück zur Bearbeitung der Metadaten"
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr "zurück zum Buch"
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, fuzzy, python-format
 msgid "Change cover — %(title)s"
 msgstr " Autor und Titel tauschen"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr "Dieser Buchumschlag ist gesperrt. Bitte erst entsperren. "
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr "Geben Sie eine URL zum Buchcover an."
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr "Dieses Buch hat kein eingebettetes Cover, das extrahiert werden kann."
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Ein unbekannter Fehler ist aufgetreten."
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr "Sperrstatus konnte nicht gespeichert werden."
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr "Vorschau nur für http(s) URLs. "
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Could not render the e-reader preview."
 msgstr "Angegebener Ordner konnte nicht gefunden werden"
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr "Konnte kein Quellbild für die Vorschau laden."
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr "Speichern des Covers fehlgeschlagen."
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr "Der Themenwechsel ist bis v5.0.0 vorübergehend deaktiviert"
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
@@ -1120,265 +1105,256 @@ msgstr ""
 "Bibliothek aktualisieren 🔄 Prüfe auf Bücher, die vielleicht vergessen "
 "wurden, bitte warten..."
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 "Ungültiger Cron-Ausdruck für Dubletten-Scans. Änderungen wurden nicht "
 "gespeichert."
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr "Calibre-Web NextGen Benutzer-Einstellungen"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr "Zeitstempel"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Book ID"
 msgstr "Buch-ID"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Buchtitel"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Book Author"
 msgstr "Autor des Buches"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr "Auslösertyp"
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Filepath"
 msgstr "Dateipfad"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Filename"
 msgstr "Dateiname"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr "Manuell?"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr "Anzahl der Korrekturen"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr "Original gesichert?"
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr "Korrekturen angewendet"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr "Originalformat"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "End Format"
 msgstr "Zielformat"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 msgid "Unknown User"
 msgstr "Unbekannter Benutzer"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr "Calibre-Web NextGen Statistiken & Aktivitäten"
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr "Calibre-Web NextGen - Alle Durchführungen anzeigen"
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr "Calibre-Web NextGen - Alle Durchführungen anzeigen (w/Paths)"
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr "Calibre-Web NextGen - Alle Importe anzeigen"
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr "Calibre-Web NextGen - alle Konvertierungen anzeigen "
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr "Calibre-Web NextGen - alle EPUB-Fixer Aktionen anzeigen"
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 "Calibre-Web NextGen - alle EPUB-Fixer Aktionen anzeigen (w/ Paths & Fixes)"
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr "✅ Alle Überwachungsdienste laufen wie vorgesehen! 👍"
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr "🔴 Der Ingest-Dienst läuft, aber der Metadaten-Änderungsdetektor nicht"
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 "🔴 Der Metadaten-Änderungsdetektor wird ausgeführt, der Ingest-Dienst jedoch "
 "nicht"
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 "⛔ Weder der Ingest-Dienst noch der Metadaten-Änderungsdetektor werden "
 "ausgeführt"
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr "Ein Fehler ist aufgetreten"
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr "Calibre-Web Nextgen - Konvertiere Bibliothek"
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr "Calibre-Web NextGen - EPUB Fixer Dienst"
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 "Single-book EPUB Fixer wird nicht mit Google Drive-Bibliotheken unterstützt."
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 msgid "Invalid book selection."
 msgstr "Ungültige Buchauswahl."
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr "Buch wurde nicht gefunden."
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 msgid "Selected book has no EPUB format."
 msgstr "Das ausgewählte Buch hat kein EPUB-Format."
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 msgid "EPUB file not found on disk."
 msgstr "EPUB-Datei wurde nicht auf dem Datenträger gefunden."
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 msgid "EPUB Fixer started for selected book."
 msgstr "EPUB-Fixer für das ausgewählte Buch gestartet."
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr "EPUB Fixer konnte für das aktuelle Buch nicht gestartet werden."
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr "Du musst Administrator sein, um auf diese Seite zugreifen zu können."
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr "Sowohl der Benutzername als auch die Bilddaten sind erforderlich."
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr "Ungültiges Bilddatenformat. Es muss ein gültiges Bild sein."
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr "Nicht unterstützter Bildtyp. Nur PNG und JPEG sind zulässig."
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr "Bild ist zu groß. Bitte ein Bild kleiner als 500 KB verwenden."
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr "Ungültige Base64-Bilddaten."
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 msgid "Invalid image data format."
 msgstr "Ungültiges Bilddatenformat."
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr "Fehler bei der Validierung der Bilddaten."
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr "Profilbild erfolgreich aktualisiert."
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr "Calibre-Web NextGen Profilbild Management (WIP)"
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Keine"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 msgid "Duplicate Books"
 msgstr "Bücherduplikate"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr "Dublettengruppe bereits verworfen"
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 msgid "Duplicate group dismissed"
 msgstr "Duplikatgruppe verworfen"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 msgid "Duplicate group restored"
 msgstr "Duplikatgruppe wiederhergestellt"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr "Dublettengruppe wurde nicht verworfen"
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 msgid "Duplicate scan queued"
 msgstr "Duplikat-Scan in Warteschlange eingereiht"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr "Dubletten-Scan abgeschlossen (Fallback)"
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 msgid "Invalid resolution strategy"
 msgstr "Ungültige Lösungsstrategie"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
@@ -1386,97 +1362,94 @@ msgstr ""
 "Ingest Ordner nicht schreibbar, prüfe die Berechtigung vom /cwa-book-ingest "
 "Ordner."
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr "Fehlende oder ungültige Buch-ID für den Format-Upload"
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 "Format kann nicht hochgeladen werden: Buch existiert nicht mehr in der "
 "Bibliothek"
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Hochladen beendet, verarbeite Daten, bitte warten..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 msgid "Failed to queue upload for processing"
 msgstr "Fehler beim Hinzufügen des Uploads in die Verarbeitungswarteschlange"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Quell- oder Zielformat für Konvertierung fehlt"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr ""
 "Buch wurde erfolgreich für die Konvertierung nach %(book_format)s eingereiht"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Es trat ein Fehler beim Konvertieren des Buches auf: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "Dateityp kann nicht auf diesen Server hochgeladen werden"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr "Dateiendung '%(ext)s' kann nicht auf diesen Server hochgeladen werden"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "Dateien müssen eine Erweiterung haben, um hochgeladen zu werden"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 "Ups! Gewähltes Buch ist nicht verfügbar. Datei existiert nicht oder ist "
 "nicht zugänglich"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "Benutzer hat keine Berechtigung Cover hochzuladen"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 "Cover ist gesperrt. Bitte erst auf der Buchumschlag ändern Seite entsperren."
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 "IDs unterscheiden nicht zwischen Groß- und Kleinschreibung, alte ID wird "
 "überschrieben"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "'%(langname)s' ist keine gültige Sprache"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Metadaten wurden erfolgreich aktualisiert"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "Fehler beim Editieren des Buches: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1484,80 +1457,80 @@ msgstr ""
 "Das hochgeladene Buch existiert evtl. schon in der Bibliothek, vor dem "
 "erneuten Hochladen Änderung in Betracht ziehen: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 "Die Datei %(filename)s konnte nicht im temporären Ordner gespeichert werden"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Fehler beim Verschieben der Cover Datei %(file)s: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Buch Format erfolgreich gelöscht"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Buch erfolgreich gelöscht"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "Keine Erlaubnis zum Löschen von Büchern"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "Metadaten editieren"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "Serienindex: %(seriesindex)s ist keine gültige Zahl, wird übersprungen"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr "Benutzer hat kein Recht zusätzliche Dateiformate hochzuladen"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Fehler beim Erzeugen des Pfads %(path)s (Zugriff verweigert)"
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Fehler beim Speichern der Datei %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Dateiformat %(ext)s zu %(book)s hinzugefügt"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Buch wurde nicht gefunden."
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 "Das Buch hat keine Dateiformate auf dem Datenträger, aus denen neu geladen "
 "werden kann."
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "EPUB-Datei wurde nicht auf dem Datenträger gefunden."
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 "Metadaten aus der %(format)s-Datei konnten nicht eingelesen werden: %(err)s"
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
@@ -1565,21 +1538,21 @@ msgstr ""
 "Der Buchordner konnte nicht umbenannt werden, um ihn an die neu geladenen "
 "Metadaten anzupassen: %(err)s "
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr "Neu geladene Metadaten konnten nicht gespeichert werden: %(err)s"
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr "%(n)d Feld(er) aus der %(fmt)s-Datei auf dem Datenträger neu geladen"
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr "Metadaten auf dem Datenträger sind gleich - keine Felder aktualisiert"
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1587,7 +1560,7 @@ msgstr ""
 "Google Drive Setup is nicht komplett, bitte versuche Google Drive zu "
 "deaktivieren und aktiviere es anschließend erneut"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1595,89 +1568,88 @@ msgstr ""
 "Callback Domain ist nicht verifiziert, bitte Domain in der Google Developer "
 "Console verifizieren"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr "Diese eMail wurde via Calibre-Web NextGen gesendet."
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr "Ankündigungs-Mail für %(email)s"
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "%(format)s Format für Buch-ID %(book)d nicht gefunden"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(format)s von Buch %(fn)s nicht auf Google Drive gefunden"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s nicht gefunden: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "An E-Reader senden"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "%(format)s Format für Buch-ID %(book)d nicht gefunden"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "%(format)s Format für Buch-ID %(book)d nicht gefunden"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr "Calibre-Web NextGen Test eMail"
 
-#: cps/helper.py:387
+#: cps/helper.py
 msgid "Test Email"
 msgstr "E-Mail testen"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr "Erste Schritte mit Calibre-Web NextGen"
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Registrierungs-E-Mail für Benutzer: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Konvertiere %(orig)s nach %(format)s und sende an E-Reader"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Sende %(format)s an E-Reader"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s an E-Reader gesendet"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr ""
 "Die angeforderte Datei konnte nicht gelesen werden. Evtl. falsche "
 "Zugriffsrechte?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "Gelesen-Status konnte nicht aktualisiert werden: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
@@ -1685,12 +1657,12 @@ msgstr ""
 "Löschen des Ordners für Buch %(id)s ist fehlgeschlagen, der Pfad hat "
 "Unterordner: %(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "Löschen von Buch %(id)s fehlgeschlagen: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1699,7 +1671,7 @@ msgstr ""
 "Lösche Buch %(id)s nur aus Datenbank, Pfad zum Buch in Datenbank ist nicht "
 "gültig: %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
@@ -1707,171 +1679,171 @@ msgstr ""
 "Umbenennen des Autors '%(src)s' zu '%(dest)s' fehlgeschlagen mit dem Fehler: "
 "%(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Datei %(file)s wurde nicht auf Google Drive gefunden"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Umbenennen des Titels '%(src)s' zu '%(dest)s' fehlgeschlagen mit dem Fehler: "
 "%(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Buchpfad %(path)s wurde nicht auf Google Drive gefunden"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr "Es existiert bereits ein Benutzerkonto für diese E-Mail Adresse"
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Benutzername ist schon vergeben"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr "Ungültiges E-Mail Adressformat"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr "Passwort entspricht nicht den Passwortvorgaben"
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 "Python-Modul 'advocate' ist nicht installiert, wird aber für das Hochladen "
 "von Covern benötigt"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Fehler beim Herunterladen des Covers"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr "Cover Bild ist zu groß %(size)s MB"
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr "Coverdatei ist keine gültige Bilddatei, kann nicht gespeichert werden"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Coverdatei fehlerhaft"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
 msgstr ""
 "Keine Berechtigung Cover von localhost oder dem lokalen Netzwerk hochzuladen"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Fehler beim Erzeugen des Ordners für die Coverdatei"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "Nur jpg/jpeg/png/webp/bmp-Dateien werden als Cover unterstützt"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "Ungültiger Coverdatei-Inhalt"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Nur jpg/jpeg-Dateien werden als Cover unterstützt"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr "Titelbild"
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "UnRar-Programm nicht gefunden"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr "Fehler beim Ausführen von UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr "Angegebener Ordner konnte nicht gefunden werden"
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr "Bitte keine Datei sondern einen Ordner angeben"
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr "Die Calibre Programmdaten sind nicht verwendbar"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr "Fehlendes Calibre-Programm: %(missing)s"
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Ausführberechtigung fehlt: %(missing)s"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr "Fehler beim Ausführen von Calibre"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr "Alle Bücher für Metadaten-Backup einreihen"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Kobo Setup"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr "Kürzlich hinzugefügt"
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr "Hoch bewertet"
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr "Wird gerade gelesen"
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr "Noch zu lesen"
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr "Neuere Veröffentlichungen"
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Anmelden mit %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
@@ -1881,13 +1853,13 @@ msgstr ""
 "fehlerhaften Scope-Konfiguration liegen. Bitte prüfen Sie Ihre OAuth-Scopes "
 "oder kontaktieren Sie Ihren Administrator."
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 "Anmeldung fehlgeschlagen: OAuth-Token abgelaufen. Bitte versuchen Sie, sich "
 "erneut anzumelden."
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
@@ -1896,7 +1868,7 @@ msgstr ""
 "OAuth-Anbieters fehlgeschlagen. Bitte versuchen Sie es erneut oder "
 "kontaktieren Sie Ihren Administrator."
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
@@ -1905,7 +1877,7 @@ msgstr ""
 "Benutzerprofildaten zurückgegeben. Bitte kontaktieren Sie Ihren "
 "Administrator."
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1916,40 +1888,40 @@ msgstr ""
 "erforderliche Felder: %(fields)s. Bitte prüfen Sie Ihre OAuth-Konfiguration "
 "oder kontaktieren Sie Ihren Administrator."
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 "Verknüpfung des OAuth-Kontos fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 "Login fehlgeschlagen: Ihr Account kann nicht auf diese Applikation zugreifen."
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 "OAuth-Fehler: Provider lieferte ungültige Benutzerinformationen. Bitte "
 "versuchen Sie es erneut."
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 "Dieses %(oauth)s-Konto ist bereits mit einem anderen Benutzer verknüpft"
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "Erfolg! Du bist nun eingeloggt als '%(nickname)s'"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Verbindung mit %(oauth)s erfolgreich"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1960,58 +1932,58 @@ msgstr ""
 "Konto verknüpft. Bitte kontaktieren Sie Ihren Administrator, um ein Konto zu "
 "erstellen oder Ihr bestehendes Konto zu verknüpfen."
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 "OAuth-Authentifizierung fehlgeschlagen. Bitte versuchen Sie es erneut oder "
 "kontaktieren Sie den Administrator."
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 msgid "OAuth system error. Please contact administrator."
 msgstr "OAuth-Systemfehler. Bitte kontaktieren Sie den Administrator."
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "Verbindung zu %(oauth)s ist erfolgreich getrennt"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Verbindung mit %(oauth)s trennen ist fehlgeschlagen"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "Nicht mit %(oauth)s verbunden"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Login mit GitHub fehlgeschlagen."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Laden der Benutzerinformationen von GitHub fehlgeschlagen."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Login mit Google fehlgeschlagen."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Laden der Benutzerinformationen von Google fehlgeschlagen."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 msgid "Failed to log in with Generic OAuth."
 msgstr "Login mit generischem OAuth fehlgeschlagen."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 "OAuth-Authentifizierung fehlgeschlagen: Token-Validierungsfehler. Bitte "
 "versuchen Sie es erneut."
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
@@ -2019,7 +1991,7 @@ msgstr ""
 "OAuth-Authentifizierung aufgrund eines unerwarteten Fehlers fehlgeschlagen. "
 "Bitte kontaktieren Sie den Administrator."
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
@@ -2029,215 +2001,208 @@ msgstr ""
 "auftritt, konfigurieren Sie bitte die Einstellung „OAuth-Redirect-Host“ "
 "unter Admin > Basiskonfiguration > OAuth."
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "GitHub OAuth Fehler, bitte später erneut versuchen."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "Github OAuth Fehler {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Google OAuth Fehler, bitte später erneut versuchen."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Google OAuth Fehler: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr "OAuth-Fehler: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 #, fuzzy
 msgid "Alphabetical Books"
 msgstr "Bücherduplikate"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "Bücher alphabetisch sortiert"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Beliebte Bücher"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr ""
 "Beliebte Publikationen aus dieser Bibliothek basierend auf Anzahl der "
 "Downloads."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Am besten bewertete Bücher"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Beliebte Veröffentlichungen dieses Katalogs basierend auf Bewertung."
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "Neu hinzugefügte Bücher"
 
-#: cps/opds.py:183
+#: cps/opds.py
 #, fuzzy
 msgid "The latest Books"
 msgstr "Die neuesten Bücher"
 
-#: cps/opds.py:188
+#: cps/opds.py
 #, fuzzy
 msgid "Random Books"
 msgstr "Zeige zufällige Bücher"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Zeige zufällige Bücher"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Gelesene Bücher"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Kürzlich gelesene Bücher"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Ungelesene Bücher"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Autoren"
 
-#: cps/opds.py:213
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by Author"
 msgstr "Autor des Buches"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Verleger"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Bücher nach Verleger sortiert"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Kategorien"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Bücher nach Kategorie sortiert"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Serien"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Bücher nach Serie sortiert"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Sprachen"
 
-#: cps/opds.py:237
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by Languages"
 msgstr "Bücher pro Seite"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Bewertungen"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Bücher nach Bewertung sortiert"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Dateiformate"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Bücher nach Dateiformat sortiert"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Regale"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "Bücher in Regalen organisiert"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Magische Regale ✨"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Bücher in Magische Regale sortiert"
 
-#: cps/opds.py:317
+#: cps/opds.py
 msgid "description"
 msgstr "Beschreibung"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} Sterne"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Suchen"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Anmelden"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Token wurde nicht gefunden"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Token ist abgelaufen"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Erfolg! Bitte zum Gerät zurückkehren"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
@@ -2246,111 +2211,110 @@ msgstr ""
 "bevor nach Importen und Metadatenänderungen schnelle Duplikatprüfungen "
 "durchgeführt werden können."
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Bücher"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Zeige zuletzt hinzugefügte Bücher"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Zeige beliebte Bücher"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Heruntergeladene Bücher"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Zeige heruntergeladene Bücher"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Zeige am besten bewertete Bücher"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 msgid "Show Read and Unread"
 msgstr "Zeige Gelesen und Ungelesen"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Zeige Ungelesene"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Entdecken"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Category Section"
 msgstr "Zeige Kategorienabschnitt"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Series Section"
 msgstr "Zeige Serienabschnitt"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Author Section"
 msgstr "Zeige Autorenabschnitt"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Publisher Section"
 msgstr "Zeige Verlegerabschnitt"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Language Section"
 msgstr "Zeige Sprachenabschnitt"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Ratings Section"
 msgstr "Zeige Bewertungsabschnitt"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show File Formats Section"
 msgstr "Zeige Dateiformatabschnitt"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Archivierte Bücher"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Archived Books"
 msgstr "Zeige archivierte Bücher"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr "Favoriten"
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr "Zeige Favoriten"
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Bücherliste"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Zeige Bücherliste"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr "Duplikate"
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 msgid "Show Duplicate Books"
 msgstr "Zeige Bücherduplikate"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 "Calibre-Web NextGen %(latest)s ist verfügbar - Sie sind auf Version "
 "%(current)s"
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
@@ -2359,398 +2323,397 @@ msgstr ""
 "Helfen Sie, Calibre-Web NextGens %(language)s zu übersetzen - %(count)s "
 "müssen noch übersetzt werden."
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Herausgegeben nach dem "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Herausgegeben vor dem "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Bewertung <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Bewertung >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Lesestatus = '%(status)s'"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 "Fehler bei der Suche nach eigenen Spalten, bitte Calibre-Web neustarten"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Erweiterte Suche"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Ungültiges Regal angegeben"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr ""
 "Entschuldige, die Berechtigung ein Buch zu diesem Regal hinzuzufügen fehlt"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "Buch ist bereits Teil des Regals %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 "%(book_id)s ist eine ungültige Buch ID. Buch konnte nicht zu Regal "
 "hinzugefügt werden"
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "Das Buch wurde zum Regal %(sname)s hinzugefügt"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "Keine Berechtigung Bücher zu diesem Regal hinzuzufügen"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Bücher sind bereits Teil des Regals %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "Bücher wurden zum Regal %(sname)s hinzugefügt"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Bücher konnten nicht zum Regal %(sname)s hinzugefügt werden"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "Ungültiges Regal angegeben"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Bücher konnten nicht zum Regal %(sname)s hinzugefügt werden"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Bücher sind bereits Teil des Regals %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "Bücher wurden zum Regal %(sname)s hinzugefügt"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "Das Buch wurde aus dem Regal: %(sname)s entfernt"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr ""
 "Entschuldige, die Berechtigung, um Bücher aus diesem Regal zu löschen, fehlt"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Neues Regal"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Entschuldige, die Berechtigung das Regal zu editieren fehlt"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Regal bearbeiten"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "Fehler beim Löschen des Regals"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "Regal erfolgreich gelöscht"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Reihenfolge in Regal '%(name)s' verändern"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr ""
 "Entschuldige, die Berechtigung, um ein öffentliches Regal zu erzeugen, fehlt"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Regal %(title)s erstellt"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Regal %(title)s geändert"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Es trat ein Fehler auf"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "Es existiert bereit ein öffentliches Regal mit dem Namen '%(title)s'."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "Es existiert bereit ein privates Regal mit dem Namen '%(title)s'."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Regal: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Fehler beim Öffnen des Regals. Regal exisitert nicht oder ist nicht "
 "zugänglich"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr "Ungültiger Sortiermodus: %(mode)s"
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr "Reihenfolge konnte nicht gespeichert werden"
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 msgid "Reorder Shelves"
 msgstr "Regale neu anordnen"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr "Name (A → Z)"
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr "Name (Z → A)"
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr "Buchanzahl (meiste → wenigste)"
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr "Buchanzahl (wenigste → meiste)"
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr "Erstellt (neueste → älteste)"
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr "Erstellt (älteste → neueste)"
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr "Geändert (letzte → älteste)"
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr "Geändert (älteste → letzte)"
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr "Manuell (unten ziehen)"
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr "Jetzt lesen"
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr "Details zu {title} öffnen"
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr "{title} lesen"
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr "Standard (Benutzername / Passwort)"
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Anonym"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Nicht authentifiziert"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr "Einfach (Dienstkonto)"
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr "Serie - Nr."
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr "Serie - Nr. (umgekehrt)"
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr "Tag hinzufügen"
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr "Neuer Tag"
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr "Tag entfernen"
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr "Tag entfernen {name}"
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr "Tag umbenennen {name}"
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr "Bezeichnung Tag"
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr "Bezeichnung Tag darf nicht leer sein"
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr "Tag-Bezeichnung speichern"
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr "Format auswählen"
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr "Tag umbenannt zu {name}"
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr "Sie müssen angemeldet sein"
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr "Keine Berechtigung Metadaten zu bearbeiten"
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr "Es gibt bereits einen Tag mit dieser Bezeichnung"
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr "Die Tag-Bezeichnung muss Text sein"
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr "Tag-Bezeichnung darf keine Kommas enthalten"
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr "Geben Sie eine gültige Tag-Bezeichnung ein"
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr "Konnte diese Seite nicht laden"
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr "Seite nicht gefunden"
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr "Bewertung zurücksetzen"
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr "Nicht bewertet"
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Ja"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Nein"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr "Nachrichtentext"
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr "Bewertet {rating} von 5"
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr "Mehr von {name}"
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
@@ -2759,311 +2722,299 @@ msgstr ""
 "{n} Bücher mit dem ersten Ausgewählten zusammenführen? Die anderen werden "
 "entfernt, wenn die Formate umkopiert wurden."
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr "Zu {n} Büchern hinzufügen."
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr "Übereinstimmungsbedingung"
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr "Regelfeld"
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr "Regeloperator"
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr "Konnte Smart-Shelf Regeln nicht laden"
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr "Hat Cover"
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr "Serien Nr. "
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Lesestatus"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr "Hat Hardcover ID"
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr "In den letzten N Tagen"
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr "Nicht in den letzten N Tagen"
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr "ist vor / kleiner als"
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Design"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Hell"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Dunkel"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "Sepia"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr "Regel hinzufügen"
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Zu Regal hinzufügen"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Autor"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr "Autoren (mit & trennen)"
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr "Zurück zur Anmeldung"
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr "Buchinhalt"
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Durchsuchen"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr "Passwort ändern"
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Schließen"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr "Menü schließen"
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr "Inhalt"
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr "Konvertierung fehlgeschlagen."
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr "Konvertiere nach"
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr "Konvertiere zu format"
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr "Konnte Passwort nicht ändern"
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr "Konnte nicht erstellt werden."
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr "Konnte kein Cover finden."
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr "Konnte Metadaten nicht laden."
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr "Konnte die Buchdatei nicht laden ({status})"
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr "Konnte Ihren Account nicht laden."
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr "Speichern fehlgeschlagen."
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr "Coverbild URL"
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr "Cover update fehlgeschlagen"
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr "Cover aktualisiert."
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr "Intelligentes Regal erstellen"
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr "Erstellen Sie Ihren Account"
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Löschen"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr "Buch löschen"
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
@@ -3072,488 +3023,481 @@ msgstr ""
 "Wirklich löschen \"{title}\"? Das Buch und alle Dateien werden aus der "
 "Bibliothek entfernt. Dies kann nicht rückgängig gemacht werden."
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr "Lösche..."
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr "Löschen des Buches fehlgeschlagen."
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 "{fmt} Datei löschen? Das Buch bleibt in der Bibliothek, nur dieses Format "
 "wird entfernt."
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr "{fmt} löschen"
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr "{n} Bücher löschen? Dies kann nicht rückgängig gemacht werden."
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr "Beschreibung enthält"
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr "Markierung aufheben {title}"
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr "Metadaten bearbeiten"
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr "{title} bearbeiten"
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr "Ihre Standard-Bibliotheksansicht anzeigen."
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr "Alle Bücher anzeigen"
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr "Bibliotheksansicht bearbeiten"
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr "Laden der Bücher fehlgeschlagen."
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr "Öffnen des Buchs fehlgeschlagen"
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr "Erstellen"
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr "grün"
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr "Hilfe"
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr "Farbe der Highlights"
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr "Von Kobo importieren"
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr "Sprache Benutzeroberfläche"
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr "Ungültiger Nutzername oder Passwort"
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Zusammenführen"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr "Metadaten zu {n} Büchern hinzugefügt."
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 "Neues Passwort für “{label}” - kopieren Sie es jetzt,es wird nicht noch "
 "einmal angezeigt."
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr "Passwörter sind nicht gleich"
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr "Keine Bücher hier"
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr "Keine Ergebnisse für \"{q}\". "
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr "Keine Vorschläge"
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr "Keine {filter} Bücher hier."
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr "Passwort geändert."
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr "URL einfügen"
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr "Privates Regal"
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr "Profil"
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr "Profil gespeichert."
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr "Öffentliches Regal"
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Verleger"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr "Verleger (mit Komma trennen)"
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Gelesen"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr "Lesefortschritt"
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr "Registrierung fehlgeschlagen."
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr "Entferne {name}"
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr "Anfrage fehlgeschlagen"
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr "Passwort zurücksetzen"
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr "{label} widerrufen"
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr "Speichern fehlgeschlagen"
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr "Profil speichern"
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr "Gespeichert."
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr "Suche fehlgeschlagen"
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr "Suche nach Metadaten"
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr "Metadaten-Anbieter"
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr "Lade Anbieter"
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr "Konnte Anbieter nicht laden."
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr "Konnte Anbieter nicht aktualisieren"
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr "An"
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr "Aus"
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr "Suchtreffer"
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr "Bibliothek durchsuchen"
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr "{title} auswählen"
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr "Serienposition {n}"
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr "Anmelden"
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr "Anmeldung fehlgeschlagen. Bitte noch einmal probieren."
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr "Zurück zum Inhalt"
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr "Einige Felder konnten nicht gespeichert werden."
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr "Inhaltsverzeichnis"
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr "Tags (mit Komma trennen)"
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Titel"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr "ungelesen"
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr "Passwort aktualisieren"
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Upload"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr "Bücher zum Hochladen auswählen."
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr "Bild hochladen"
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr "Hochladen..."
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr "{n} Bücher zum Regal hinzugefügt."
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr "{n} Bücher gelöscht."
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr "{n} als gelesen markiert."
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr "{n} als ungelesen markiert."
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr "{n} ausgewählt"
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr "{pct}% gelesen"
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr "Neuigkeiten"
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr "Hilfe — neue Aktualisierungen verfügbar"
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 "Die neuesten Features und Fixes in Calibre-Web NextGen - die Neuesten zuerst."
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 "Noch keine Versionshinweise - nach dem nächsten Update noch einmal prüfen."
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
@@ -3561,252 +3505,249 @@ msgstr ""
 "Die Oberfläche wurde in Ihre Sprache übersetzt. Diese Update-Hinweise sind "
 "in Englisch"
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr "gerade am Lesen"
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr "Bibliothek"
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr "Listenansicht"
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Account"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Admin"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr "Unter der Haube"
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr "Bibliothek öffnen"
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr "Schlagwörter durchsuchen"
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr "Table View öffnen"
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr "Auf Duplikate prüfen"
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr "Regale öffnen"
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr "E-Reader Adresse prüfen."
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr "App-Passwort erstellen"
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr "Serien durchsuchen"
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr "Autoren durchsuchen"
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr "Sprachen durchsuchen"
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr "Administrator öffnen"
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr "Benutzereinstellungen öffnen"
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr "Discover durchsuchen"
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr "Ihre Bibliothek entdecken"
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr "gehe zum Upload"
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr "Suche öffnen"
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr "Editionen"
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr "Zurück zur neuen Benutzeroberfläche"
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr "Zurück zu den Ergebnissen"
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr "Keine Ausgaben für dieses Buch gefunden."
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr "Alle Details anzeigen"
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr "Ergebnisdetails"
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Herausgabedatum"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr "Zielformat"
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Quelle"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr "Anpassen"
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr "Seitenleiste anpassen"
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr "Navigation anpassen"
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr "Fertig"
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr "Zurücksetzen zu Default"
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr "Immer anzeigen"
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 "Seitenleiste bearbeiten. Abschnitte neu anordnen oder verstecken, dann auf "
 "Fertig klicken."
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr "Bearbeiten abgebrochen."
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 "Ziehen um umzusortieren. Klicke X um einen Abschnitt zu verstecken. "
 "Pfeiltasten bewegen den ausgewählten Abschnitt."
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr "Seitenleiste gespeichert."
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr "Seitenleiste zu Default zurücksetzen."
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr "{label} zu position {pos} von {total} verschoben."
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 "{label} neu anordnen (Position {pos} von {total}). Pfeiltasten zum "
 "Verschieben."
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr "Lösche {label}"
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr "{label} wiederherstellen"
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr "{label} versteckt"
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr "{label} wiederhergestellt"
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr "Seitenleiste speichern fehlgeschlgen. Bitte noch einmal probieren."
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr "Bibliothek aktualisieren"
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
@@ -3814,2334 +3755,2297 @@ msgstr ""
 "Ein einmaliger Duplikat-Scan wird benötigt. Von CWA-Einstellungen ausführen, "
 "dann hierher zurückkehren."
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr "Hinzugefügt am"
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr "Veröffentlichungsdatum"
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr "beginnt mit"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr "enthält"
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr "enthält nicht"
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr "endet mit"
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr "in den letzten N Tagen"
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr "ist nicht"
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr "ist"
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr "nicht in den letzten N Tagen"
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr "am oder nach dem"
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr "am oder vor dem"
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr "(Umschlag ersetzen)"
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr "Ein paar zufällige Titel aus deiner Bibliothek"
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "Über"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr "Zu Favoriten hinzufügen"
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr "Administratoren-Gruppe"
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr "Erweitert"
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr "Erweiterte Suche"
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr "Alle Regale"
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr "Remote-Login (magic link) erlauben"
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr "Beliebig"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr "Beliebiges Format"
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr "Beliebige Sprache"
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr "Beliebige Serie"
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr "Beliebige Tags/Schlagwörter"
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr "Ausgewählte hinzufügen"
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 "Zu allen Markierten hinzufügen (nur gefüllte Felder werden geändert, "
 "bestehende Werte werden überschrieben):"
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr "Hinzufügen..."
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr "Archiv"
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Archiviert"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr "Auf Discord fragen"
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr "Authentifizierung"
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr "Authentifizierung und Sicherheit"
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr "Autor A-Z"
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr "Autor Z-A"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr "Autorisiert - Sie werden angemeldet..."
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr "URL autorisieren"
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr "Benutzer automatisch erstellen"
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr "Benutzer beim ersten Login automatisch erstellen"
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr "Zurück zur Bibliothek"
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr "Zurück zur klassischen Ansicht"
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr "Grundkonfiguration"
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr "Buch Standard"
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr "Band {number}"
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr "Bücher pro Seite"
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr "Massenverarbeitung"
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr "CWA-Einstellungen (ingest, konvertieren)"
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr "Kann Bücher hochladen"
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Abbruch"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr "Umbennen abbrechen"
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr "Titelbearbeitung abbrechen"
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr "Aufgabe „{task}“ abbrechen"
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr "Pfad zur Zertifikatsdatei"
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr "Pfad zum Zertifikat"
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr "Cover ändern"
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr "Prüfe..."
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr "Cover auswählen"
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr "Coverbild zum Upload auswählen"
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr "Bild auswählen..."
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr "Felder auswählen"
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr "Theme wählen"
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr "Standardeinstellungen zurücksetzen"
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr "Auswahl zurücksetzen"
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr "Schließe Reader"
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr "Spalten"
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr "Bequem"
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr "Kompakt"
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr "Konfiguriert"
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr "Passwort bestätigen"
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "Konvertiere"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr "Vor dem Senden konvertieren"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr "Konvertieren von"
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr "In die Zwischenablage kopiert"
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr "Link kopieren"
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr "Regal konnte nicht erstellt werden."
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr "Das Regal konnte nicht erstellt werden."
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr "Regal konnte nicht gelöscht werden."
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr "Vorschläge konnten nicht geladen werden."
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr "Duplikate konnten nicht geladen werden."
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr "Highlights konnten nicht geladen werden."
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr "Statistiken konnten nicht geladen werden."
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr "Aufgaben konnten nicht geladen werden."
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr "Laden dieser Textdatei fehlgeschlagen."
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr "Benutzer konnten nicht geladen werden."
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr "Lesen des Comic-Archivs fehlgeschlagen."
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr "Metadaten konnten nicht neu geladen werden."
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr "Regal konnte nicht umbenannt werden."
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr "Passwort zurücksetzen fehlgeschlagen"
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr "Reihenfolge konnte nicht gespeichert werden."
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr "Konnte Reader-Einstellungen nicht speichern."
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr "Konnte Standard-Bibliotheksfilter nicht speichern."
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr "Das Regal konnte nicht gespeichert werden."
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr "Titel konnte nicht gespeichert werden."
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr "Regal konnte nicht aktualisiert werden."
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr "Konnte Magic Link nicht starten. Bitte noch einmal probieren."
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr "Cover gesperrt"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr "Cover nicht erreichbar"
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr "Cover von den ausgewählten Vorschlägen aktualisiert. "
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr "Erstellen"
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr "Account erstellen"
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr "Account erstellen"
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr "Erstellen fehlgeschlagen."
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr "Erstelle ein Regal und füge ein Buch hinzu"
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr "Erstelle Benutzer"
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr "{name} wurde erstellt."
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr "Erstelle..."
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr "Aktuell"
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr "Aktuelles Cover"
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr "Aktuelles Passwort"
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr "Gerade am Lesen"
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr "Datenbanks- und Bibliothekspfad"
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr "Hinzugefügt am"
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr "Standard Bücher-Sprache"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr "Standard Bibliotheksfilter gespeichert."
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr "Bücher entfernen"
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr "Löschen fehlgeschlagen."
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr "Regal „{name}“ löschen? Dies kann nicht rückgängig gemacht werden."
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr "Dieses Regal entfernen? Ihre Bücher bleiben in der Bibliothek."
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 "Benutzer „{name}“ löschen? Seine Regale und Lesedaten werden ebenfalls "
 "entfernt."
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr "{name} löschen"
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr "{name} wurde gelöscht."
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr "Dicht"
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Beschreibung"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr "Aktiviere Standard Passwort Login"
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr "Entdecken — Zufällige Auswahl"
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr "Dokumentation"
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Download"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Editieren"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr "Intelligentes Regal bearbeiten"
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "E-Mail"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Synchronisation mit Kobo aktivieren"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Verschlüsselung"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr "Regale konnten nicht geladen werden."
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr "Filtern: {items}"
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr "Filtern: {items}…"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr "Gib deinem intelligenten Regal einen Namen."
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr "Hilfe und Support"
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr "Hilfemenü"
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "Verstecke"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr "Entdeckungsbereich ausblenden"
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr "Beliebt"
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr "Beliebt — Am häufigsten heruntergeladen"
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr "Symbol"
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "IDs"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr "KOReader-Fortschritt"
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Sprache"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr "Zuletzt geändert"
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr "Mehr laden"
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr "Wird geladen…"
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr "Als gelesen markieren"
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr "Als ungelesen markieren"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr "Übereinstimmung"
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr "Name"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr "Möchtest du ein Problem melden? Probiere das neue"
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr "Name des neuen Regals"
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr "Name des neuen Regals…"
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr "Neues intelligentes Regal"
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr "Keine Treffer in {items} für „{query}“."
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr "Noch keine Regale. Erstelle oben eines, um Bücher zu sammeln."
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr "Noch keine Einträge in {items}."
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr "Seite {number}"
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Passwort"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Fortschritt"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr "Öffentlich"
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Bewertung"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr "Lesestatusfilter"
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr "Aktualisieren"
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr "Vom Regal entfernen"
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr "Regel entfernen"
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr "Problem auf Discord melden"
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr "Problem auf GitHub melden"
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Speichern"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "Auswahl"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr "Senden"
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr "Senden fehlgeschlagen."
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr "Alle in {items} anzeigen"
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr "Auswahl neu mischen"
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr "Intelligente Regale"
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr "Sortierreihenfolge"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Status"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr "Auf Ko-fi unterstützen →"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr "Tabellenansicht"
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr "Schlagwort"
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Tags"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Aufgabe"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Aufgaben"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 "Dieses Regal ist leer. Füge Bücher über eine beliebige Buchseite hinzu."
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr "Am besten bewertet"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr "Entarchivieren"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr "Aktualisierung fehlgeschlagen."
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Benutzer"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Benutzername"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Ansicht"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr "alle Regeln"
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr "mindestens eine Regel"
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr "Bücher stimmen überein"
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr "z. B. ungelesene Science-Fiction"
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr "Wert"
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr "{count} Buch"
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr "{count} Bücher"
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr "{count} Datei für den Import vorgemerkt"
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr "{count} Datei abgelehnt"
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr "{count} Dateien für den Import vorgemerkt"
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr "{count} Dateien abgelehnt"
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr "{count} Ergebnis"
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr "{count} Ergebnisse"
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Warte..."
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Gestartet"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Fertiggestellt"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "Beendet"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "Abgebrochen"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Unbekannter Status"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Aktualisierungsinformationen enthalten unerwartete Daten"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr ""
 "Keine Aktualisierung verfügbar. Du nutzt bereits die aktuellste Version"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6149,17 +6053,17 @@ msgstr ""
 "Es sind Updates verfügbar. Klicke auf den Button unten, um auf die "
 "aktuellste Version zu aktualisieren."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Updateinformationen konnten nicht geladen werden"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr ""
 "Klicke auf den Button unten, um auf die letzte stabile Version zu "
 "aktualisieren."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6168,152 +6072,152 @@ msgstr ""
 "Ein neues Update ist verfügbar. Klicke auf den Button unten, um auf Version: "
 "%(version)s zu aktualisieren"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Keine Release-Informationen verfügbar"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Entdecken (Zufällige Bücher)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Beliebte Bücher (meiste Downloads)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "Von %(user)s heruntergeladene Bücher"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Author: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Verleger: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Serie: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "Bewertung: Keine"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Bewertung: %(rating)s Sterne"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Dateiformat: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Kategorie: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Sprache: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Beliebte Bücher"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Verstecktes Buch"
 
-#: cps/web.py:1193
+#: cps/web.py
 msgid "Error loading magic shelf"
 msgstr "Fehler beim Laden des magischen Regals"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr "Magisches Regal&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr "Keine Regeln angegeben"
 
-#: cps/web.py:1400
+#: cps/web.py
 msgid "Invalid rules format"
 msgstr "Ungültiges Regelformat"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr "Fehler beim Verarbeiten der Regeln"
 
-#: cps/web.py:1426
+#: cps/web.py
 msgid "Invalid request"
 msgstr "Ungültige Anfrage"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr "Name und Regeln sind erforderlich"
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr "Regalname zu lang (maximal 100 Zeichen)"
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 msgid "Error creating shelf"
 msgstr "Fehler beim Erstellen des Regals"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 msgid "Create Magic Shelf"
 msgstr "Neues magisches Regal"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr "Berechtigung zum Ändern des öffentlichen Status verweigert"
 
-#: cps/web.py:1587
+#: cps/web.py
 msgid "Shelf name is required"
 msgstr "Regalname ist erforderlich"
 
-#: cps/web.py:1647
+#: cps/web.py
 msgid "Error updating shelf"
 msgstr "Fehler beim Aktualisieren des Regals"
 
-#: cps/web.py:1652
+#: cps/web.py
 msgid "Edit Magic Shelf"
 msgstr "Magisches Regal bearbeiten"
 
-#: cps/web.py:1668
+#: cps/web.py
 msgid "Shelf not found"
 msgstr "Regal nicht gefunden"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr "Zugriff verweigert"
 
-#: cps/web.py:1704
+#: cps/web.py
 msgid "Shelf duplicated successfully"
 msgstr "Regal erfolgreich dupliziert"
 
-#: cps/web.py:1710
+#: cps/web.py
 msgid "Error duplicating shelf"
 msgstr "Fehler beim Duplizieren des Regals"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
@@ -6321,105 +6225,103 @@ msgstr ""
 "Systemregale können nicht gelöscht werden. Sie können diese in Ihren "
 "Benutzerprofil-Einstellungen ausblenden."
 
-#: cps/web.py:1755
+#: cps/web.py
 msgid "Error deleting shelf"
 msgstr "Fehler beim Löschen des Regals"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 "Sie können Ihre eigenen Regale nicht ausblenden. Löschen Sie diese "
 "stattdessen, wenn Sie sie nicht mehr benötigen."
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr "Regal bereits ausgeblendet"
 
-#: cps/web.py:1795
+#: cps/web.py
 msgid "Error hiding shelf"
 msgstr "Fehler beim Ausblenden des Regals"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr "Regal war nicht ausgeblendet"
 
-#: cps/web.py:1818
+#: cps/web.py
 msgid "Error unhiding shelf"
 msgstr "Fehler beim Einblenden des Regals"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Downloads"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Liste der Dateiformate"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr ""
 "Bitte zunächst die SMTP-Einstellungen des E-Mail-Server konfigurieren..."
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 "Ups! Bitte zuerst das Profil mit einer validen E-Reader-E-Mail-Adresse "
 "aktualisieren."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "Erfolg! Buch erfolgreich zum Senden an %(eReadermail)s eingereiht"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Ups! Beim Senden des Buches trat ein Fehler auf: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr "Keine E-Mail-Adresse ausgewählt"
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr "Zusätzliche E-Mail-Adressen sind für Ihr Konto deaktiviert."
 
-#: cps/web.py:2500
+#: cps/web.py
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "Erfolg! Buch zum Senden an die ausgewählte(n) Adresse(n) eingereiht!"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr "Bitte eine Minute warten vor der Registrierung des nächsten Benutzers"
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Registrieren"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr "Verbindugnsfehler zu Limiter Backend, bitte Administrator kontaktieren"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr ""
 "Ups! Der E-Mail-Server ist nicht konfiguriert, bitte den Administrator "
 "kontaktieren."
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "Ups! Diese E-Mail ist nicht erlaubt."
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "Erfolg! Eine E-Mail zur Bestätigung wurde versendet."
 
-#: cps/web.py:2624
+#: cps/web.py
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
@@ -6427,7 +6329,7 @@ msgstr ""
 "Authentifizierungsschleife erkannt. Wenn Sie Probleme beim Anmelden haben, "
 "kontaktieren Sie bitte Ihren Administrator."
 
-#: cps/web.py:2704
+#: cps/web.py
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
@@ -6435,28 +6337,28 @@ msgstr ""
 "Die OAuth-Authentifizierung ist nicht korrekt konfiguriert. Bitte "
 "kontaktieren Sie den Administrator."
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr "LDAP-Authentifizierung kann nicht aktiviert werden"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr "Standard-Login ist deaktiviert."
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr "Bitte eine Minute vor dem nächsten Anmeldeversuch warten"
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr "Benutzername darf nicht leer sein"
 
-#: cps/web.py:2756
+#: cps/web.py
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "du bist nun eingeloggt als: '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
@@ -6465,7 +6367,7 @@ msgstr ""
 "Willkommen! Ihr Konto wurde automatisch erstellt. Sie sind jetzt eingeloggt "
 "als: '%(nickname)s'"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
@@ -6473,7 +6375,7 @@ msgstr ""
 "Authentifizierung erfolgreich, aber die Kontoerstellung ist fehlgeschlagen. "
 "Bitte kontaktieren Sie Ihren Administrator."
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
@@ -6481,7 +6383,7 @@ msgstr ""
 "Authentifizierung erfolgreich, aber kein lokales Konto gefunden. Bitte "
 "kontaktieren Sie Ihren Administrator, um Ihr Konto zu erstellen."
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6490,696 +6392,666 @@ msgstr ""
 "Fallback Login als: '%(nickname)s', LDAP Server ist nicht erreichbar, oder "
 "der Nutzer ist unbekannt"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr "Login nicht erfolgreich: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 msgid "Wrong Username or Password"
 msgstr "Falscher Benutzername oder Passwort"
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr "Das neue Passwort wurde an die E-Mail-Adresse geschickt"
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr ""
 "Es ist ein unbekannter Fehler aufgetreten. Bitte später erneut versuchen."
 
-#: cps/web.py:2838
+#: cps/web.py
 msgid "Please enter valid username to reset password"
 msgstr ""
 "Bitte einen gültigen Benutzernamen zum Zurücksetzen des Passworts angeben"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "Du bist nun eingeloggt als: '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 msgid "Success! Profile Updated"
 msgstr "Erfolg! Profil aktualisiert"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "Ups! Es existiert bereits ein Benutzer für diese E-Mail-Adresse."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr "Ungültige Buch-ID."
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr "KOReader Sync-Plugin"
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "Keine gültige gmail.json Datei mit OAuth informationen gefunden"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr "Hardcover-IDs werden automatisch abgerufen"
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 msgid "Preparing to send to eReader..."
 msgstr "Senden an E-Reader wird vorbereitet..."
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr "Verfügbare Formate werden geprüft..."
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 msgid "Sending to eReader..."
 msgstr "Wird an E-Reader gesendet..."
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 msgid "Auto-send completed successfully"
 msgstr "Automatischer Versand erfolgreich abgeschlossen"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr "Automatischer Versand"
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr "Temp Ordner Inhalt löschen"
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s an E-Reader gesendet"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Calibre E-Book Konverter %(tool)s nicht gefunden"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "%(format)s Format nicht gefunden"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "E-Book Converter mit unbekanntem Fehler fehlgeschlagen"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Kepubify Konverter Aufruf fehlgeschlagen: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "Konvertierte Datei nicht gefunden, oder mehr als eine Datei im Pfad "
 "%(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre fehlgeschlagen mit Fehler: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Fehler des E-Book-Converters: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Calibre-Datenbank wird neu verbunden"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr "Archivierte Buchreferenzen bereinigen"
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan"
 msgstr "Duplikat-Scan"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan skipped: import in progress"
 msgstr "Dubletten-Scan abgeschlossen: %(count)s neue Gruppen"
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr "Duplikatindex erstellen"
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr "Duplikatindex erstellen: %(processed)s/%(total)s Bücher"
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr "Duplikatindex erstellen: keine Bücher"
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Diese Dubletten-Gruppe ignorieren"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Entpacke Aktualisierungspaket"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Duplikat-Scan in Warteschlange eingereiht"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr "Dubletten-Scan abgeschlossen: %(count)s Gruppen"
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr "Dubletten-Scan abgeschlossen: %(count)s neue Gruppen"
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr "Dubletten-Scan abgeschlossen: %(count)s Gruppen automatisch bereinigt"
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Hardcover-Synchronisation einschalten"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "E-Mail"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr "Metadaten Backup läuft"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr "Bibliothek konvertieren – vollständiger Durchlauf"
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 msgid "Convert Library"
 msgstr "Bibliothek konvertieren"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr "EPUB-Fixer – vollständiger Durchlauf"
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr "EPUB-Fixer"
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "%(count)s Cover Miniaturansichten erzeugt"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "Cover Miniaturansichten"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "{0} Serien Miniaturansichten erzeugt"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "Cover Miniaturansichten Cache wird gelöscht"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 msgid "Book organizer"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Passwort ändern"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Bitte zuerst ein Buch auswählen"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "Seitenleisten-Anzeigeeinstellungen"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Benutzereinstellungen"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "wähle eine Option"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 msgid "Add to Shelf"
 msgstr "Zu Regal hinzufügen"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Öffentlich)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "Erstellt (neueste zuerst)"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Log herunterladen"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "Erstellt (neueste zuerst)"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "Erstellt (älteste zuerst)"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Autor"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Autor"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Erstellt (neueste zuerst)"
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Erstellt (älteste zuerst)"
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Sortiere nach Buch zu Regal hinzugefügt, neueste zuerst"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "Sortiere nach Buch zu Regal hinzugefügt, älteste zuerst"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr "Benutzer&nbsp;&nbsp;👤"
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "An E-Reader E-Mail Adresse senden"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 msgid "Send to eReader Subject"
 msgstr "E-Mail-Betreff für „An E-Reader senden“"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Bücher ansehen"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Öffentliches Regal"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr "Profilbilder verwalten"
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "LDAP Benutzer importieren"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Einstellungen des E-Mail-Server&nbsp;&nbsp;📬"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "SMTP-Hostname"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "SMTP-Port"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "SMTP-Login"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Absenderadresse"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr "E-Mail Service"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail via OAuth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr "Konfiguration&nbsp;&nbsp;⚙️"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Ordner der Calibre Datenbank"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Log-Level"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Externer Port"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Bücher pro Seite"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Uploads"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Anonymes Durchsuchen"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Öffentliche Registrierung"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Magischer Link für Remote-Anmeldung"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Reverse Proxy Login"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Reverse Proxy Header Name"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Basiskonfiguration"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Ansichtseinstellungen"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Konfiguration der Calibre Datenbank editieren"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "Geplante Aufgaben&nbsp;&nbsp;⌛"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "Startzeit"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "Maximale Dauer"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr "Geplante Vorschaubild-Aktualisierung"
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "Seriencover Miniaturansichten erzeugen"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Mit Calibre-Datenbank neu verbinden"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr "Metadaten Backup Datei erzeugen"
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "Cover-Miniaturansichten aktualisieren"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 msgid "Setup KOReader Sync"
 msgstr "KOReader Sync einrichten"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr "Hardcover Auto-Fetch ausführen"
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Administration&nbsp;&nbsp;🚀"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Debug Daten herunterladen"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Logs ansehen"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Neustart"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Ausschalten"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "Versionsinformationen&nbsp;&nbsp;📜"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Version"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Details"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "Aktualisierung fehlgeschlagen:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Aktualisierungskanal"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Aktuelle Version"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Nach Update suchen"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Aktualisierung durchführen"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Calibre-Web wirklich neustarten?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Calibre-Web wirklich anhalten?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Aktualisierungsvorgang, bitte diese Seite nicht neu laden"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7187,425 +7059,403 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import"
 msgstr "Wichtig:"
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Bücher in dieser Bibliothek"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Lädt hoch..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "Aktualisierung fehlgeschlagen:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Verbindungsfehler"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr "Hinweis:"
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Serie: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "via"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "In Bibliothek"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "reduzieren"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Mehr von"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Buch löschen"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Lösche Formate:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Buchformat konvertieren:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Konvertiere von:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr "wähle eine Option"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Konvertiere nach:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Buch konvertieren"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Fehler"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Format hochladen"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "Serien-ID"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Herausgabedatum"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "ID Typ"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "ID Wert"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Entfernen"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "ID hinzufügen"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Cover-URL (jpg, Cover wird heruntergeladen und in der Datenbank gespeichert, "
 "Feld erscheint anschließend wieder leer)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Coverdatei von lokalem Laufwerk hochladen"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 msgid "Hardcover Sync Blacklist"
 msgstr "Hardcover-Sync-Sperrliste"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr "Anmerkungen von der Synchronisierung mit Hardcover ausschließen"
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr "Lesefortschritt von der Synchronisierung mit Hardcover ausschließen"
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Buch nach Bearbeitung ansehen"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Metadaten laden"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Suchbegriff"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "Suche Schlüsselbegriff"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 "Ausgewählte Metadatenfelder wurden auf das Bearbeitungsformular angewendet."
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Lade..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Fehler bei der Suche!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "Keine Ergebnisse gefunden! Bitte ein anderes Schlüsselwort benutzen."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "Dieses Feld ist erforderlich"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr " Autor und Titel tauschen"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 msgid "Select all"
 msgstr "Wähle alle"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr "Lösche alle"
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 msgid "Update Title Sort automatically  "
 msgstr "Titelsortierung automatisch aktualisieren "
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Autorensortierung automatisch aktualisieren"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Titel eingeben"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Titelsortierung eingeben"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Titelsortierung"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Autorensortierung eingeben"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Autorensortierung"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Autoren eingeben"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Kategorien eingeben"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Serie eingeben"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Sprache eingeben"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Herausgabedatum"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Herausgeber eingeben"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Kommentare eingeben"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Comments"
 msgstr "Kommentare"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 msgid "Archived?"
 msgstr "Archiviert?"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 msgid "Read?"
 msgstr "Gelesen?"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "Eingeben "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Sicher?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "Bücher werden zusammengeführt. Von Titel:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "In Buch mit Titel:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr "Die folgenden Bücher werden gelöscht:"
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr "Die folgenden Bücher werden archiviert:"
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr "Die folgenden Bücher werden entarchiviert:"
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr "Die folgenden Bücher werden als gelesen markiert:"
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr "Die folgenden Bücher werden als ungelesen markiert:"
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Metadaten bearbeiten"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 "Bearbeiten Sie die Felder, die Sie ändern möchten. Leere Felder werden "
 "ignoriert:"
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
@@ -7613,26 +7463,25 @@ msgstr ""
 "Für Autoren, Tags/Kategorien, Sprachen und Verlage werden mehrere Werte "
 "unterstützt. Verwenden Sie kommagetrennte Werte (z. B. „Name1, Name2“)."
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 msgid "Select a Shelf"
 msgstr "Wähle ein Regal"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 "Bitte wähle ein Regal aus, dem die ausgewählten Bücher hinzugefügt werden:"
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr "-- Wähle ein Regal --"
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
@@ -7640,164 +7489,164 @@ msgstr ""
 "Ups! Der E-Mail-Server ist nicht konfiguriert, bitte den Administrator "
 "kontaktieren."
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr "Nachricht"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Use current announcement banner text"
 msgstr "Server-Ankündigungs-Banner"
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Wähle E-Reader-E-Mail-Adressen"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send announcement"
 msgstr "Server-Ankündigungs-Banner"
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "An E-Reader senden"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Zurück"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Speicherort der Calibre-Datenbank (metadata.db-Datei)"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7813,13 +7662,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7830,7 +7679,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7847,11 +7696,11 @@ msgstr ""
 "        sobald du die Option <b>Separiere Bücherdateien von der Bibliothek</"
 "b> angewählt hast."
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr "Bibliothek aufspalten-Funktionalität"
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
@@ -7861,31 +7710,31 @@ msgstr ""
 "<code>metadata.db</code> sollte in <code>/calibre-library</code> verbleiben, "
 "die Bücherdateien können jedoch an einem beliebigen Ort gespeichert werden"
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Google Drive benutzen?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Google Drive authentifizieren"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Google Drive Calibre-Ordner"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "Metadaten Überwachungs-ID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Widerrufen"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Letzter Ausweg: Calibre-Datenbank wiederherstellen (experimentell)"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7903,90 +7752,90 @@ msgstr ""
 "automatisch ein Backup unter /config/backup erstellt.</b> Ein Protokoll der "
 "Wiederherstellung wird zusammen mit den Backups gespeichert."
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 msgid "Are you sure? This cannot be undone."
 msgstr "Sind Sie sicher? Dies kann nicht rückgängig gemacht werden."
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Calibre-Datenbank wiederherstellen (Letzter Ausweg)"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr "Neuer Datenbankpfad ist ungültig, bitte einen gültigen Pfad eingeben"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Benutze Standardauthentifizierung"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Benutze LDAP-Authentifizierung"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Benutze OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Server-Konfiguration"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Server-Port"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "Speicherort der SSL-Certdatei (leerlassen, falls kein SSL-Server)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "Speicherort der SSL-Keydatei (leerlassen, falls kein SSL-Server)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Aktualisierungskanal"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Stabil"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Nächtlich"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "Vertrauenswürdige Hosts (kommasepariert)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Konfiguration der Logdatei"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr ""
 "Speicherort und Name der Protokolldatei (/dev/stdout für keinen Eintrag)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Zugriffs-Logdatei aktivieren"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "Pfad und Name der Zugriffs-Logdatei (access.log wenn leergelassen)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 msgid "Feature Configuration"
 msgstr "Feature-Konfiguration"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 "Nicht-englische Zeichen in Titel und Autor beim Speichern auf Festplatte "
 "ersetzen"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
@@ -7994,40 +7843,40 @@ msgstr ""
 "Metadaten bei Download/Konvertierung/E-Mail zu Ebook Datei hinzufügen "
 "(benötigt Calibre/Kepubify)"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Hochladen aktivieren"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr ""
 "(Bitte sicherstellen, dass Benutzer über die Upload Berechtigung verfügen)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Erlaubte Dateiformate zum Hochladen"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Anonymes Durchsuchen aktivieren"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Öffentliche Registrierung aktivieren"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "Benutze E-Mail als Benutzername"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Remotelogin ('Magischer Link') aktivieren"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr "Nutzern erlauben, Bücher in ihrer persönlichen Bibliothek auszublenden"
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -8035,155 +7884,155 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "unbekannte Anfragen an den Kobo Store weiterleiten"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Externer Server-Port (für Portweiterleitung von API-Aufrufen)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 "Kobo-Anmerkungen mit Hardcover synchronisieren (erfordert einen API-"
 "Schlüssel pro Benutzer)"
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Benutze Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Öffentlicher Goodreads API Schlüssel"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 msgid "Enable Hardcover Sync"
 msgstr "Hardcover-Synchronisation einschalten"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr "Hardcover API-Schlüssel"
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "Token ist abgelaufen"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Öffentlicher Goodreads API Schlüssel"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8191,11 +8040,11 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Reverse Proxy Authentifizierung zulassen"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
@@ -8205,11 +8054,11 @@ msgstr ""
 "Authentifizierung. Dies ist eine Authentifizierungsmethode, die sich von der "
 "unten stehenden HTTPS-Sicherheitseinstellung unterscheidet."
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr "Über HTTPS nutzen"
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
@@ -8218,11 +8067,11 @@ msgstr ""
 "Sie dies NUR, wenn Sie über HTTPS auf den Server zugreifen, andernfalls "
 "werden Sie ausgesperrt."
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr "Benutzer automatisch über Reverse-Proxy erstellen"
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
@@ -8232,78 +8081,78 @@ msgstr ""
 "empfangen werden. Nur aktivieren, wenn Ihre Reverse-Proxy-Authentifizierung "
 "ordnungsgemäß abgesichert ist."
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Anmeldetyp"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr "OAuth verwenden (erfordert HTTPS)"
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "LDAP-Server Hostname oder IP-Adresse"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "LDAP-Server-Port"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "LDAP-Verschlüsselung"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "LDAP-CA-Zertifikatspfad (nur für Client-Zertifikatsauthentifizierung "
 "benötigt)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "LDAP-Zertifikatspfad (nur für Client-Zertifikatsauthentifizierung benötigt)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "LDAP-Schlüsseldateipfad (nur für Client-Zertifikatsauthentifizierung "
 "benötigt)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "LDAP-Authentifizierung"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Einfach"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "LDAP-Administrator-Benutzername"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "LDAP-Administrator-Passwort"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "LDAP-Distinguished Name (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "LDAP-Benutzerobjektfilter"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "Ist der LDAP-Server ein OpenLDAP-Server?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr "Benutzer automatisch über LDAP erstellen"
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
@@ -8311,44 +8160,44 @@ msgstr ""
 "Benutzerkonten automatisch erstellen, wenn die LDAP-Authentifizierung für "
 "neue Benutzer erfolgreich ist. Empfohlen für Unternehmensumgebungen."
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr ""
 "Die nachfolgenden Einstellungen werden nur für den Benutzerimport benötigt"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "LDAP-Gruppenobjektfilter"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "LDAP-Gruppenname"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "LDAP-Gruppenmitgliedsfeld"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "LDAP-Mitgliederfiltererkennung"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "Automatisch erkennen"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "Benutzerdefinierter Filter"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "LDAP-Mitgliederfilter"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr "Wichtig:"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
@@ -8356,27 +8205,27 @@ msgstr ""
 "Die OAuth-Authentifizierung erfordert, dass auf diesen Server über HTTPS "
 "zugegriffen wird. Wenn Sie HTTP verwenden, wird die Anmeldung fehlschlagen."
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr "Generischer OAuth-Anbieter"
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr "OAuth-Metadaten-URL (für Autoerkennung)"
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 msgid "Test Metadata"
 msgstr "Metadaten testen"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr "Freilassen, um die manuelle Konfiguration von unten zu nutzen"
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr "Nutze manuelle Endpunkt-URLs (überschreibt Autoerkennung)"
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
@@ -8384,43 +8233,43 @@ msgstr ""
 "Hake dies an, um manuell individuelle OAuth Endpunkte zu konfigurieren "
 "anstatt automatische Erkennung zu nutzen"
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 msgid "Manual Endpoint Configuration"
 msgstr "Manuelle Endpunktkonfiguration"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr "OAuth-Basis-URL"
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr "Autorisierungsendpunkt"
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 msgid "Token Endpoint"
 msgstr "Token Endpunkt"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr "UserInfo Endpunkt"
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 msgid "Test Connection"
 msgstr "Verbindung testen"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 msgid "OAuth Scopes"
 msgstr "OAuth-Scopes"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr "Leerzeichen-separierte Liste von OAuth Scopes"
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr "OAuth-Redirect-Host"
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
@@ -8430,7 +8279,7 @@ msgstr ""
 "vom Typ „Ungültige Weiterleitungs-URI“ zu vermeiden. Geben Sie das Protokoll "
 "(https://) mit an. Leer lassen, um die automatische Erkennung zu nutzen."
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
@@ -8438,70 +8287,70 @@ msgstr ""
 "Erforderlich, falls: Zugriff über mehrere Hostnamen, hinter einem Reverse-"
 "Proxy oder bei Fehlern vom Typ „Ungültige Weiterleitungs-URI“."
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 msgid "OAuth Client Id"
 msgstr "OAuth-Client-ID"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 msgid "OAuth Client Secret"
 msgstr "OAuth-Client-Geheimnis"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 msgid "Field Mapping Configuration"
 msgstr "Feldzuordnungskonfiguration"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 msgid "Username Field"
 msgstr "Benutzernamefeld"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr "JWT-Feld, von dem der Benutzername extrahiert wird"
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 msgid "Email Field"
 msgstr "E-Mail-Feld"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr "JWT-Feld, von dem die E-Mail-Adresse extrahiert wird"
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "OAuth-Gruppe für Admins"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr "OAuth-Gruppe für Admins"
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
@@ -8512,101 +8361,101 @@ msgstr ""
 "für mehr Kontrolle die globalen Einstellungen in den "
 "Sicherheitseinstellungen."
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Standard-Einstellungen für neue Benutzer"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Downloads erlauben"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Anzeige von Büchern erlauben"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Hochladen erlauben"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Bearbeiten erlauben"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Löschen von Büchern erlauben"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Ändern des Passworts erlauben"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Editieren öffentlicher Regale erlauben"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr "Anmelde-Button-Text"
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Erhalte %(provider)s OAuth-Berechtigungen"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "%(provider)s OAuth Client Id"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "%(provider)s OAuth Client Secret"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Externe Programme"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr "Pfad zum Calibre-Programm"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 msgid "Calibre E-Book Converter Settings"
 msgstr "Calibre E-Book Konverter Einstellungen"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Pfad zum Kepubify E-Book Konverter"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 msgid "Location of Unrar binary"
 msgstr "Pfad zum UnRar-Programm"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 msgid "Security Settings"
 msgstr "Sicherheitseinstellungen"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr "Standardanmeldung deaktivieren (Benutzername/Passwort)"
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
@@ -8615,11 +8464,11 @@ msgstr ""
 "oder LDAP anmelden. Stellen Sie sicher, dass Sie eine funktionierende "
 "alternative Anmeldemethode haben, bevor Sie dies aktivieren."
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr "Gruppenbasierte OAuth-Admin-Rollenverwaltung aktivieren"
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8631,92 +8480,92 @@ msgstr ""
 "Admin-Rollen manuell in der Benutzerverwaltung zu verwalten und zu "
 "verhindern, dass OAuth-Logins lokale Rollenzuweisungen überschreiben."
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr "Fehlgeschlagene Anmeldeversuche begrenzen"
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr "Backend für Limiter konfigurieren"
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr "Optionen für das Limiter Backend"
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr "Überprüfe bei Upload ob Dateiinhalt zur Endung passt"
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 msgid "Session protection"
 msgstr "Sessionschutz"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr "Einfach"
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr "Stark"
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 msgid "User Password policy"
 msgstr "Passwortregeln"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr "Minimale Passwortlänge"
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr "Erzwinge Zahl"
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr "Erzwinge Kleinbuchstaben"
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr "Erzwinge Großbuchstaben"
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 "Zeichen erzwingen (erforderlich für chinesische/japanische/koreanische "
 "Zeichen)"
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr "Erzwinge Spezialzeichen"
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Ansichtskonfiguration"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 "Der Titel, der im Browser-Tab und in der Navigationsleiste angezeigt wird."
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 "Anzahl der Bücher, die pro Seite in Listenansichten angezeigt werden (1-200)."
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Anzahl anzuzeigender zufälliger Bücher"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 "Anzahl der zufälligen Bücher, die auf der Startseite angezeigt werden (1-30)."
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr "Anzahl in Übersicht anzuzeigender Autoren (0=alle werden angezeigt)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
@@ -8724,15 +8573,15 @@ msgstr ""
 "Maximale Anzahl an Autoren, die in den Buchdetails angezeigt werden, bevor "
 "sie gekürzt wird. Zum Deaktivieren auf 0 setzen."
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 msgid "Default Theme"
 msgstr "Standard-Design"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "caliBlur! dunkles Design"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
@@ -8740,42 +8589,42 @@ msgstr ""
 "Standard-Design für neue Benutzer und anonymes browsen. Benutzer können in "
 "ihrem Profil ihr eigenes bevorzugtes Design wählen."
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Regulärer Ausdruck, um Spalten zu ignorieren"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 "Regex-Muster, um benutzerdefinierte Spalten in der Benutzeroberfläche "
 "auszublenden."
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Verbinde Gelesen/Ungelesen-Status mit Calibre-Spalte"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr ""
 "Gelesen/Ungelesen-Status mit einer benutzerdefinierten booleschen Calibre-"
 "Spalte synchronisieren."
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Sichtbarkeitsbeschränkung basierend auf Calibre-Spalte"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 "Beschränkt die Sichtbarkeit von Büchern basierend auf den Werten einer "
 "benutzerdefinierten Calibre-Textspalte."
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Regulärer Ausdruck für Titelsortierung"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
@@ -8783,15 +8632,15 @@ msgstr ""
 "Regex, um Präfixe für die korrekte Sortierung von Titeln zu entfernen (z. B. "
 "„Der“, „Die“, „Das“, „Ein“, „Eine“)."
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 msgid "Site Customization"
 msgstr "Website-Anpassung"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr "Server-Ankündigungs-Banner"
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
@@ -8799,7 +8648,7 @@ msgstr ""
 "Leer lassen, um das Banner auszublenden. Wird oben auf jeder Seite "
 "angezeigt, bis jeder Benutzer es ausblendet."
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
@@ -8807,177 +8656,172 @@ msgstr ""
 "Bis zu 500 Zeichen. HTML wird maskiert. Jeder Benutzer blendet das Banner "
 "unabhängig aus; das Bearbeiten des Textes zeigt es allen erneut an."
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Custom CSS"
 msgstr "Benutzerdefinierter Filter"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Standard-Einstellungen für neue Benutzer"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 "Diese Einstellungen werden auf alle neu erstellten Benutzerkonten angewendet."
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 msgid "Permissions"
 msgstr "Berechtigungen"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Administrator"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 msgid "Language & Display"
 msgstr "Sprache & Anzeige"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "Standardsprache"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 msgid "Default interface language for new users."
 msgstr "Standard-Sprache der Benutzeroberfläche für neue Benutzer."
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "Defaulteinstellung sichtbare Büchersprache"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 msgid "Default book language filter for new users."
 msgstr "Standard-Büchersprachfilter für neue Benutzer."
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Standard-Sichtbarkeiten für neue Benutzer"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 "Wählen Sie aus, welche Seitenleisten-Abschnitte standardmäßig für neue "
 "Benutzer sichtbar sind."
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Zeige zufällige Bücher in der Detailansicht"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Erlaubte/Verbotene Tags hinzufügen"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Erlaubte/Verbotene Calibre Spalten hinzufügen"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Upload"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Candidates"
 msgstr "Mögliche Treffer"
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run Archive"
 msgstr "Log-Archiv"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 msgid "Download Log"
 msgstr "Log herunterladen"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Start"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr "In 5 Min. planen"
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr "In 15 Min. planen"
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr "Bibliothekskonvertierung erfolgreich geplant"
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr "Fehler beim Planen der Bibliothekskonvertierung"
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8986,14 +8830,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -9001,87 +8845,86 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr "Auf einem einzelnen Buch ausführen"
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr "Suche nach Titel/Autor"
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on selected book"
 msgstr "Für das ausgewählte Buch ausführen"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer scheduled successfully"
 msgstr "EPUB Fixer erfolgreich geplant"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error scheduling EPUB Fixer"
 msgstr "Fehler beim Planen des EPUB Fixers"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 msgid "No matches found"
 msgstr "Keine Treffer gefunden"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 msgid "Enter a search term"
 msgstr "Suchbegriff eingeben"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 msgid "Failed to search library"
 msgstr "Suche in der Bibliothek fehlgeschlagen"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 msgid "Select a book first"
 msgstr "Bitte zuerst ein Buch auswählen"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer started for selected book"
 msgstr "EPUB-Fixer für das ausgewählte Buch gestartet"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error starting EPUB Fixer"
 msgstr "Fehler beim Starten des EPUB-Fixers"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Aktiviere/Deaktiviere Calibre-Web Automated Services"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -9089,11 +8932,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -9104,11 +8947,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -9118,7 +8961,7 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
@@ -9128,18 +8971,18 @@ msgstr ""
 "\">kindle-epub-fix.netlify.app</a> Tool adaptiert, das von <a href=\"https://"
 "github.com/innocenat\">innocenat</a> erstellt wurde."
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
@@ -9150,11 +8993,11 @@ msgstr ""
 "kann. Um einen laufenden Backfill zu stoppen, starten Sie den Container nach "
 "der Deaktivierung neu."
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr "Aggressiven EPUB-Fixer-Modus aktivieren (riskanter)"
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
@@ -9163,11 +9006,11 @@ msgstr ""
 "Kodierungskonvertierungen mit geringerer Vertrauenswürdigkeit. Für die "
 "meisten Bibliotheken wird der sichere Modus empfohlen."
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 msgid "Enable Archived Book Cleanup"
 msgstr "Bereinigung archivierter Bücher aktivieren"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
@@ -9176,116 +9019,116 @@ msgstr ""
 "Buch in der Calibre-Bibliothek nicht mehr existiert. Hilft dabei, die Anzahl "
 "der archivierten Bücher korrekt zu halten."
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr "Bereinigungszeitplan:"
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr "Häufige Intervalle"
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr "Alle 15 Minuten"
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr "Alle 30 Minuten"
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr "Stündlich"
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr "Alle 2 Stunden"
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr "Alle 4 Stunden"
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr "Alle 6 Stunden"
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr "Alle 12 Stunden"
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr "Täglich/Wöchentlich/Monatlich"
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr "Täglich zu einer bestimmten Zeit"
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr "Wöchentlich an einem bestimmten Tag"
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr "Monatlich an einem bestimmten Tag"
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr "Standard: Täglich um 03:00 Uhr"
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr "Wochentag:"
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr "Montag"
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr "Dienstag"
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr "Mittwoch"
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr "Donnerstag"
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr "Freitag"
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr "Samstag"
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr "Sonntag"
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr "Tag des Monats:"
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr "(1-28)"
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr "Uhrzeit:"
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr "(Server-Zeitzone: %(tz)s)"
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr "Automatisches Abrufen von Metadaten für neue Bücher aktivieren"
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9293,11 +9136,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr "Intelligente Metadaten-Zuweisung aktivieren"
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9310,11 +9153,11 @@ msgstr ""
 "abgerufenen Metadaten des bevorzugten Anbieters die vorhandenen Daten so, "
 "wie sie sind."
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 msgid "Metadata Fields to Update"
 msgstr "Zu aktualisierende Metadatenfelder"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
@@ -9325,25 +9168,23 @@ msgstr ""
 "des automatischen Abrufens von Metadaten geändert, wodurch Ihre vorhandenen "
 "Daten erhalten bleiben."
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr "Tags/Genres"
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identifikatoren (ISBN usw.)"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 msgid "Cover Image"
 msgstr "Titelbild"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr "Tipp"
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
@@ -9354,15 +9195,15 @@ msgstr ""
 "Qualitätskriterien auf die ausgewählten Felder an, während der direkte Modus "
 "alle ausgewählten Felder eins zu eins durch die Daten des Anbieters ersetzt."
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr "Maximale Cover Dateigröße (MB)"
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr "Bereich: 1–200 MB (Standard: 15)"
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
@@ -9371,11 +9212,11 @@ msgstr ""
 "maximale Größe der von Metadatenanbietern oder URLs heruntergeladenen "
 "Coverbilder begrenzt."
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr "Zeitüberschreitung des Ingestierungsprozesses"
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
@@ -9386,19 +9227,19 @@ msgstr ""
 "Zeitüberschreitung auftritt werden in Ordner für fehlgeschlagen Dateien "
 "geschoben, um sie untersuchen zu können."
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr "Zeitüberschreitung (Minuten):"
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr "Bereich: 5-120 Minuten (Standard: 15)"
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr "Bereinigung veralteter temporärer Dateien"
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
@@ -9409,27 +9250,27 @@ msgstr ""
 "gesetzt wird, wird die Bereinigung deaktiviert. Änderungen werden beim "
 "nächsten Bereinigungszyklus angewendet."
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr "Alter veralteter temporärer Dateien (Minuten):"
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr "Bereich: 0-10080 Minuten (Standard: 120)"
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr "Intervall zur Bereinigung veralteter temporärer Dateien (Sekunden):"
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr "Bereich: 0-86400 Sekunden (Standard: 600)"
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr "Verzögerung für automatisches Senden neuer Bücher"
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9441,19 +9282,19 @@ msgstr ""
 "andere Verarbeitungsschritte. Gilt nur für Benutzer, die das automatische "
 "Senden in ihrem Profil aktiviert haben."
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr "Verzögerung (Minuten):"
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr "Bereich: 1-60 Minuten (Standard: 5)"
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr "Hierarchie der Anbieter für den automatischen Metadaten-Abruf"
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
@@ -9464,25 +9305,25 @@ msgstr ""
 "Verschieben Sie die Anbieter per Drag-and-Drop, um die Reihenfolge zu "
 "ändern. Es werden nur aktivierte Anbieter verwendet."
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 "Die Anbieter werden nacheinander von oben nach unten abgefragt. Ziehen Sie "
 "die Einträge, um die Reihenfolge zu ändern."
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr "Aktivierte Metadaten-Anbieter"
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr "Nicht ausgewählte Anbieter sind global deaktiviert."
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Hardcover-Auto-Fetch-Einstellungen"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
@@ -9492,11 +9333,11 @@ msgstr ""
 "Hardcover-IDs ermöglichen die Synchronisierung von Lesefortschritten und "
 "Anmerkungen mit Hardcover.app bei Verwendung kompatibler eReader."
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr "Hardcover-Token erforderlich"
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
@@ -9507,18 +9348,18 @@ msgstr ""
 "festlegen oder einen globalen Token in der Grundkonfiguration konfigurieren. "
 "Ohne einen gültigen Token bleibt diese Funktion deaktiviert."
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
@@ -9529,25 +9370,25 @@ msgstr ""
 "zugewiesen; Übereinstimmungen mit geringer Vertrauenswürdigkeit werden zur "
 "manuellen Überprüfung in eine Warteschlange gestellt."
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr "Ausführungszeitplan:"
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 "Wie oft die Aufgabe zum Abrufen der Hardcover-IDs automatisch ausgeführt "
 "werden soll"
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr "Mindest-Vertrauensschwellenwert:"
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr "Bereich: 0,50–1,00 (Standard: 0,85)"
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
@@ -9558,15 +9399,15 @@ msgstr ""
 "vorgemerkt. Höhere Werte = weniger automatische Treffer, aber höhere "
 "Genauigkeit."
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr "Stapelgröße:"
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr "Bereich: 10–200 Bücher pro Durchlauf (Standard: 50)"
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
@@ -9575,15 +9416,15 @@ msgstr ""
 "Stapel reduzieren die API-Last; größere Stapel verarbeiten Ihre Bibliothek "
 "schneller."
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr "Verzögerung für Ratenbegrenzung (Sekunden):"
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr "Bereich: 0–60 Sekunden (Standard: 5,0)"
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
@@ -9592,33 +9433,33 @@ msgstr ""
 "und schützt Ihren API-Schlüssel. Verwendet einen exponentiellen Backoff bei "
 "Fehlern."
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 msgid "Web UI Settings"
 msgstr "Web UI-Einstellungen"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "Einstellungen für automatische Backups"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9626,36 +9467,35 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr "Aktiviere Benachrichtigungen zur Übersetzungsbeitragung"
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -9665,11 +9505,11 @@ msgstr ""
 "mehr erhalten, wenn du eine andere Sprache als Englisch nutzt und es "
 "fehlende Übersetzungen gibt."
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Magische Regale mit Kobo synchronisieren"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
@@ -9678,11 +9518,11 @@ msgstr ""
 "Gerät synchronisiert. Hinweis: Sie müssen zusätzlich die Kobo-"
 "Synchronisierung in der Grundkonfiguration aktivieren."
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Aktiviere unscharfe Hintergründe auf dem Handy (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -9691,15 +9531,15 @@ msgstr ""
 "auf kleinen Bildschirm dargestellt. Deaktiviere es, wenn du beim Scrollen "
 "oder bei Animationen Stocken siehst."
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 msgid "Automatic Backup Settings"
 msgstr "Einstellungen für automatische Backups"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -9707,11 +9547,11 @@ msgstr ""
 "Wenn es aktiviert ist, wird eine Kopie aller importierten Dateien unter <i>/"
 "config/processed_books/imported</i> gespeichert"
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -9719,21 +9559,21 @@ msgstr ""
 "Wenn es aktiviert ist, werden die Orignale der ingestierten Dateien, die "
 "konvertiert wurden, gespeichert unter /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9746,11 +9586,11 @@ msgstr ""
 "Unterverzeichnisse von /config/processed_books übersichtlich zu halten und "
 "die Festplattennutzung zu minimieren."
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -9760,32 +9600,32 @@ msgstr ""
 "ingestierten Bücher automatisch in das hier ausgewählte Format konvertiert "
 "(außer der gewählten Formate in der Liste mit ignorierten Formaten von unten)"
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 msgid "Choose a target format:"
 msgstr "Wähle ein Zielformat:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9793,20 +9633,20 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "Calibre kann doppelte Buchtitel beim Import erkennen und abhängig von dem"
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr "automatisches Zusammenführen"
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -9814,35 +9654,35 @@ msgstr ""
 "Einstellung. Es kann gesetzt werden, eine Kopie des Bücherduplikats zu "
 "löschen oder beide zu behalten (Standard)."
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Verwirft duplizierte Importe, behält die Kopie in der Bibliothek"
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 "Überschreibt die Kopie in der Bibliothek mit der neu importierten Datei"
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Erstellt einen doppelten Eintrag, wobei beide Kopien behalten werden"
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
@@ -9851,31 +9691,31 @@ msgstr ""
 "deaktiviert, wird kein Scan nach Dubletten ausgeführt und es werden keine "
 "Benachrichtigungen angezeigt."
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Detection"
 msgstr "Duplikaterkennung aktivieren"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr "Methode zur Dublettenerkennung"
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr "Hybrid (SQL-Vorfilter + Python-Validierung)"
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr "Nur Python (am langsamsten, am robustesten)"
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr "Nur Legacy-SQL (experimentell)"
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
@@ -9884,11 +9724,11 @@ msgstr ""
 "Kandidaten einzugrenzen, und wendet dann die robuste Python-Logik für die "
 "Endergebnisse an."
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 msgid "Automatic Duplicate Scanning"
 msgstr "Automatischer Duplikat-Scan"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
@@ -9896,27 +9736,27 @@ msgstr ""
 "Konfigurieren Sie Dubletten-Scans im Hintergrund. Diese werden automatisch "
 "ausgeführt, ohne die Benutzeroberfläche zu blockieren."
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr "Automatische Dubletten-Scans aktivieren"
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr "Scans nach dem Import"
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr "Nach jedem Import ausführen (mit Verzögerung)"
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr "Nur manuell"
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr "Wartezeit nach Import (Sekunden)"
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
@@ -9924,15 +9764,15 @@ msgstr ""
 "Wartet diese Anzahl an Sekunden nach dem letzten Import ab, bevor ein "
 "Hintergrund-Scan gestartet wird."
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr "Geplante Scans (Cron-Ausdruck)"
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr "Leer lassen, um geplante Scans zu deaktivieren. Beispiel:"
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
@@ -9941,15 +9781,15 @@ msgstr ""
 "ausgeführt werden. Wählen Sie „Nur manuell“, um Scans nach dem Import zu "
 "deaktivieren, während Cron-Zeitpläne beibehalten werden."
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr "Nächster geplanter Scan:"
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
@@ -9959,31 +9799,31 @@ msgstr ""
 "ob Bücher Dubletten sind. Bücher müssen ALLE ausgewählten Kriterien "
 "erfüllen, um als Dubletten eingestuft zu werden."
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr "Buchtitel bei der Dublettenerkennung berücksichtigen"
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr "Buchautoren bei der Dublettenerkennung berücksichtigen"
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr "Buchsprache bei der Dublettenerkennung berücksichtigen"
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr "Buchreihen bei der Dublettenerkennung berücksichtigen"
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr "Buchverlag bei der Dublettenerkennung berücksichtigen"
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr "Dateiformat bei der Dublettenerkennung berücksichtigen"
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
@@ -9991,11 +9831,11 @@ msgstr ""
 "Es muss mindestens ein Kriterium ausgewählt werden. Titel und Autor werden "
 "als Kernkriterien empfohlen."
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr "Prioritätsrangfolge für Dubletten-Formate"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
@@ -10006,11 +9846,11 @@ msgstr ""
 "Verschieben Sie die Formate per Drag-and-Drop, um die Priorität festzulegen "
 "(höher = besser)."
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr "Tipp:"
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
@@ -10020,11 +9860,11 @@ msgstr ""
 "werden Bücher mit höher eingestuften Formaten beibehalten. Formate mit "
 "niedrigerer Priorität werden gelöscht."
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr "Dubletten-Benachrichtigungen & automatische Lösung"
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
@@ -10032,11 +9872,11 @@ msgstr ""
 "Konfigurieren Sie, wie Sie über Buchdubletten benachrichtigt werden, und "
 "aktivieren Sie optional die automatische Auflösung."
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Notifications"
 msgstr "Duplikatbenachrichtigungen aktivieren"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
@@ -10047,15 +9887,15 @@ msgstr ""
 "Schaltfläche „Dubletten“ in der Seitenleiste sowie ein Benachrichtigungs-"
 "Popup beim Login."
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Automatische Duplikatbehandlung aktivieren"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr "Warnung:"
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
@@ -10063,75 +9903,75 @@ msgstr ""
 "Dies wird automatisch Bücher basierend auf der untenstehenden Strategie "
 "löschen. Originaldateien werden gesichert unter"
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr "Strategie zur automatischen Auflösung"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr "Neueste behalten"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr "Ältere Kopien löschen, das zuletzt hinzugefügte Buch behalten"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr "Älteste behalten"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr "Neuere Kopien löschen, das zuerst hinzugefügte Buch behalten"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge Formats"
 msgstr "Formate zusammenführen"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr "Formate im neuesten Buch zusammenführen, den Rest löschen"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr "Format mit höchster Qualität behalten"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 "Bevorzugt Formate basierend auf Ihrer Prioritätsrangfolge für Dubletten-"
 "Formate"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep Most Metadata"
 msgstr "Eintrag mit den meisten Metadaten behalten"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr "Buch mit den vollständigsten Informationen behalten"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr "Größte Dateigröße behalten"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr "Das Buch mit der größten Gesamtdateigröße behalten"
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 "Auswählen, welches Buch behalten werden soll, wenn Dubletten automatisch "
 "aufgelöst werden."
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 msgid "Rate Limiting"
 msgstr "Anzahl der Anfragen begrenzen"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr "Abkühlzeit (Minuten)"
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
@@ -10139,7 +9979,7 @@ msgstr ""
 "Mindestzeit zwischen automatischen Auflösungen (0 zum Deaktivieren). "
 "Verhindert schlagartige Löschungen während Massenimporten."
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -10148,276 +9988,264 @@ msgstr ""
 "Dubletten erkannt hat. Ignorierte Dubletten-Gruppen werden niemals "
 "automatisch aufgelöst."
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr "%(count)s ausstehende Treffer prüfen"
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr "Klicken Sie, um mehr zu sehen"
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Nächste"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Als ungelesen markieren"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Als gelesen markieren"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 msgid "Marked as read"
 msgstr "Als gelesen markiert"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 msgid "Marked as unread"
 msgstr "Als ungelesen markiert"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Zum Archiv hinzufügen"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Aus dem Archiv wiederhergestellt"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Vom Archiv wiederherstellen"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Zum Archiv hinzufügen"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 msgid "Restored from archive"
 msgstr "Aus dem Archiv wiederhergestellt"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Reloaded metadata from disk"
 msgstr "Aktivierte Metadaten-Anbieter"
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Unhide from your library"
 msgstr "Dieses Regal in der Seitenleiste ausblenden"
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "Dieses Regal in der Seitenleiste ausblenden"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 msgid "Rating updated"
 msgstr "Bewertung aktualisiert"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 msgid "Rating cleared"
 msgstr "Bewertung gelöscht"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "Buch %(index)s von %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr "ID"
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr "UUID"
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr "UUID in die Zwischenablage kopiert"
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr "UUID konnte nicht kopiert werden"
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr "UUID kopieren"
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr "Dateigrößen"
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Beschreibung:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 msgid "Select eReader Email Addresses"
 msgstr "Wähle E-Reader-E-Mail-Adressen"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 msgid "Choose email addresses:"
 msgstr "Wähle die E-Mail-Adressen:"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 msgid "Select All"
 msgstr "Wähle alle"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr "E-Reader anderer Benutzer:"
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr "Zusätzliche E-Mail-Adressen:"
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr "Zusätzliche E-Mail-Adressen eingeben (durch Kommas getrennt):"
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr "beispiel@domain.de, person@domain.de"
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr "Geben Sie eine oder mehrere E-Mail-Adressen durch Kommas getrennt ein"
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 msgid "Select format:"
 msgstr "Wähle Formate:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 msgid "Failed to update tags"
 msgstr "Aktualisierung der Tags fehlgeschlagen"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 msgid "Failed to update shelves"
 msgstr "Aktualisierung der Regale fehlgeschlagen"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
@@ -10425,32 +10253,32 @@ msgstr ""
 "Bücher mit übereinstimmenden Titeln, Autoren und Sprachen. Bücher in "
 "verschiedenen Sprachen werden nicht als Duplikate betrachtet."
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Duplikat-Scan"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 msgid "Scan for Duplicates Now"
 msgstr "Jetzt nach Duplikaten suchen"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr "Duplikate auswählen"
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 msgid "Select None"
 msgstr "Keines auswählen"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 msgid "Delete Selected"
 msgstr "Ausgewählte löschen"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr "Für Duplikatscans ist ein einmaliger vollständiger Scan erforderlich."
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
@@ -10460,7 +10288,7 @@ msgstr ""
 "Metadatenänderungen zu beschleunigen. Bevor inkrementelle Scans ausgeführt "
 "werden können, benötigt der Index eine initiale Baseline."
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
@@ -10469,25 +10297,25 @@ msgstr ""
 "Dies kann bei großen Bibliotheken einige Minuten dauern. Sie können CWA "
 "währenddessen weiterhin verwenden."
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Duplikat-Scan"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr "Sie können CWA weiterhin verwenden, während es läuft."
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View Background Tasks"
 msgstr "Übersicht der Hintergrundaufgaben"
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr "Duplikate automatisch bereinigen"
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
@@ -10495,26 +10323,26 @@ msgstr ""
 "Alle Dubletten-Gruppen automatisch auflösen, indem ein Buch behalten und "
 "andere basierend auf einer Strategie gelöscht werden."
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr "Strategie:"
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 "Neueste behalten – Ältere Kopien löschen, das zuletzt hinzugefügte behalten"
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 "Älteste behalten – Neuere Kopien löschen, das zuerst hinzugefügte behalten"
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 "Formate zusammenführen – Formate im neuesten Buch bündeln, den Rest löschen"
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
@@ -10522,62 +10350,62 @@ msgstr ""
 "Format mit höchster Qualität behalten – Bevorzugt Formate basierend auf "
 "Ihrer Prioritätsrangfolge"
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 "Die meisten Metadaten behalten – Buch mit den vollständigsten Informationen "
 "behalten"
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 "Größte Dateigröße behalten – Das Buch mit der größten Gesamtdateigröße "
 "behalten"
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 msgid "Preview"
 msgstr "Vorschau"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr "Bereinigung ausführen"
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 "Dies wird Bücher dauerhaft löschen. Originaldateien werden gesichert unter"
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 msgid "Merge Selected"
 msgstr "Ausgewählte zusammenführen"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr "Diese Dubletten-Gruppe ignorieren"
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 msgid "View book details"
 msgstr "Buchdetails anzeigen"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 msgid "Edit book metadata"
 msgstr "Buch-Metadaten bearbeiten"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 msgid "Archive/delete book"
 msgstr "Buch archivieren/löschen"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 msgid "No Duplicate Books Found"
 msgstr "Keine Bücherduplikate gefunden"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 "Deine Bibliothek hat keine Bücher mit doppelten Titel- und "
 "Autorkombinationen."
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
@@ -10585,12 +10413,12 @@ msgstr ""
 "Diese Suche sucht nach Büchern mit identischen Titeln UND Autoren, um "
 "Fehlalarme zu vermeiden."
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Execute Auto-Resolution"
 msgstr "Bereinigung ausführen"
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
@@ -10598,112 +10426,112 @@ msgstr ""
 "CWA wird doppelte Gruppen mithilfe der ausgewählten Strategie auflösen und "
 "doppelte Bücher endgültig löschen."
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Wähle Formate:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr "Diese Aktion kann nicht rückgängig gemacht werden!"
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 msgid "The following books will be permanently deleted:"
 msgstr "Die folgenden Bücher werden permanent gelöscht:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Merge Books"
 msgstr "Bücher zusammenführen"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 msgid "The following book will be kept:"
 msgstr "Das folgende Buch wird behalten:"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 msgid "The following books will be merged into it (and then deleted):"
 msgstr ""
 "Die folgenden Bücher werden darin zusammengeführt (und anschließend "
 "gelöscht):"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr "Hinweis: Dateiformate der Quellbücher werden dem Zielbuch hinzugefügt."
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr "Lösungsvorschau"
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr "Erfolg"
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr "Gewählte Bücherduplikate wurden erfolgreich gelöscht!"
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr "Ein Fehler trat während des Ausführens deiner Anfrage auf."
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "Wähle Servertyp"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr "Standard-E-Mail-Account"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr "G-Mail Konto"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr "G-Mail-Konto einrichten"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "G-Mail-Zugriff widerrufen"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "SMTP-Passwort"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Anhangsgröße"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 msgid "Save and Send Test Email"
 msgstr "Einstellungen speichern und Test-E-Mail versenden"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Erlaubte Domains für die Registrierung"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Domain hinzufügen"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Domainnamen eingeben"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Verbotene Domains für eine Registrierung"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr "(Magisch)"
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10711,23 +10539,23 @@ msgstr ""
 "Öffne die .kobo/Kobo/Kobo eReader.conf-Datei in einem Texteditor und füge "
 "hinzu (oder bearbeite):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Kobo Token:"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "Liste"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr "Überprüfung der Hardcover-Treffer 🔖"
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr "Alles erledigt!"
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
@@ -10736,15 +10564,15 @@ msgstr ""
 "Neue Treffer erscheinen hier, sobald die automatische Abfrage ausgeführt "
 "wird."
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr "Zurück zum Admin-Bereich"
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr "Überprüfung erforderlich"
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
@@ -10754,11 +10582,11 @@ msgstr ""
 "jeden Treffer und wählen Sie das korrekte Ergebnis aus, oder überspringen/"
 "ablehnen Sie ihn, falls kein passender Treffer existiert."
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr "Ausstehende Treffer"
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
@@ -10768,66 +10596,60 @@ msgstr ""
 "Eindeutige Treffer werden automatisch zugewiesen; diese hier erfordern eine "
 "manuelle Verifizierung."
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 msgid "Reject All Pending"
 msgstr "Alle ausstehenden ablehnen"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 msgid "Search Query"
 msgstr "Suchanfrage"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr "Mögliche Treffer"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr "Beste %(count)s"
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr "Konfidenz"
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr "Treffergrund"
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 msgid "View on Hardcover"
 msgstr "Auf Hardcover anzeigen"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr "Diesen Treffer auswählen"
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 msgid "Reject All"
 msgstr "Alle ablehnen"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr "Vorerst überspringen"
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 msgid "Processing..."
 msgstr "Wird verarbeitet..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr "✓ Diesen Treffer auswählen"
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr "Zuweisung des Treffers fehlgeschlagen"
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
@@ -10835,41 +10657,38 @@ msgstr ""
 "Sind Sie sicher, dass Sie alle Treffer für dieses Buch ablehnen möchten? "
 "Dies kann nicht rückgängig gemacht werden."
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr "✗ Alle Treffer ablehnen"
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject match"
 msgstr "Ablehnen des Treffers fehlgeschlagen"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr ""
 "Sind Sie sicher, dass Sie alle ausstehenden Treffer ablehnen möchten? Dies "
 "kann nicht rückgängig gemacht werden."
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Pending"
 msgstr "✗ Alle ausstehenden ablehnen"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject all pending matches"
 msgstr "Ablehnen aller ausstehenden Treffer fehlgeschlagen"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr "→ Vorerst überspringen"
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr "Überspringen des Treffers fehlgeschlagen"
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
@@ -10878,270 +10697,269 @@ msgstr ""
 "Calibre-Web Automated Instanz ist nicht konfiguriert, bitte den "
 "Administrator kontaktieren"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Fehlermeldung erzeugen"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Zurück zur Hauptseite"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "Benutzer abmelden"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr "Hinweis für Mobilgeräte"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 "Das Bearbeiten von Magischen Regalen funktioniert am besten auf Desktop-"
 "Geräten oder Tablets."
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr "Regal aktualisieren, um die neuesten Änderungen zu laden"
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 msgid "Edit shelf rules"
 msgstr "Regalregeln bearbeiten"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr "Dieses Regal in der Seitenleiste ausblenden"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Show this shelf in your sidebar"
 msgstr "Dieses Regal in der Seitenleiste anzeigen"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 msgid "Show Shelf"
 msgstr "Regal anzeigen"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 msgid "Hide Shelf"
 msgstr "Regal ausblenden"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Zu Regal hinzufügen"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr "KOReader Sync ist deaktiviert."
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Home"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Navigation umschalten"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Bibliothek durchsuchen"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Calibre-Web Automated E-Book-Katalog"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Abmelden"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 msgid "Refresh Library"
 msgstr "Bibliothek aktualisieren"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Keine Release-Informationen verfügbar"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Calibre-Web Automated E-Book-Katalog"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr "Siehe Änderungsprotokoll"
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Duplikate"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr "Hier mitmachen!"
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Bitte diese Seite nicht neu laden"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 msgid "Create Shelf"
 msgstr "Neues Regal"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr "Magische Regale ✨"
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Vorheriger Eintrag"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Buchdetails"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Diese Aktion kann nicht rückgängig gemacht werden!"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Ausgewählte löschen"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Zielformat"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Lösche Formate:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 msgid "Duplicate Books Detected"
 msgstr "Bücherduplikate erkannt"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr "Nicht aufgelöste Buch-Dubletten in der Bibliothek"
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 msgid "Duplicate Groups Found"
 msgstr "Duplikatgruppen gefunden"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr "Später erinnern"
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr "Duplikate anzeigen & bereinigen"
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Optimale Skalierung"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "Tipp"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 msgid "Confirm"
 msgstr ""
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Zu Regal hinzufügen"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Als gelesen markiert"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Als ungelesen markiert"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Buch löschen"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Buch löschen"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -11149,37 +10967,37 @@ msgid ""
 msgstr ""
 "Dies wird Bücher dauerhaft löschen. Originaldateien werden gesichert unter"
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Bitte zuerst ein Buch auswählen"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Wiederherstellung fehlgeschlagen: %(err)s"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr "Nach Anfangsbuchstaben filtern"
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "Raster"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 msgid "Show Password"
 msgstr "Passwort anzeigen"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Merken"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Passwort vergessen?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 msgid ""
 "Log in with Magic\n"
 "      Link"
@@ -11187,55 +11005,55 @@ msgstr ""
 "Anmelden mit magischem\n"
 "      Link"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 msgid "Log in with SSO"
 msgstr "Anmelden mit SSO"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 "Der Standard-Login ist deaktiviert. Bitte verwenden Sie eine der "
 "alternativen Login-Methoden."
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Zeige Calibre-Web Log:  "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Calibre-Web Log: "
 msgstr "Calibre-Web Logdatei: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Stream-Ausgabe, kann nicht angezeigt werden"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Zeige Zugriffslog: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Calibre-Web Logdatei herunterladen"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "Zugriffslogbuch herunterladen"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr "Systemvorlage"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 "Dies ist eine vorkonfigurierte Regalvorlage. Sie können sie frei bearbeiten."
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 msgid "Share with Everyone (Public)"
 msgstr "Mit allen teilen (öffentlich)"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
@@ -11243,50 +11061,50 @@ msgstr ""
 "Andere Benutzer können dieses Regal sehen. Benutzer mit der Berechtigung "
 "„Öffentliche Regale bearbeiten“ können es bearbeiten oder löschen."
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Erlaubte/Verbotene Tags auswählen"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Erlaubte/Verbotene Spaltenwerte auswählen"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Erlaubte/Verbotene Tags des Benutzers auswählen"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr "Erlaubte/Verbotene Spaltenwerte des Benutzers auswählen"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Tag eingeben"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Sichtbeschränkung hinzufügen"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "Dieses Buchformat wird permanent aus der Datenbank gelöscht"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Das Buch wird endgültig aus der Datenbank gelöscht"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "und von der Festplatte gelöscht"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Wichtiger Kobo Hinweis: Gelöschte Bücher bleiben auf allen verbundenen Kobo "
 "Geräten erhalten."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11294,284 +11112,284 @@ msgstr ""
 "Bücher müssen zuerst archiviert werden und dann mit dem Gerät synchronisiert "
 "werden, bevor ein Buch sicher gelöscht werden kann."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Dateispeicherort auswählen"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "Typ"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "Name"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "Größe"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "Übergeordnetes Verzeichnis"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "Ok"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Calibre-Web Automated E-Book-Katalog"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "EPUB-Leser"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "Aktionen"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "Schwarz"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "Schriftgröße"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Nächste Seite"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr "Schriftart"
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 msgid "Default"
 msgstr "Standard"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr "Yahei"
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr "SimSun"
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 msgid "KaiTi"
 msgstr "KaiTi"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 msgid "Arial"
 msgstr "Arial"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 msgid "Spread"
 msgstr "Aufteilung"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr "Zwei Spalten"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr "Eine Spalte"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Text umbrechen, wenn Seitenleiste geöffnet ist."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 #, fuzzy
 msgid "Note"
 msgstr "Hinweis:"
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Comic-Leser"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Tastaturkürzel"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Vorherige Seite"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Nächste Seite"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 msgid "Single Page Display"
 msgstr "Einzelseitendarstellung"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr "Fortlaufende Seitendarstellung"
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Optimale Skalierung"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Skaliere auf Breite"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Skaliere auf Höhe"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Skaliere 1:1"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Rechts rotieren"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Links rotieren"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Bild umdrehen"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "Darstellung"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 msgid "Single Page"
 msgstr "Einzelne Seite"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr "Fortlaufend"
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Skalierung"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Beste"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Breite"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Höhe"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Nativ"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Rotieren"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Umdrehen"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Horizontal"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Vertikal"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 msgid "Direction"
 msgstr "Leserichtung"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Links nach rechts"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Rechts nach links"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr "Auf Anfang zurücksetzen"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 msgid "Remember Position"
 msgstr "Position merken"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "Scrollleiste"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "Zeige"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "DJVU-Leser"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "PDF-Reader"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "txt-Leser"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Neues Benutzerkonto registrieren"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Wähle einen Benutzernamen"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Deine E-Mail-Adresse"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Magischer Link - Neues Gerät autorisieren"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "Benutze eein anderes Gerät, logge dich ein und besuche:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr ""
 "Einmal verifiziert, wirst du automatisch auf diesem Gerät eingeloggt sein."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Dieser Link wird in 10 Minuten ablaufen."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
@@ -11580,262 +11398,258 @@ msgstr ""
 "Vorschaubilder werden unabhängig von dieser Einstellung immer bei Bedarf "
 "generiert."
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "Thumbnails für Serien Cover erzeugen"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Keine Ergebnisse gefunden"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Suchbegriff:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Ergebnisse für:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Herausgabedatum von"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Herausgabedatum bis"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr "Leer"
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Tags ausschließen"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Serien ausschließen"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "Regale ausschliessen"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Sprachen ausschließen"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Dateierweiterungen"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Dateierweiterungen ausschliessen"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Bewertungen größer als"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Bewertungen kleiner als"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "Von:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "Bis:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Lösche dieses Regal"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "Regal-Eigenschaften bearbeiten"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Verstecktes Buch"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "Bücher manuell sortieren"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "Manuelles Sortieren deaktivieren"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "Manuelles Sortieren aktivieren"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Für das ausgewählte Buch ausführen"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Beste %(count)s"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Buch wurde nicht gefunden."
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Lösche dieses Regal"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Could not add the books. Please try again."
 msgstr ""
 "Verknüpfung des OAuth-Kontos fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Zu Regal hinzufügen"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Bibliothek durchsuchen"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Bibliothek durchsuchen"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Mit allen teilen"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "Dieses Regal mit Kobo synchronisieren"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Order saved"
 msgstr "Sortiermodus"
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Regal nicht gefunden"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Verstecktes Buch"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr "Sortieren nach"
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr "Sie haben noch keine Regale zum Neuanordnen."
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr "Ziehen, um die Reihenfolge der Regale in der Seitenleiste zu ändern."
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 "Reihenfolge gespeichert. Die Seitenleiste wird beim nächsten Seitenaufruf "
 "aktualisiert."
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Bibliotheksstatistiken"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Bücher in dieser Bibliothek"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Autoren in dieser Bibliothek"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Kategorien in dieser Bibliothek"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Serien in dieser Bibliothek"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Systemstatistiken"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "Programm"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Installierte Version"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr "Übersicht der Hintergrundaufgaben"
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Laufzeit"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr "Aktionen"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr "Anstehende geplante Versendungen"
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr "Geplante Zeit"
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 msgid "State"
 msgstr "Status"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
@@ -11844,15 +11658,15 @@ msgstr ""
 "Zeitpunkt in die Warteschlange gestellt. Sie können eine ausstehende "
 "Versendung abbrechen, bevor sie ausgeführt wird."
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr "Anstehende geplante Vorgänge"
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr "Typ"
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
@@ -11861,12 +11675,12 @@ msgstr ""
 "nach Neustarts erhalten. Brechen Sie diese ab, um die Ausführung zu "
 "verhindern."
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr "Diese Aufgabe wird abgebrochen. Der Fortschritt wird gespeichert."
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
@@ -11874,148 +11688,148 @@ msgstr ""
 "Dies ist eine geplante Aufgabe, sie wird zur geplanten Zeit erneut "
 "ausgeführt."
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 msgid "Scheduled item cancelled successfully"
 msgstr "Geplanter Task erfolgreich abgebrochen"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr "Fehler beim Abbrechen des geplanten Elements"
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Calibre-Web Automated E-Book-Katalog"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Portainer:"
 msgstr "Wichtig:"
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Set up automatic updates"
 msgstr "Automatische Dubletten-Scans aktivieren"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "Your Profile"
 msgstr "Dein Profil"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "User Settings"
 msgstr "Benutzereinstellungen"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr "Kontoinformationen"
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 "Falls Sie Ihre E-Mail-Adresse oder Ihr Passwort ändern müssen, können Sie "
 "dies hier tun."
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Benutzerpasswort zurücksetzen"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 msgid "eReader Configuration"
 msgstr "eReader-Konfiguration"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 msgid "Send to eReader Email Address"
 msgstr "An eReader-E-Mail-Adresse senden"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr "Verwenden Sie Kommas, um mehrere Adressen zu trennen"
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
@@ -12023,11 +11837,11 @@ msgstr ""
 "E-Mail-Adresse(n) für Ihre eReader-Geräte. Trennen Sie mehrere Adressen "
 "durch Kommas."
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr "Aktiviere \"an den eReader\" senden Popup"
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
@@ -12037,7 +11851,7 @@ msgstr ""
 "Benutzer zusätzliche E-Mail-Adressen eingeben und beim Senden an eReader nur "
 "an eine Auswahl gespeicherter Adressen senden können."
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
@@ -12045,11 +11859,11 @@ msgstr ""
 "Wenn diese Option deaktiviert ist, werden E-Mails ohne Rückfrage an alle "
 "konfigurierten E-Reader-Adressen gesendet."
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr "Neue Bücher automatisch an meine(n) eReader senden"
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
@@ -12057,108 +11871,108 @@ msgstr ""
 "Wenn aktiviert, werden neu hinzugefügte Bücher automatisch an alle oben "
 "konfigurierten E-Mail-Adressen für eReader gesendet."
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr "Sprach- & Design-Einstellungen"
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 msgid "Interface Language"
 msgstr "Sprache der Benutzeroberfläche"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Zeige nur Bücher mit dieser Sprache"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 "Die Bibliothek filtern, um nur Bücher in einer bestimmten Sprache anzuzeigen."
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 msgid "Book Language Filter"
 msgstr "Bücher-Sprachfilter"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr "OAuth- & API-Integrationen"
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "OAuth-Einstellungen"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Verknüpfen"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Verbindung trennen"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr "Hardcover API-Token"
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr "API-Token für die Integration des Metadaten-Anbieters Hardcover."
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Kobo Sync Token"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Erzeugen/Ansehen"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "Kobo Komplettsynchronisation erzwingen"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "Nur Bücher der ausgewählten Regale mit Kobo synchronisieren"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "Nur Bücher der ausgewählten Regale mit Kobo synchronisieren"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 msgid "Sidebar Display Settings"
 msgstr "Seitenleisten-Anzeigeeinstellungen"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 "Wählen Sie aus, welche Bereiche in der Seitenleiste angezeigt werden sollen."
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Erlaubte/Verbotene Calibre Spalten hinzufügen"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr "OPDS-Katalog-Sortierung"
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
@@ -12167,7 +11981,7 @@ msgstr ""
 "gewünschten Reihenfolge auflisten. Unbekannte IDs werden ignoriert und "
 "fehlende Einträge werden automatisch am Ende angehängt."
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
@@ -12175,71 +11989,71 @@ msgstr ""
 "Ziehen Sie die OPDS-Stammeinträge, um sie neu zu ordnen. Fehlende Einträge "
 "werden automatisch angehängt."
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr "Benutzerberechtigungen"
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr "Konfigurieren Sie, welche Aktionen dieser Benutzer ausführen darf."
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Order"
 msgstr "Magische Regale Sortierung"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr "Wähle wie die Magischen Regale angeordnet sein sollen"
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr "Sortiermodus"
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr "Manuell (ziehen zum neuordnen)"
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr "Name (A-Z)"
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr "Name (Z-A)"
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr "Buchanzahl (hoch zu niedrig)"
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr "Buchanzahl (niedrig zu hoch)"
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr "Erstellt (neueste zuerst)"
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr "Erstellt (älteste zuerst)"
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 msgid "Recently modified"
 msgstr "Kürzlich geändert"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr "Zuletzt am wenigsten geändert"
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr "Manuell ist nur aktiv, wenn der Sortiermodis \"Manuell\" gewählt ist."
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr "Sichtbarkeit der Magischen Regale"
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
@@ -12248,33 +12062,33 @@ msgstr ""
 "Systemregale können nicht gelöscht, sondern nur ausgeblendet werden. "
 "Öffentliche Regale anderer Benutzer können ebenfalls ausgeblendet werden."
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr "Standard-Systemregale:"
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 msgid "Public Shelves:"
 msgstr "Öffentliche Regale:"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr "%(visible)s von %(total)s Standardregalen sichtbar"
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr "%(visible)s von %(total)s öffentlichen Regalen sichtbar"
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Benutzer löschen"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12282,154 +12096,154 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Passwort ändern"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Passwort ändern"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Erzeugen/Ansehen"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Last used"
 msgstr "Zuletzt geändert"
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Kobo Auth URL erzeugen"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr "Sichtbar"
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Auswahl..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Auswahl aufheben"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "Benutzer bearbeiten"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "Benutzernamen eingeben"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 msgid "Enter Email"
 msgstr "E-Mailadresse eingeben"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "Enter eReader Email"
 msgstr "E-Reader E-Mail Adresse eingeben"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "eReader Email"
 msgstr "E-Reader E-Mail"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 msgid "Enter eReader Email Subject"
 msgstr "E-Reader E-Mail-Betreff eingeben"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 msgid "eReader Email Subject"
 msgstr "E-Reader E-Mail-Betreff"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Anzeigesprache"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "Sichtbare Büchersprachen"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "Erlaubte Tags bearbeiten"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Erlaubte Tags"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Verbotene Tags bearbeiten"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Verbotene Tags"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "Erlaubte/Verbotene Calibre Spalten bearbeiten"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "Erlaubte Calibre Spalten hinzufügen"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "Erlaubte/Verbotene Calibre Spalten bearbeiten"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "Verbotene Spaltennamen"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "Passwort ändern"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "Öffentliche Regale bearbeiten"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "Ausgewählte Regale mit Kobo synchronisieren"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "Ausgewählte Regale mit Kobo synchronisieren"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 msgid "Show Read/Unread Section"
 msgstr "Zeige Gelesen/Ungelesen-Abschnitt"
 
@@ -12621,9 +12435,9 @@ msgstr "Zeige Gelesen/Ungelesen-Abschnitt"
 #~ "        <a href=\"https://github.com/crocodilestick/Calibre-Web-Automated/"
 #~ "wiki/Configuration#database-configuration\">see here</a>!"
 #~ msgstr ""
-#~ "CWA ist so konfiguriert, dass es deine Calibre-Datenbank (<code>metadata."
-#~ "db</code>-Datei) irgendwo in dem Pfad <code>/calibre-library</code> "
-#~ "sucht.\n"
+#~ "CWA ist so konfiguriert, dass es deine Calibre-Datenbank "
+#~ "(<code>metadata.db</code>-Datei) irgendwo in dem Pfad <code>/calibre-"
+#~ "library</code> sucht.\n"
 #~ "        CWA durchsucht automatisch das Verzeichnis, das du auf <code>/"
 #~ "calibre-library</code> in der docker-compose-Datei verbunden hast, um "
 #~ "eine existierende Calibre-\n"

--- a/cps/translations/el/LC_MESSAGES/messages.po
+++ b/cps/translations/el/LC_MESSAGES/messages.po
@@ -18,1433 +18,1406 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Στατιστικά"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 #, fuzzy
 msgid "Server restarted, please reload page."
 msgstr "Ο διακομιστής επανεκκίνησε, παρακαλούμε φόρτωσε ξανά τη σελίδα"
 
-#: cps/admin.py:210
+#: cps/admin.py
 #, fuzzy
 msgid "Performing Server shutdown, please close window."
 msgstr ""
 "Πραγματοποιείται κλείσιμο του διακομιστή, παρακαλούμε κλείσε το παράθυρο"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr ""
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Άγνωστη εντολή"
 
-#: cps/admin.py:232
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr "Το βιβλίο έχει επιτυχώς μπει σε σειρά για αποστολή στο %(eReadermail)s"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr ""
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 
-#: cps/admin.py:414
+#: cps/admin.py
 msgid "Hardcover ID applied successfully"
 msgstr ""
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr ""
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr ""
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr ""
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr ""
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr ""
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Σελίδα διαχειριστή"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "OAuth Ρυθμίσεις"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Βασική Διαμόρφωση"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "UI Διαμόρφωση"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, fuzzy, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 "Η ειδικά προσαρμοσμένη στήλη No.%(column)d δεν υπάρχει στο επίπεδο βάσης "
 "δεδομένων"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Edit Users"
 msgstr "Χρήστης Διαχειριστής"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Όλα"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Δεν βρέθηκε χρήστης"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr ""
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Προβολή Όλων"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr ""
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr ""
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr ""
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr ""
 "Δεν έχει απομείνει χρήστης διαχειριστής, δεν μπορεί να αφαιρεθεί ο ρόλος "
 "διαχειριστή"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr ""
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr ""
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr ""
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr ""
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr ""
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr ""
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr ""
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr ""
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr ""
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr ""
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Θέλεις πραγματικά να διαγράψεις τη Μονάδα Kobo;"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr ""
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr ""
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Είσαι σίγουρος/η πως θέλεις να διαγράψεις αυτό το ράφι;"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 #, fuzzy
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr "Είσαι σίγουρος/η πως θέλεις να διαγράψεις αυτό το ράφι;"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1095
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
 msgstr "Είσαι σίγουρος/η πως θέλεις να διαγράψεις αυτό το ράφι;"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1100
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr "Είσαι σίγουρος/η πως θέλεις να διαγράψεις αυτό το ράφι;"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
 msgstr "Είσαι σίγουρος/η πως θέλεις να διαγράψεις αυτό το ράφι;"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 #, fuzzy
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Είσαι σίγουρος/η πως θέλεις να κάνεις κλείσιμο;"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Απόρριψη"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Επιτρέπεται"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr ""
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Η μάρκα δεν βρέθηκε"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr ""
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr ""
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json Δεν Έχει Διαμορφωθεί Για Διαδικτυακή Εφαρμογή"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Το Φύλλο Καταγραφής Τοποθεσίας δεν είναι Έγκυρο, Παρακαλούμε Συμπλήρωσε Τη "
 "Σωστή Πορεία"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Η Πρόσβαση Φύλλου Καταγραφης Τοποθεσίας δεν είναι έγκυρη, Παρακαλούμε "
 "Συμπλήρωσε Τη Σωστή Πορεία"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 "Παρακαλούμε Συμπλήρωσε ένα Πάροχο LDAP, Θύρα, DN και Αντικείμενο Αναγνώρισης "
 "Χρήστη"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 #, fuzzy
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr ""
 "Παρακαλούμε συμπλήρωσε ένα έγκυρο όνομα χρήστη για επαναφορά του κωδικού"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr ""
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Το Αντικείμενο Φίλτρου Ομάδας LDAP Πρέπει να Έχει Μια \"%s\" Αναγνώριση "
 "Μορφής"
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "Το Αντικείμενο Φίλτρου Ομάδας LDAP Έχει Παρενθέσεις Που Δεν Ταιριάζουν"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Το Αντικείμενο Φίλτρου Χρήστη LDAP πρέπει να Έχει Μια \"%s\" Αναγνώριση "
 "Μορφής"
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "Το Αντικείμενο Φίλτρου Χρήστη LDAP Έχει Παρενθέσεις Που Δεν Ταιριάζουν"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
 msgstr ""
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Προσθήκη Νέου Χρήστη"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Επεξεργασία Ρυθμίσεων E-mail Διακομιστή"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr ""
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Σφάλμα βάσης δεδομένων: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
 msgstr ""
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr ""
 "Παρουσιάστηκε σφάλμα κατά την αποστολή του δοκιμαστικού e-mail: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Παρακαλούμε ρύθμισε πρώτα τη διεύθυνση e-mail σου..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Ενημερώθηκαν οι ρυθμίσεις E-mail διακομιστή"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "Χρήστης Διαχειριστής"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Παρακαλούμε διαμόρφωσε πρώτα τις ρυθμίσεις ταχυδρομείου SMTP..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "Παρακαλούμε ρύθμισε πρώτα τη διεύθυνση e-mail σου..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "Ο Νέος Κωδικός έχει σταλεί στη διεύθυνση email σου"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
 msgstr ""
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
 "delivery."
 msgstr ""
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr ""
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr ""
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr ""
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr ""
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Προέκυψε ένα άγνωστο σφάλμα. Παρακαλούμε δοκίμασε ξανά αργότερα."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "Τίτλος"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Επεξεργασία χρήστη %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Κωδικός για επαναφορά %(user) χρήστη/ών"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Παρακαλούμε διαμόρφωσε πρώτα τις ρυθμίσεις ταχυδρομείου SMTP..."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Προβολέας αρχείου φύλλου καταγραφής"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Αίτημα πακέτου ενημέρωσης"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Κατεβάζει πακέτο ενημέρωσης"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Ανοίγει πακέτο ενημέρωσης"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Αντικατάσταση αρχείων"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Οι συνδέσεις βάσης δεδομένων είναι κλειστές"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Σταματάει το διακομιστή"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr ""
 "Η ενημέρωση τελειώσε, παρακαλούμε πιέστε το εντάξει και φορτώστε ξανά τη "
 "σελίδα"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Η ενημέρωση απέτυχε:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "HTTP Σφάλμα"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Σφάλμα σύνδεσης"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Τελείωσε ο χρόνος κατά την προσπάθεια δημιουργίας σύνδεσης"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Γενικό σφάλμα"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 #, fuzzy
 msgid "Update file could not be saved in temp dir"
 msgstr "Το Αρχείο Ενημέρωσης Δεν Μπόρεσε Να Αποθηκευτεί σε"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr ""
 
-#: cps/admin.py:2419
+#: cps/admin.py
 #, fuzzy
 msgid "Failed to extract at least One LDAP User"
 msgstr "Αποτυχία Δημιουργίας Τουλάχιστον Ενός Χρήστη LDAP"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Αποτυχία Δημιουργίας Τουλάχιστον Ενός Χρήστη LDAP"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Σφάλμα: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Σφάλμα: Δεν επιστράφηκε χρήστης σε απάντηση του διακομιστή LDAP"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "Τουλάχιστον Ένας Χρήστης LDAP Δεν Βρέθηκε Στη Βάση Δεδομένων"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr ""
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr ""
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Η Τοποθεσία DB δεν είναι Έγκυρη, Παρακαλούμε Συμπληρώστε Τη Σωστή Πορεία"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "Η DB δεν μπορεί να Γραφτεί"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Το Αρχειο Κλειδί Τοποθεσίας δεν είναι Έγκυρο, Παρακαλούμε Συμπληρώστε Τη "
 "Σωστή Πορεία"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Η Τοποθεσία Certfile δεν είναι Έγκυρη, Παρακαλούμε Συμπληρώστε Τη Σωστή "
 "Πορεία"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr ""
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 #, fuzzy
 msgid "Database Settings updated"
 msgstr "Ενημερώθηκαν οι ρυθμίσεις E-mail διακομιστή"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 #, fuzzy
 msgid "Database Configuration"
 msgstr "Διαμόρφωση Λειτουργίας"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Παρακαλούμε συμπλήρωσε όλα τα πεδία!"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "Το E-mail δεν είναι από έγκυρο domain"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Προσθήκη νέου χρήστη"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Χρήστης/ες '%(user)s' δημιουργήθηκαν"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! An account already exists for this Email. or name."
 msgstr ""
 "Βρέθηκε ένας ήδη υπάρχον λογαριασμός για αυτή τη διεύθυνση e-mail ή όνομα "
 "χρήστη."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Χρήστης/ες '%(nick)s' διαγράφηκαν"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr ""
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr ""
 "Δεν έχει απομείνει χρήστης διαχειριστής, δεν μπορεί να διαγραφεί ο χρήστης"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr ""
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Χρήστης/ες '%(nick)s' ενημερώθηκαν"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr ""
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr ""
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Σφάλμα σύνδεσης"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr ""
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "Δεν υπάρχουν διαθέσιμες πληροφορίες αποδέσμευσης"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr ""
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr ""
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr ""
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "Προέκυψε ένα άγνωστο σφάλμα. Παρακαλούμε δοκίμασε ξανά αργότερα."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "Σφάλμα σύνδεσης"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Σφάλμα σύνδεσης"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "Το αρχείο %(file)s ανέβηκε"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr ""
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr ""
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr ""
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr ""
 
-#: cps/constants.py:265
+#: cps/constants.py
 #, fuzzy
 msgid "Finnish"
 msgstr "Τελείωσε"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr ""
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr ""
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr ""
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr ""
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr ""
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr ""
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr ""
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr ""
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr ""
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr ""
 
-#: cps/constants.py:276
+#: cps/constants.py
 #, fuzzy
 msgid "Polish"
 msgstr "Εκδότης"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr ""
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr ""
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr ""
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr ""
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr ""
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr ""
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr ""
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr ""
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr ""
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr ""
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "δεν εγκαταστάθηκε"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Λείπουν άδειες εκτέλεσης"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, python-format
 msgid "Change cover — %(title)s"
 msgstr ""
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Σφάλμα σύνδεσης"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr ""
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Book ID"
 msgstr "Βιβλία"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Τίτλος Βιβλίου"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "Συγγραφέας"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr ""
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "Μορφές αρχείου"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filename"
 msgstr "Όνομα Χρήστη"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr ""
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr ""
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "Μορφή Ανεβάσματος"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "ʼΑγνωστο"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr ""
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "Διευκρινίστηκε μη έγκυρο ράφι"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "Συγχώνευση επιλεγμένων βιβλίων"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "%(format)s μορφή δεν βρέθηκε σε δίσκο"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB Fixer started for selected book."
 msgstr "Συγχώνευση επιλεγμένων βιβλίων"
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr ""
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr ""
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 msgid "Invalid image data format."
 msgstr ""
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr ""
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Κανένα"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "Δεν Βρέθηκαν Αποτελέσματα"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 msgid "Invalid resolution strategy"
 msgstr ""
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Το ανέβασμα έγινε, γίνεται επεξεργασία, παρακαλούμε περίμενε..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 #, fuzzy
 msgid "Failed to queue upload for processing"
 msgstr "Αποτυχία δημιουργίας πορείας για φόντο"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Η δομή πηγής ή προορισμού για μετατροπή λείπει"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "Το βιβλίο είναι σε σειρά επιτυχώς για μετατροπή σε %(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Υπήρξε ένα σφάλμα στη μετατροπή αυτού του βιβλίου: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 #, fuzzy
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr ""
 "Η επέκταση αρχείου '%(ext)s' δεν επιτρέπεται να ανέβει σε αυτό το διακομιστή"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr ""
 "Η επέκταση αρχείου '%(ext)s' δεν επιτρέπεται να ανέβει σε αυτό το διακομιστή"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "Το αρχείο προς ανέβασμα πρέπει να έχει μια επέκταση"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 "Oυπς! Ο επιλεγμένος τίτλος βιβλίου δεν είναι διαθέσιμος. Το αρχείο δεν "
 "υπάρχει ή δεν είναι προσβάσιμο"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr ""
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 "Τα αναγνωριστικά δεν έχουν Διάκριση Πεζών-Κεφαλαίων Γραμμάτων, Αντικατάσταση "
 "Παλιού Αναγνωριστικού"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "%(langname)s δεν είναι μια έγκυρη γλώσσα"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Τα μεταδεδομένα ενημερώθηκαν επιτυχώς"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr ""
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "ʼΑγνωστο"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1452,96 +1425,96 @@ msgstr ""
 "Το βιβλίο που ανέβηκε πιθανόν να υπάρχει στη βιβλιοθήκη, σκέψου να το "
 "αλλάξεις πριν ανεβάσεις νέο: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "Το αρχείο %(filename)s δεν μπόρεσε να αποθηκευτεί σε temp dir"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Αποτυχία Μετακίνησης Αρχείου Φόντου %(file)s: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Η μορφή βιβλίου Διαγράφηκε Επιτυχώς"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Το Βιβλίο Διαγράφηκε Επιτυχώς"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr ""
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "επεξεργασία μεταδεδομένων"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr ""
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr ""
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Αποτυχεία δημιουργίας πορείας %(path)s (Η άδεια απορρήφθηκε)."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Αποτυχία αποθήκευσης αρχείου %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Μορφή αρχείου %(ext)s προστέθηκε σε %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Η μάρκα δεν βρέθηκε"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "%(format)s μορφή δεν βρέθηκε σε δίσκο"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1549,7 +1522,7 @@ msgstr ""
 "Η ρύθμιση του Google Drive δεν ολοκληρώθηκε, προσπάθησε να απενεργοποιήσεις "
 "και να ενεργοποιήσεις ξανά το Google Drive"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1557,91 +1530,90 @@ msgstr ""
 "Η ανάκληση ονόματος δεν έχει επαληθευτεί, παρακαλούμε ακολούθησε τα βήματα "
 "για την επαλήθευση ονόματος στην κονσόλα προγραμματιστή google"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "%(format)s η δομή δεν βρέθηκε για την ταυτότητα βιβλίου: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(format)s δεν βρέθηκε στο Google Drive: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s δεν βρέθηκε: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 #, fuzzy
 msgid "Send to eReader"
 msgstr "Αποστολή στο Kindle"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "%(format)s η δομή δεν βρέθηκε για την ταυτότητα βιβλίου: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "%(format)s η δομή δεν βρέθηκε για την ταυτότητα βιβλίου: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 #, fuzzy
 msgid "Test Email"
 msgstr "Δοκιμαστικό e-mail"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "e-mail εγγραφής για χρήστη: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Μετατροπή %(orig)s σε %(format)s και αποστολή στο Kindle"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Αποστολή %(format)s στο Kindle"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "%(book)s send to eReader"
 msgstr "Αποστολή στο Kindle"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr ""
 "Το αρχείου που χητήθηκε δεν μπορεί να διαβαστεί. Μπορεί να υπάρχουν "
 "λαθασμένες άδειες;"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr ""
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
@@ -1649,19 +1621,19 @@ msgstr ""
 "Η διαγραφή φακέλου βιβλίου για το βιβλίο %(id)s απέτυχε, η πορεία έχει υπό-"
 "φακέλους: %(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "Η διαγραφή βιβλίου %(id)s απέτυχε: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, fuzzy, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
 "%(path)s"
 msgstr "Διαγραφή βιβλίου %(id)s, η πορεία βιβλίου δεν είναι έγκυρη: %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, fuzzy, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
@@ -1669,190 +1641,190 @@ msgstr ""
 "Η μετονομασία τίτλου από: '%(src)s' σε '%(dest)s' απέτυχε με σφάλμα: "
 "%(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Το αρχείο %(file)s δεν βρέθηκε στο Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Η μετονομασία τίτλου από: '%(src)s' σε '%(dest)s' απέτυχε με σφάλμα: "
 "%(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Η πορεία βιβλίου %(path)s δεν βρέθηκε στο Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr ""
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Αυτό το όνομα χρήστη έχει ήδη παρθεί"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr ""
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr ""
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Σφάλμα Κατεβάσματος Φόντου"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr ""
 "Το αρχείο φόντου δεν είναι ένα έγκυρο αρχείο εικόνας, ή δεν μπόρεσε να "
 "αποθηκευτεί"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Σφάλμα Μορφής Φόντου"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
 msgstr ""
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Αποτυχία δημιουργίας πορείας για φόντο"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr ""
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr ""
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Μόνο jpg/jpeg αρχεία υποστηρίζονται ως αρχεία φόντου"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr ""
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "Δεν βρέθηκε δυαδικό αρχείο UnRar"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing UnRar"
 msgstr "Σφάλμα εκτέλεσης UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr ""
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr ""
 
-#: cps/helper.py:2125
+#: cps/helper.py
 #, fuzzy
 msgid "Calibre binaries not viable"
 msgstr "Η DB δεν μπορεί να Γραφτεί"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Λείπουν άδειες εκτέλεσης"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing Calibre"
 msgstr "Σφάλμα εκτέλεσης UnRar"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr ""
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Καθορισμός Kobo"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Εγγραφή με %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
@@ -1861,7 +1833,7 @@ msgstr ""
 "Ο διακομιστής E-Mail δεν έχει διαμορφωθεί, παρακαλούμε επικοινώνησε με το "
 "διαχειριστή σου!"
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1869,35 +1841,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "τώρα έχεις συνδεθεί ως: '%(nickname)s'"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Η Σύνδεση στο %(oauth)s Πέτυχε"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1905,4156 +1877,4088 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr ""
 "Ο διακομιστής E-Mail δεν έχει διαμορφωθεί, παρακαλούμε επικοινώνησε με το "
 "διαχειριστή σου!"
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "Η αφαίρεση σύνδεσης με το %(oauth)s Πέτυχε"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Η αφαίρεση σύνδεσης με το %(oauth)s Απέτυχε"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "Δεν Είναι Συνδεδεμένο με το %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Αποτυχία σύνδεσης με GitHub."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Αποτυχία συγκέντρωσης πληροφοριών χρήστη από το GitHub."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Αποτυχία σύνδεσης με το Google."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Αποτυχία συγκέντρωσης πληροφοριών χρήστη από το Google."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "Failed to log in with Generic OAuth."
 msgstr "Αποτυχία σύνδεσης με GitHub."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "GitHub Oauth σφάλμα, παρακαλούμε δοκίμασε ξανά αργότερα."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr ""
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Google Oauth σφάλμα, παρακαλούμε δοκίμασε ξανά αργότερα."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr ""
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr ""
 
-#: cps/opds.py:164
+#: cps/opds.py
 #, fuzzy
 msgid "Alphabetical Books"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr ""
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Βιβλία στη Μόδα"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "Δημοφιλείς εκδόσεις από αυτό τον κατάλογο με βάση τις Λήψεις."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Βιβλία με Κορυφαία Αξιολόγηση"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Δημοφιλείς εκδόσεις από αυτό τον κατάλογο με βάση την Αξιολόγηση."
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "Κατεβασμένα Βιβλία"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Τα τελευταία Βιβλία"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Τυχαία Βιβλία"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Προβολή Τυχαίων Βιβλίων"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Βιβλία που Διαβάστηκαν"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Τρέχουσα έκδοση"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Βιβλία που δεν Διαβάστηκαν"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Συγγραφείς"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Τα βιβλία ταξινομήθηκαν ανά Συγγραφέα"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Εκδότες"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Τα βιβλία ταξινομήθηκαν ανά εκδότη"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Κατηγορίες"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Τα βιβλία ταξινομήθηκαν ανά κατηγορία"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Σειρές"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Τα βιβλία ταξινομήθηκαν ανά σειρές"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Γλώσσες"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Τα βιβλία ταξινομήθηκαν ανά Γλώσσες"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Αξιολογήσεις"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Τα βιβλία ταξινομήθηκαν ανά Αξιολόγηση"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Μορφές αρχείου"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Τα βιβλία ταξινομήθηκαν ανά μορφές αρχείου"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Ράφια"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "Βιβλία οργανωμένα σε ράφια"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Δημόσιο Ράφι"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Βιβλία οργανωμένα σε ράφια"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "Περιγραφή"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr ""
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Αναζήτηση"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Σύνδεση"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Η μάρκα δεν βρέθηκε"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Η μάρκα έχει λήξει"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Επιτυχία! Παρακαλούμε επέστρεψε στη συσκευή σου"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Βιβλία"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Προβολή πρόσφατων βιβλίων"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Προβολή Βιβλίων στη Μόδα"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Κατεβασμένα Βιβλία"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Προβολή Κατεβασμένων Βιβλίων"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Προβολή Βιβλίων με Κορυφαία Αξιολόγηση"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Read and Unread"
 msgstr "Προβολή διαβασμένων και αδιάβαστων"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Προβολή αδιάβαστων"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Ανακάλυψε"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Category Section"
 msgstr "Προβολή επιλογών κατηγορίας"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Series Section"
 msgstr "Προβολή επιλογών σειράς"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Author Section"
 msgstr "Προβολή επιλογών συγγραφέα"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Publisher Section"
 msgstr "Προβολή επιλογών εκδότη"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Language Section"
 msgstr "Προβολή επιλογών γλώσσας"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Ratings Section"
 msgstr "Προβολή επιλογών αξιολόγησης"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show File Formats Section"
 msgstr "Προβολή επιλογών μορφής αρχείου"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Αρχειοθετημένα Βιβλία"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Archived Books"
 msgstr "Προβολή αρχειοθετημένων βιβλίων"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Λίστα Βιβλίων"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Προβολή Λίστας Βιβλίων"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr ""
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Προβολή Βιβλίων με Κορυφαία Αξιολόγηση"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Εκδόθηκε μετά"
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Εκδόθηκε πριν"
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Αξιολόγηση <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Αξιολόγηση >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr ""
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Προχωρημένη Αναζήτηση"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Διευκρινίστηκε μη έγκυρο ράφι"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 #, fuzzy
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr ""
 "Συγγνώμη δεν σου επιτρέπεται να προσθέσεις ένα βιβλίο στο ράφι: %(shelfname)s"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "Το βιβλίο είναι ήδη μέρος αυτού του ραφιού: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "Το βιβλίο έχει προστεθεί στο ράφι: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr ""
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Τα βιβλία είναι ήδη μέρος του ραφιού: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "Βιβλία είχαν προστεθεί στο ραφι: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Δεν μπόρεσε να γίνει η προσθήκη βιβλίων στο ράφι: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "Διευκρινίστηκε μη έγκυρο ράφι"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Δεν μπόρεσε να γίνει η προσθήκη βιβλίων στο ράφι: %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Τα βιβλία είναι ήδη μέρος του ραφιού: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "Βιβλία είχαν προστεθεί στο ραφι: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "Το βιβλίο έχει αφαιρεθεί από το ράφι: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr ""
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 #, fuzzy
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr ""
-"Συγγνώμη αλλά δεν σου επιτρέπεται η αφαίρεση ενός βιβλίου από αυτό το ράφι: "
-"%(sname)s"
+"Συγγνώμη αλλά δεν σου επιτρέπεται η αφαίρεση ενός βιβλίου από αυτό το ράφι: %"
+"(sname)s"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Επεξεργασία ενός ραφιού"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr ""
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 #, fuzzy
 msgid "Shelf successfully deleted"
 msgstr "Το Βιβλίο Διαγράφηκε Επιτυχώς"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Αλλαγή σειράς του Ραφιού: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr ""
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Το ράφι %(title)s δημιουργήθηκε"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Το ράφι %(title)s άλλαξε"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Υπήρξε ένα σφάλμα"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "Ένα δημόσιο ράφι με το όνομα '%(title)s' υπάρχει ήδη."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "Ένα ιδιωτικό ράφι με το όνομα '%(title)s' υπάρχει ήδη."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Ράφι: '%(name)s"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Σφάλμα κατά το άνοιγμα του ραφιού. Το ράφι δεν υπάρχει ή δεν είναι προσβάσιμο"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Εξαίρεση Σειρών"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Ανώνυμοι"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Μη επαληθεύσιμο"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Ναι"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Όχι"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr ""
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Θέμα"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Φωτεινό"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Σκοτεινό"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr ""
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Προσθήκη στο ράφι"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Συγγραφέας"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Περιήγηση"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Κλείσιμο"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Συγχώνευση"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Εκδότης"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Διαβάστηκε"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Τίτλος"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Ανέβασμα"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Λογαριασμός"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Διαχειριστής"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Εκδόθηκε"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Πηγή"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "Σχετικά"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Αρχειοθετήθηκε"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Περιγραφή"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Κατέβασμα"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Επεξεργασία"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "Διεύθυνση E-mail"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Ενεργοποίηση συγχρονισμού Kobo"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Κρυπτογράφηση"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Αναγνωριστικά"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Γλώσσα"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Κωδικός"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Θύρα"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Πρόοδος"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Αξιολόγηση"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr ""
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Κατάσταση"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Ετικέτες"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Εργασία"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Εργασίες"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Χρήστης"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Όνομα Χρήστη"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr ""
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Αναμονή"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Απέτυχε"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Ξεκίνησε"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Τελείωσε"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr ""
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr ""
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "ʼΑγνωστη κατάσταση"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Απρόβλεπτα δεδομένα κατά την ανάγνωση των πληροφοριών ενημέρωσης"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr ""
 "Δεν υπάρχει διαθέσιμη ενημέρωση. Έχεις ήδη την τελευταία έκδοση εγκατεστημένη"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6062,17 +5966,17 @@ msgstr ""
 "Μια νέα ενημέρωση είναι διαθέσιμη. Κάνε κλικ στο κουμπί πιο κάτω για να "
 "ενημερώσεις με την τελευταία έκδοση."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Δεν μπόρεσε να συγκεντρώσει τις πληροφορίες ενημέρωσης"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr ""
 "Κάνε κλικ στο κουμπί πιο κάτω για να ενημερώσεις με την τελευταία σταθερή "
 "έκδοση."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6081,272 +5985,270 @@ msgstr ""
 "Μια νέα ενημέρωση είναι διαθέσιμη. Κάνε κλικ στο κουμπί πιο κάτω για "
 "ενημέρωση με την έκδοση: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Δεν υπάρχουν διαθέσιμες πληροφορίες αποδέσμευσης"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Ανακάλυψε (Τυχαία Βιβλία)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Βιβλία στη Μόδα (Με τα περισσότερα κατεβάσματα)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "Κατεβασμένα βιβλία από %(user)s"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Συγγραφέας: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Εκδότης: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Σειρές: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr ""
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Αξιολόγηση: %(rating)s stars"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Μορφή αρχείου: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Κατηγορία: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Γλώσσα: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Βιβλία στη Μόδα"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Κρυμμένο Βιβλίο"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "Σφάλμα Κατεβάσματος Φόντου"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "Μορφές αρχείου"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 msgid "Invalid request"
 msgstr ""
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr ""
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 #, fuzzy
 msgid "Error creating shelf"
 msgstr "Σφάλμα Κατεβάσματος Φόντου"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 #, fuzzy
 msgid "Shelf name is required"
 msgstr "Αυτό το Πεδίο Απαιτείται"
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "Σφάλμα Κατεβάσματος Φόντου"
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "Επεξεργασία ενός ραφιού"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "Δεν βρέθηκε χρήστης"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "Το Βιβλίο Διαγράφηκε Επιτυχώς"
 
-#: cps/web.py:1710
+#: cps/web.py
 #, fuzzy
 msgid "Error duplicating shelf"
 msgstr "Σφάλμα Κατεβάσματος Φόντου"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 #, fuzzy
 msgid "Error deleting shelf"
 msgstr "Σφάλμα Κατεβάσματος Φόντου"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "Σφάλμα Κατεβάσματος Φόντου"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 #, fuzzy
 msgid "Error unhiding shelf"
 msgstr "Σφάλμα Κατεβάσματος Φόντου"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Κατεβασμένα"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Λίστα μορφών αρχείου"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 #, fuzzy
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Παρακαλούμε διαμόρφωσε πρώτα τις ρυθμίσεις ταχυδρομείου SMTP..."
 
-#: cps/web.py:2400
+#: cps/web.py
 #, fuzzy
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 "Παρακαλούμε ενημέρωσε το προφίλ σου με μια έγκυρη Διεύθυνση E-mail Αποστολής "
 "στο Kindle."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "Το βιβλίο έχει επιτυχώς μπει σε σειρά για αποστολή στο %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Oυπς! Υπήρξε ένα σφάλμα κατά την αποστολή αυτού του βιβλίου: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "Το βιβλίο έχει επιτυχώς μπει σε σειρά για αποστολή στο %(eReadermail)s"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Εγγραφή"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 #, fuzzy
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr ""
 "Ο διακομιστής E-Mail δεν έχει διαμορφωθεί, παρακαλούμε επικοινώνησε με το "
 "διαχειριστή σου!"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr ""
 "Ο διακομιστής E-Mail δεν έχει διαμορφωθεί, παρακαλούμε επικοινώνησε με το "
 "διαχειριστή σου!"
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "Η διεύθυνση e-mail σου δεν επιτρέπεται να εγγραφεί"
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "Το e-mail επιβεβαίωσης έχει σταλεί στον e-mail λογαριασμό σου."
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
@@ -6355,7 +6257,7 @@ msgstr ""
 "Ο διακομιστής E-Mail δεν έχει διαμορφωθεί, παρακαλούμε επικοινώνησε με το "
 "διαχειριστή σου!"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
@@ -6364,36 +6266,36 @@ msgstr ""
 "Ο διακομιστής E-Mail δεν έχει διαμορφωθεί, παρακαλούμε επικοινώνησε με το "
 "διαχειριστή σου!"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 #, fuzzy
 msgid "Cannot activate LDAP authentication"
 msgstr "Δεν μπόρεσε να ενεργοποιηθεί η επαλήθευση LDAP"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr ""
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, fuzzy, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "τώρα έχεις συνδεθεί ως: '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "τώρα έχεις συνδεθεί ως: '%(nickname)s'"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
@@ -6402,13 +6304,13 @@ msgstr ""
 "Ο διακομιστής E-Mail δεν έχει διαμορφωθεί, παρακαλούμε επικοινώνησε με το "
 "διαχειριστή σου!"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6417,717 +6319,687 @@ msgstr ""
 "Εναλλακτική Σύνδεση ως: '%(nickname)s', Ο Διακομιστής LDAP δεν είναι "
 "προσβάσιμος, ή ο χρήστης δεν είναι γνωστός"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, fuzzy, python-format
 msgid "Could not login: %(message)s"
 msgstr "Δεν μπόρεσε να συνδεθεί: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 #, fuzzy
 msgid "Wrong Username or Password"
 msgstr "Λανθασμένο Όνομα Χρήστη ή Κωδικός"
 
-#: cps/web.py:2832
+#: cps/web.py
 #, fuzzy
 msgid "New Password was sent to your email address"
 msgstr "Ο Νέος Κωδικός έχει σταλεί στη διεύθυνση email σου"
 
-#: cps/web.py:2836
+#: cps/web.py
 #, fuzzy
 msgid "An unknown error occurred. Please try again later."
 msgstr "Προέκυψε ένα άγνωστο σφάλμα. Παρακαλούμε δοκίμασε ξανά αργότερα."
 
-#: cps/web.py:2838
+#: cps/web.py
 #, fuzzy
 msgid "Please enter valid username to reset password"
 msgstr ""
 "Παρακαλούμε συμπλήρωσε ένα έγκυρο όνομα χρήστη για επαναφορά του κωδικού"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, fuzzy, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "τώρα έχεις συνδεθεί ως: '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 #, fuzzy
 msgid "Success! Profile Updated"
 msgstr "Το προφίλ ενημερώθηκε"
 
-#: cps/web.py:3164
+#: cps/web.py
 #, fuzzy
 msgid "Oops! An account already exists for this Email."
 msgstr "Βρέθηκε ένας ήδη υπάρχον λογαριασμός για αυτή τη διεύθυνση e-mail."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr ""
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr ""
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "Αποστολή στο Kindle"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "Αποστολή στο Kindle"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 msgid "Auto-send completed successfully"
 msgstr ""
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr ""
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr ""
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, fuzzy, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "Αποστολή στο Kindle"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Το εργαλείο μετατροπής Calibre ebook %(tool)s δεν βρέθηκε"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "%(format)s μορφή δεν βρέθηκε σε δίσκο"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "Ο μετατροπέας Ebook απέτυχε με άγνωστο σφάλμα"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Ο μετατροπέας Kepubify απέτυχε: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "Το τροποποιημένο αρχείο δεν βρέθηκε ή υπάρχουν περισσότερα από ένα αρχεία "
 "στο φάκελο %(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Το Calibre απέτυχε με σφάλμα: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Ο μετατροπέας Ebook απέτυχε: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 #, fuzzy
 msgid "Reconnecting Calibre database"
 msgstr "Τοποθεσία Βάσης Δεδομένων Calibre"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Ανοίγει πακέτο ενημέρωσης"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Δεν Βρέθηκαν Αποτελέσματα"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Ενεργοποίηση συγχρονισμού Kobo"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 #, fuzzy
 msgid "E-mail"
 msgstr "Διεύθυνση E-mail"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 #, fuzzy
 msgid "Backing up Metadata"
 msgstr "επεξεργασία μεταδεδομένων"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "Στη Βιβλιοθήκη"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "Βιβλία οργανωμένα σε ράφια"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Να Επιτρέπεται η Αλλαγή Κωδικού"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "OAuth Ρυθμίσεις"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Ρυθμίσεις"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "διάλεξε μια επιλογή"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "Προσθήκη στο ράφι"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Δημόσιο)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "Κατεβασμένα"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Κατεβασμένα"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 msgid "Date added, newest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 msgid "Date added, oldest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Συγγραφέας"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Συγγραφέας"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Εκδόθηκε πριν"
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Εκδόθηκε πριν"
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Προσθήκη στο ράφι"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "Προσθήκη στο ράφι"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Send to eReader Email"
 msgstr "Διεύθυνση E-mail Αποστολής στο Kindle"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "Αποστολή στο Kindle"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Προβολή Βιβλίων"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Δημόσιο Ράφι"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr ""
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "Εισαγωγή Χρηστών LDAP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Ρυθμίσεις E-mail Διακομιστή"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "Όνομα Εξυπηρετητή SMTP"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "SMTP Θύρα"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "Σύνδεση SMTP"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Από E-mail"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Service"
 msgstr "Ρυθμίσεις E-mail Διακομιστή"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr ""
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Ευρετήριο Βάσης Δεδομένων Calibre"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Επίπεδο Φύλλου Καταγραφής"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Εξωτερική Θύρα"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Βιβλία ανά Σελίδα"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Ανεβάσμένα"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Ανώνυμη Περιήγηση"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Δημόσια Εγγραφή"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Μαγικός Σύνδεσμος Απομακρυσμένης Σύνδεσης"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Αναστροφή Σύνδεσης Διακομιστή Μεσολάβησης"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Αναστροφή Proxy Όνομα Επικεφαλίδας"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Επεξεργασία Βασικής Διαμόρφωσης"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Επεξεργασία Διαμόρφωσης UI"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Edit Calibre Database Configuration"
 msgstr "Επεξεργασία Βασικής Διαμόρφωσης"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr ""
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Start Time"
 msgstr "Ξεκίνησε"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr ""
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr ""
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 #, fuzzy
 msgid "Reconnect Calibre Database"
 msgstr "Τοποθεσία Βάσης Δεδομένων Calibre"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr ""
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr ""
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Setup KOReader Sync"
 msgstr "PDF πρόγραμμα ανάγνωσης"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr ""
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Διοίκηση"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Download Debug Package"
 msgstr "Κατεβάζει πακέτο ενημέρωσης"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Προβολή Φύλλων Καταγραφής"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Επανεκκίνηση"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Κλείσιμο"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr ""
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Έκδοση"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Λεπτομέρειες"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "Η ενημέρωση απέτυχε:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Ενημέρωση Καναλιού"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Τρέχουσα έκδοση"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Έλεγχος για Ενημέρωση"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Πραγματοποίηση Ενημέρωσης"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Είσαι σίγουρος/η πως θέλεις να κάνεις επανεκκίνηση"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Είσαι σίγουρος/η πως θέλεις να κάνεις κλείσιμο;"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Γίνεται ενημέρωση, παρακαλούμε μη φορτώσεις ξανά αυτή τη σελίδα"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7135,457 +7007,434 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Βιβλία σε αυτή τη Βιβλιοθήκη"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Φόρτωση..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "Η ενημέρωση απέτυχε:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Σφάλμα σύνδεσης"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Σειρές: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "μέσω"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "Στη Βιβλιοθήκη"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "μείωση"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Περισσότερα από"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Διαγραφή μορφών:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Μετατροπή μορφής βιβλίου:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Μετατροπή από:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "select an option"
 msgstr "διάλεξε μια επιλογή"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Μετατροπή σε:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Μετατροπή βιβλίου"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Σφάλμα"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Μορφή Ανεβάσματος"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "Ταυτότητα Σειράς"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Ημερομηνία Έκδοσης"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Είδος Αναγνωριστικού"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Τιμή Αναγνωριστικού"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Αφαίρεση"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Προσθήκη Αναγνωριστικού"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Συγκέντρωση Εξώφυλλου από URL (JPEG - Η εικόνα θα κατέβει και θα αποθηκευτεί "
 "σε βάση δεδομένων)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Ανέβασμα Εξώφυλλου από Τοπικό Δίσκο"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "Ενεργοποίηση συγχρονισμού Kobo"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Προβολή Βιβλίου σε Αποθήκευση"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Συγκέντρωση Μεταδεδομένων"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Λέξη κλειδί"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Search keyword"
 msgstr "Αναζήτηση λέξης κλειδιού"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Φόρτωση..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Σφάλμα αναζήτησης!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr ""
 "Δεν βρέθηκε(αν) αποτέλεσμα(τα)! Παρακαλούμε δοκίμασε μια άλλη λέξη κλειδί."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "Αυτό το Πεδίο Απαιτείται"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr ""
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr ""
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Update Title Sort automatically  "
 msgstr "Ενημέρωση Ταξινόμησης Τίτλων αυτόματα"
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Ενημέρωση Ταξινίμησης Συγγραφέα αυτόματα"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Εισαγωγή Τίτλου"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Εισαγωγή Ταξινόμησης Τίτλου"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Ταξινόμηση Τίτλου"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Εισαγωγή Ταξινόμησης Συγγραφέας"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Ταξινόμηση Συγγραφέα"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Εισαγωγή Συγγραφέων"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Εισαγωγή Κατηγοριών"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Εισαγωγή Σειρών"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Εισαγωγή Γλωσσών"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Ημερομηνία Έκδοσης"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Εισαγωγή Εκδοτών"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter comments"
 msgstr "Όνομα domain"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Comments"
 msgstr "Όνομα domain"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Archived?"
 msgstr "Αρχειοθετήθηκε"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Read?"
 msgstr "Διαβάστηκε"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter "
 msgstr "Αναγνωριστικά"
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Είσαι πραγματικά σίγουρος/η;"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "Βιβλία με Τίτλους θα ενωθούν από:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "Μέσα σε Βιβλίο με Τίτλο:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr ""
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr ""
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr ""
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr ""
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr ""
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Επεξεργασία Μεταδεδομένων"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr ""
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Προσθήκη"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
@@ -7593,164 +7442,164 @@ msgstr ""
 "Ο διακομιστής E-Mail δεν έχει διαμορφωθεί, παρακαλούμε επικοινώνησε με το "
 "διαχειριστή σου!"
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 #, fuzzy
 msgid "Message"
 msgstr "Συγχώνευση"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Ο Νέος Κωδικός έχει σταλεί στη διεύθυνση email σου"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Αποστολή στο Kindle"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Πίσω"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Τοποθεσία Βάσης Δεδομένων Calibre"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7766,13 +7615,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7783,7 +7632,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7794,43 +7643,43 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr ""
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
 "can be wherever you desire"
 msgstr ""
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Χρήση Google Drive;"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Πιστοποίηση αυθεντικότητας Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Αρχείο Google Drive Calibre"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "Ταυτότητα Καναλιού Προβολής Μεταδεδομένων"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Αναίρεση"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Τοποθεσία Βάσης Δεδομένων Calibre"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7840,139 +7689,139 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "Είσαι σίγουρος/η πως θέλεις να κάνεις κλείσιμο;"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Τοποθεσία Βάσης Δεδομένων Calibre"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "New db location is invalid, please enter valid path"
 msgstr ""
 "Η Τοποθεσία DB δεν είναι Έγκυρη, Παρακαλούμε Συμπληρώστε Τη Σωστή Πορεία"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Χρήση Στεθερής Επαλήθευσης"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Χρήση Επαλήθευσης LDAP"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Χρήση OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Διαμόρφωση Διακομιστή"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Θύρα Διακομιστή"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Τοποθεσία πιστοποιητικού SSL (αφήστε το κενό για Διακομιστές που δεν είναι "
 "SSL)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Τοποθεσία αρχείου κλειδιού SSL (αφήστε το κενό για Διακομιστές που δεν είναι "
 "SSL)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Ενημέρωση Καναλιού"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Σταθερό"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Νυχτερινό"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr ""
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Διαμόρφωση αρχείου καταγραφής"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr ""
 "Τοποθεσία και όνομα πρόσβασης αρχείου φύλλου καταγραφής (access.log για "
 "καμία καταχώρηση)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Ενεργοποίηση Πρόσβασης Φύλλου Καταγραφής"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr ""
 "Τοποθεσία και όνομα πρόσβασης αρχείου φύλλου καταγραφής (access.log για "
 "καμία καταχώρηση)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "Διαμόρφωση Διακομιστή"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Ενεργοποίηση Ανεβάσματος"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr ""
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Επιτρεπόμενες Μορφές Αρχείων για Ανέβασμα"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Ενεργοποίηση Ανώνυμης Περιήγησης"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Ενεργοποίηση Δημόσιας Εγγραφής"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "Χρήση E-Mail ως Όνομα Χρήστη"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Ενεργοποίηση Μαγικού Συνδέσμου Απομακρυσμένης Σύνδεσης"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7980,154 +7829,154 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Proxy άγνωστα αιτήματα στο Κατάστημα Kobo"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Εξωτερική Θύρα Διακομιστή (για κλήσεις API προωθημένες στη θύρα)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Χρήση Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Goodreads Κλειδί API"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Hardcover Sync"
 msgstr "Ενεργοποίηση συγχρονισμού Kobo"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "Η μάρκα έχει λήξει"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Goodreads Κλειδί API"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8135,417 +7984,417 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Να Επιτραπεί η Αναστροφή Επαλήθευσης Proxy"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Είδος σύνδεσης"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "Όνομα Διακομιστή Φιλοξενίας LDAP ή Διεύθυνση IP"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "Θύρα Διακομιστή LDAP"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "LDAP Αποκρυπτογράφηση"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "LDAP Επαλήθευση"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Απλό"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "LDAP Όνομα Χρήστη Διαχειριστή"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "LDAP Κωδικός Διαχειριστή"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "LDAP Χαρακτηριστικό Όνομα (ΧΟ)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "LDAP Αντικείμενο Φίλτρου Χρήστη"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "Είναι ο Διακομιστής LDAP OpenLDAP;"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr "Χρειάζονται οι Ακόλουθες Ρυθμίσεις για Εισαγωγη Χρήστη"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "Αντικείμενο Φίλτρου Ομάδας LDAP"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "LDAP Όνομα Ομάδας"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "LDAP Πεδίο Μελών Ομάδας"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr ""
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr ""
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Member User Filter"
 msgstr "LDAP Αντικείμενο Φίλτρου Χρήστη"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "Συγκέντρωση Μεταδεδομένων"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
 msgstr ""
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "Επεξεργασία Διαμόρφωσης UI"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "Η μάρκα δεν βρέθηκε"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "Σφάλμα σύνδεσης"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "OAuth Ρυθμίσεις"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Id"
 msgstr "%(provider)s OAuth Ταυτότητα Πελάτη"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Secret"
 msgstr "%(provider)s OAuth Μυστικό Πελάτη"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "Προβολή Διαμόρφωσης"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "Όνομα Χρήστη"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr ""
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "Ρυθμίσεις E-mail Διακομιστή"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr ""
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "LDAP Όνομα Ομάδας"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr ""
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Προκαθορισμένες Ρυθμίσεις για Νέους Χρήστες"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Να Επιτρέπεται το Κατέβασμα"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Να Επιτρέπεται η Προβολή eBook Viewer"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Να Επιτρέπεται το Ανέβασμα"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Να Επιτρέπεται η Επεξεργασία"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Να Επιτρέπεται η Διαγραφή Βιβλίων"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Να Επιτρέπεται η Αλλαγή Κωδικού"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Να Επιτρέπεται η Επεξεργασία Δημόσιων Ραφιών"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr ""
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Απόκτηση %(provider)s OAuth Διαπιστευτήρια"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "%(provider)s OAuth Ταυτότητα Πελάτη"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "%(provider)s OAuth Μυστικό Πελάτη"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Εξωτερικοί Δυαδικοί"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Path to Calibre Binaries"
 msgstr "Πορεία για το Μετατροπέα Calibre E-Book"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Calibre E-Book Converter Settings"
 msgstr "Calibre E-Book Ρυθμίσεις Μετατροπέα"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Πορεία για Μετατροπέα Kepubify E-Book"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "Τοποθεσία δυαδικού UnRar"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Security Settings"
 msgstr "OAuth Ρυθμίσεις"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8553,342 +8402,337 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr ""
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr ""
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr ""
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Session protection"
 msgstr "διάλεξε μια επιλογή"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr ""
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr ""
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "User Password policy"
 msgstr "Επαναφορά Κωδικού χρήστη"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr ""
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr ""
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Προβολή Διαμόρφωσης"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Αριθμός Τυχαίων Βιβλίων για Εμφάνιση"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr ""
 "Αριθμός Συγγραφέων για Εμφάνιση Πριν την Απόκρυψη (0=Απενεργοποίηση "
 "Απόκρυψης)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "Διαγραφή"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "caliBlur! Σκοτεινό θέμα"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Συνήθης Έφραση για  για να Αγνοηθούν Στήλες"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Σύνδεση Κατάστασης Διαβασμένο/Αδιάβαστο σε Στήλη Calibre"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "Σύνδεση Κατάστασης Διαβασμένο/Αδιάβαστο σε Στήλη Calibre"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Προβολή Περιορισμών με βάση τη στήλη Calibre"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Συνήθης Έκφραση για Ταξινόμηση Τίτλου"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Προβολή Διαμόρφωσης"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 msgid "Custom CSS"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Προκαθορισμένες Ρυθμίσεις για Νέους Χρήστες"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "Έκδοση"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Χρήστης Διαχειριστής"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "Σελίδα διαχειριστή"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Language"
 msgstr "Εξαίρεση Γλωσσών"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "Προκαθορισμένες Ρυθμίσεις για Νέους Χρήστες"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Visible Language of Books"
 msgstr "Γλώσσα Βιβλίων"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "Προκαθορισμένες Ορατότηες για Νέους Χρήστες"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Προκαθορισμένες Ορατότηες για Νέους Χρήστες"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Προβολή Τυχαίων Βιβλίων σε Προβολή Λεπτομερειών"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Προσθήκη ετικετών Επιτρέπεται/Απορρίπτεται"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Προσθήκη τιμών ειδικά κατασκευασμένων στηλών Επιτρέπεται/Απορρίπτεται"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Ανέβασμα"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "Αρχειοθετήθηκε"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "Κατέβασμα"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Έναρξη"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8897,14 +8741,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8912,95 +8756,94 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "Συγχώνευση επιλεγμένων βιβλίων"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "Σφάλμα Κατεβάσματος Φόντου"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "Δεν Βρέθηκαν Αποτελέσματα"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "Επιλογή ενός ονόματος χρήστη"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "Αναζήτηση Βιβλιοθήκης"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "Συγχώνευση επιλεγμένων βιβλίων"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "Σφάλμα Κατεβάσματος Φόντου"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Calibre-Web Φύλλο Καταγραφής:"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -9008,11 +8851,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -9023,11 +8866,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -9037,162 +8880,162 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "Αρχειοθετημένα Βιβλία"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9200,11 +9043,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9212,110 +9055,108 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "Τα μεταδεδομένα ενημερώθηκαν επιτυχώς"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Αναγνωριστικά"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "Ανακάλυψε"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
 "investigation."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9323,157 +9164,157 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "OAuth Ρυθμίσεις"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "Ρυθμίσεις"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "OAuth Ρυθμίσεις"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9481,102 +9322,101 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "OAuth Ρυθμίσεις"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9584,44 +9424,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Μετατροπή μορφής βιβλίου:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9629,875 +9469,863 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Ενεργοποίηση Δημόσιας Εγγραφής"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "OAuth Ρυθμίσεις"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Ενεργοποίηση Δημόσιας Εγγραφής"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Ενεργοποίηση Δημόσιας Εγγραφής"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Διαγραφή μορφών:"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Συγκέντρωση Μεταδεδομένων"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Αξιολόγηση"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Επόμενο"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Σήμανση ως Αδιάβαστο"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Σήμανση ως Διαβασμένο"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "Σήμανση ως Αδιάβαστο"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "Σήμανση ως Αδιάβαστο"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Προσθήκη στο αρχείο"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Επαναφορά από το αρχείο"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Επαναφορά από το αρχείο"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Προσθήκη στο αρχείο"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "Επαναφορά από το αρχείο"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "Αναζήτηση Βιβλιοθήκης"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "Ενημερώθηκαν οι ρυθμίσεις E-mail διακομιστή"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "Βαθμολογία Πάνω από"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr ""
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr ""
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Περιγραφή"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "Διεύθυνση E-mail Αποστολής στο Kindle"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "Διεύθυνση E-mail Αποστολής στο Kindle"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "Διαγραφή μορφών:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "Αποτυχία δημιουργίας πορείας για φόντο"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "Αποτυχία δημιουργίας πορείας για φόντο"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr ""
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "Προβολή Βιβλίων με Κορυφαία Αξιολόγηση"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "Συγχώνευση επιλεγμένων βιβλίων"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "Προηγούμενο"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "Συγχώνευση επιλεγμένων βιβλίων"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "Λεπτομέρειες Βιβλίου"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "επεξεργασία μεταδεδομένων"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "Συγχώνευση επιλεγμένων βιβλίων"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "Δεν Βρέθηκαν Αποτελέσματα"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr ""
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Διαγραφή μορφών:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be permanently deleted:"
 msgstr "Αυτό το βιβλίο θα διαγραφεί για πάντα από τη βάση δεδομένων"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "Βιβλία που δεν Διαβάστηκαν"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "Αυτό το βιβλίο θα διαγραφεί για πάντα από τη βάση δεδομένων"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "Αυτό το βιβλίο θα διαγραφεί για πάντα από τη βάση δεδομένων"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr ""
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr ""
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr ""
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Email Account Type"
 msgstr "Λογαριασμός"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Standard Email Account"
 msgstr "Λογαριασμός"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Gmail Account"
 msgstr "Λογαριασμός"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Setup Gmail Account"
 msgstr "Λογαριασμός"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr ""
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "SMTP Κωδικός"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Όριο Μεγέθους Επισύναψης"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Save and Send Test Email"
 msgstr "Αποθήκευση και Αποστολή E-mail Δοκιμής"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Επιτρεπόμενα Domains (Λευκή λίστα)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Προσθήκη Domain"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Όνομα domain"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Domains που Απορρίφθηκαν (Μαύρη λίστα)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10505,162 +10333,153 @@ msgstr ""
 "ʼΑνοιξε το .kobo/Kobo/Kobo eReader.conf αρχείο σε πρόγραμμα επεξεργασίας "
 "κειμένου και πρόσθεσε (ή κάνε επεξεργασία):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 #, fuzzy
 msgid "Kobo Token:"
 msgstr "Kobo Μονάδα Συγχρονισμού"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "Όρος Αναζήτησης:"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "Προβολή Βιβλίου σε Αποθήκευση"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "Φόρτωση..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "Αποτυχία δημιουργίας πορείας για φόντο"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr "Είσαι σίγουρος/η πως θέλεις να διαγράψεις αυτό το ράφι;"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "Αποτυχία δημιουργίας πορείας για φόντο"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
@@ -10669,422 +10488,421 @@ msgstr ""
 "Ο διακομιστής E-Mail δεν έχει διαμορφωθεί, παρακαλούμε επικοινώνησε με το "
 "διαχειριστή σου!"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Δημιουργία Θέματος"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Επιστροφή στην Κεντρική"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 #, fuzzy
 msgid "Logout User"
 msgstr "Αποσύνδεση"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "Επεξεργασία ενός ραφιού"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Show this shelf in your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "Προβολή Όλων"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "Δημόσιο Ράφι"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Προσθήκη στο ράφι"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Κεντρική"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Αλλαγή Θέσης Περιήγησης"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Αναζήτηση Βιβλιοθήκης"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Calibre-Web Κατάλογος eBook"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Αποσύνδεση"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "Ρυθμίσεις"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "Αναζήτηση Βιβλιοθήκης"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Δεν υπάρχουν διαθέσιμες πληροφορίες αποδέσμευσης"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Calibre-Web Κατάλογος eBook"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Παρακαλούμε μην ανανεώσεις τη σελίδα"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Προηγούμενο"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Λεπτομέρειες Βιβλίου"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Είσαι σίγουρος/η πως θέλεις να κάνεις κλείσιμο;"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Συγχώνευση επιλεγμένων βιβλίων"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Μορφή Ανεβάσματος"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Διαγραφή μορφών:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Δεν Βρέθηκαν Αποτελέσματα"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Κλιμάκωση στο Καλυτερο"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "Διαμόρφωση"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Προσθήκη στο ράφι"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Συγχώνευση επιλεγμένων βιβλίων"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Σήμανση ως Αδιάβαστο"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Σφάλμα σύνδεσης"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr ""
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr ""
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "SMTP Κωδικός"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Να με Θυμάσαι"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Ξέχασες τον Κωδικό;"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Σύνδεση με το Μαγικό Σύνδεσμο"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 #, fuzzy
 msgid "Log in with SSO"
 msgstr "Σύνδεση με το Μαγικό Σύνδεσμο"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Προβολή Φύλλου Καταγραφής Calibre-Web:"
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Calibre-Web Log: "
 msgstr "Προβολή Φύλλου Καταγραφής Calibre-Web:"
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Η ροή απόδοσης, δεν μπορεί να εμφανιστεί"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Προβολή Φύλλου Καταγραφής Πρόσβασης:"
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Download Calibre-Web Log"
 msgstr "Προβολή Φύλλου Καταγραφής Calibre-Web:"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Download Access Log"
 msgstr "Ενεργοποίηση Πρόσβασης Φύλλου Καταγραφής"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "Κοινοποίηση με Όλους"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Επιλογή Ετικετών Επιτρέπεται/Απορρίπτεται"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Επιλογή Τιμών Ειδικά Προσαρμοσμένης Στήλης Επιτρέπεται/Απορρίπτεται"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Επιλογή Ετικετών Χρήστη Επιτρέπεται/Απορρίπτεται"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr ""
 "Επιλογή Τιμών Χρήστη Ειδικά Προσαρμοσμένης Στήλης Επιτρέπεται/Απορρίπτεται"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Εισαγωγή Ετικέτας"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Προσθήκη Περιορισμού Προβολής"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "Αυτή η μορφή βιβλίου θα διαγραφεί για πάντα από τη βάση δεδομένων"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Αυτό το βιβλίο θα διαγραφεί για πάντα από τη βάση δεδομένων"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "και σκληρός δίσκος"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Σημαντική Σημείωση Kobo: τα διαγραμμένα βιβλία θα παραμείνουν σε οποιαδήποτε "
 "συνδεδεμένη συσκευή Kobo."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11092,977 +10910,973 @@ msgstr ""
 "Τα βιβλία πρέπει πρώτα να αρχειοθετηθούν και να συγχρονιστεί η συσκευή πριν "
 "μπορέσει να διαγραφεί με ασφάλεια το βιβλίο."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Choose File Location"
 msgstr "Προβολή επιλογών μορφής αρχείου"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "name"
 msgstr "Όνομα Χρήστη"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Parent Directory"
 msgstr "Ευρετήριο Βάσης Δεδομένων Calibre"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 #, fuzzy
 msgid "Ok"
 msgstr "Βιβλίο"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Calibre-Web Κατάλογος eBook"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 #, fuzzy
 msgid "epub Reader"
 msgstr "PDF πρόγραμμα ανάγνωσης"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 msgid "Annotations"
 msgstr ""
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 #, fuzzy
 msgid "Black"
 msgstr "Πίσω"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr ""
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Επόμενη Σελίδα"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr ""
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 #, fuzzy
 msgid "Default"
 msgstr "Διαγραφή"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr ""
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr ""
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 #, fuzzy
 msgid "KaiTi"
 msgstr "Αναμονή"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 #, fuzzy
 msgid "Arial"
 msgstr "Κάθετο"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 #, fuzzy
 msgid "Spread"
 msgstr "Διαβάστηκε"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr ""
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr ""
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Επανάληψη ροής κειμένου όταν οι μπάρες στο πλάι είναι ανοιχτές."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Comic Reader"
 msgstr "PDF πρόγραμμα ανάγνωσης"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Συντομεύσεις Πληκτρολογίου"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Προηγούμενη Σελίδα"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Επόμενη Σελίδα"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page Display"
 msgstr "Σελίδα διαχειριστή"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Κλιμάκωση στο Καλυτερο"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Κλιμάκωση σε Πλάτος"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Κλιμάκωση σε Ύψος"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Κλιμάκωση σε Τοπικό"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Περιστροφή Δεξιά"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Περιστροφή Αριστερά"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Γύρισμα Σελίδας"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page"
 msgstr "Σελίδα διαχειριστή"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr ""
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Κλίμακα"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Καλύτερο"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Πλάτος"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Ύψος"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Ντόπιο"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Περιστροφή"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Γύρισμα"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Οριζόντιο"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Κάθετο"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Direction"
 msgstr "Περιγραφή"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Αριστερά προς Δεξιά"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Δεξιά προς Αριστερά"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Reset to Top"
 msgstr "Επιστροφή στην Κεντρική"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Remember Position"
 msgstr "Να με Θυμάσαι"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr ""
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Show"
 msgstr "Προβολή Όλων"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 #, fuzzy
 msgid "DJVU Reader"
 msgstr "PDF πρόγραμμα ανάγνωσης"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 #, fuzzy
 msgid "PDF Reader"
 msgstr "PDF πρόγραμμα ανάγνωσης"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 #, fuzzy
 msgid "txt Reader"
 msgstr "PDF πρόγραμμα ανάγνωσης"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Εγγραφή Νέου Λογαριασμού"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Επιλογή ενός ονόματος χρήστη"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Η διεύθυνση email σου"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Μαγικός Σύνδεσμος - Εξουσιοδότηση Νέας Συσκευής"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "Σε μια άλλη συσκευή, σύνδεση και επίσκεψη:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "Με την επαλήθευση, θα συνδεθείτε αυτόματα σε αυτή τη συσκευή."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Αυτός ο σύνδεσμος επαλήθευσης θα λήξει σε 10 λεπτά."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr ""
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Δεν Βρέθηκαν Αποτελέσματα"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Όρος Αναζήτησης:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Αποτελέσματα για:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Ημερομηνία Έκδοσης Από"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Ημερομηνία Έκδοσης Μέχρι"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr ""
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Εξαίρεση Ετικετών"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Εξαίρεση Σειρών"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Exclude Shelves"
 msgstr "Εξαίρεση Σειρών"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Εξαίρεση Γλωσσών"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Επεκτάσεις"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Εξαίρεση Επεκτάσεων"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Βαθμολογία Πάνω από"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Βαθμολογία Κάτω από"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr ""
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr ""
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Διαγραφή αυτού του Ραφιού"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr ""
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Κρυμμένο Βιβλίο"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr ""
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr ""
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr ""
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Συγχώνευση επιλεγμένων βιβλίων"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Λογαριασμός"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Η μάρκα δεν βρέθηκε"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Διαγραφή αυτού του Ραφιού"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Προσθήκη στο ράφι"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Αναζήτηση Βιβλιοθήκης"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Αναζήτηση Βιβλιοθήκης"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Κοινοποίηση με Όλους"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr ""
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Δεν βρέθηκε χρήστης"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Κρυμμένο Βιβλίο"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Στατιστικά Βιβλιοθήκης"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Βιβλία σε αυτή τη Βιβλιοθήκη"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Συγγραφείς σε αυτή τη Βιβλιοθήκη"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Κατηγορίες σε αυτή τη Βιβλιοθήκη"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Σειρές σε αυτή τη Βιβλιοθήκη"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 #, fuzzy
 msgid "System Statistics"
 msgstr "Στατιστικά"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 #, fuzzy
 msgid "Program"
 msgstr "Πρόοδος"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Εγκατεστημένη Έκδοση"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Χρόνος Λειτουργίας"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr ""
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "Περιστροφή"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
 msgstr ""
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 msgid "Scheduled item cancelled successfully"
 msgstr ""
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Calibre-Web Κατάλογος eBook"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "Η διεύθυνση email σου"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "Ρυθμίσεις"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Επαναφορά Κωδικού χρήστη"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "Διαμόρφωση Διακομιστή"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "Διεύθυνση E-mail Αποστολής στο Kindle"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "Εισαγωγή Γλωσσών"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Γλώσσα Βιβλίων"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "Γλώσσα Βιβλίων"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "OAuth Ρυθμίσεις"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Σύνδεση"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Αποσύνδεση"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Kobo Μονάδα Συγχρονισμού"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Δημιουγία/Προβολή"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 msgid "Expose only books in selected shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "OAuth Ρυθμίσεις"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Προσθήκη Τιμών Ειδικά Προσαρμοσμένης Στήλης επιτρέπεται/Απορρίπτεται"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "Βιβλία που προστέθηκαν Πρόσφατα"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "Δημόσιο Ράφι"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Διαγραφή Χρήστη"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12070,171 +11884,171 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Να Επιτρέπεται η Αλλαγή Κωδικού"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Να Επιτρέπεται η Αλλαγή Κωδικού"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Δημιουγία/Προβολή"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Δημιουργία Kobo Auth URL"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr ""
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Αφαίρεση Επιλογών"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit User"
 msgstr "Χρήστης Διαχειριστής"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Username"
 msgstr "Επιλογή ενός ονόματος χρήστη"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Email"
 msgstr "Δοκιμαστικό e-mail"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email"
 msgstr "Διεύθυνση E-mail Αποστολής στο Kindle"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email"
 msgstr "Δοκιμαστικό e-mail"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "Διεύθυνση E-mail Αποστολής στο Kindle"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "Δοκιμαστικό e-mail"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Locale"
 msgstr "Κλίμακα"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Visible Book Languages"
 msgstr "Γλώσσα Βιβλίων"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Allowed Tags"
 msgstr "Επιλογή Ετικετών Επιτρέπεται/Απορρίπτεται"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Allowed Tags"
 msgstr "Επιλογή Ετικετών Επιτρέπεται/Απορρίπτεται"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Denied Tags"
 msgstr "Επιλογή Ετικετών Επιτρέπεται/Απορρίπτεται"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Denied Tags"
 msgstr "Επιλογή Ετικετών Επιτρέπεται/Απορρίπτεται"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Allowed Column Values"
 msgstr "Προσθήκη τιμών ειδικά κατασκευασμένων στηλών Επιτρέπεται/Απορρίπτεται"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Allowed Column Values"
 msgstr "Προσθήκη τιμών ειδικά κατασκευασμένων στηλών Επιτρέπεται/Απορρίπτεται"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Denied Column Values"
 msgstr "Προσθήκη τιμών ειδικά κατασκευασμένων στηλών Επιτρέπεται/Απορρίπτεται"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Denied Column Values"
 msgstr "Προσθήκη τιμών ειδικά κατασκευασμένων στηλών Επιτρέπεται/Απορρίπτεται"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Change Password"
 msgstr "Να Επιτρέπεται η Αλλαγή Κωδικού"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Public Shelves"
 msgstr "Δημόσιο Ράφι"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 msgid "Expose selected Shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Read/Unread Section"
 msgstr "Προβολή επιλογών σειράς"

--- a/cps/translations/es/LC_MESSAGES/messages.po
+++ b/cps/translations/es/LC_MESSAGES/messages.po
@@ -25,40 +25,40 @@ msgstr ""
 "X-Generator: Poedit 3.8\n"
 
 # "Last-Translator: victorhck <victorhck@mailbox.org>\n"
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Estadísticas"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 "Base de datos de Calibre no disponible. Vuelve a configurar la ruta de la "
 "biblioteca."
 
-#: cps/admin.py:208
+#: cps/admin.py
 msgid "Server restarted, please reload page."
 msgstr "Servidor reiniciado. Por favor, recargue la página."
 
-#: cps/admin.py:210
+#: cps/admin.py
 msgid "Performing Server shutdown, please close window."
 msgstr "El servidor se está apagando. Por favor, cierre la ventana."
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "¡Éxito! Base de datos reconectada"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Comando desconocido"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 "¡Éxito! Libros en cola para la copia de seguridad de metadatos, compruebe "
 "las tareas para ver el resultado"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
@@ -66,7 +66,7 @@ msgstr ""
 "Error: la sincronización con Hardcover está deshabilitada. Actívala en la "
 "Configuración básica o con HARDCOVER_SYNC_ENABLED."
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
@@ -74,47 +74,47 @@ msgstr ""
 "Error: No hay token de Hardcover disponible. Define la variable de entorno "
 "HARDCOVER_TOKEN o configúralo en Configuración básica."
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 "¡Éxito! Se inició la tarea de obtención automática de Hardcover. Revisa el "
 "panel de Tareas para ver el progreso."
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 "Error al iniciar la tarea de obtención automática de Hardcover: %(error)s"
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr "Revisar coincidencias de Hardcover"
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr "Error al cargar la cola de revisión: %(error)s"
 
-#: cps/admin.py:414
+#: cps/admin.py
 msgid "Hardcover ID applied successfully"
 msgstr "ID de Hardcover aplicado correctamente"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr "Coincidencia: %(action)s"
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr "No hay coincidencias pendientes para rechazar"
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr "Se rechazaron %(count)s coincidencia(s)"
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
@@ -122,119 +122,117 @@ msgstr ""
 "Se inició la actualización de la caché de miniaturas para {} libro(s). Esto "
 "puede tardar unos minutos."
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr "No se encontraron libros con portadas para procesar."
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr "No se pudo iniciar la actualización de miniaturas: {}"
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Página de administración"
 
-#: cps/admin.py:653
+#: cps/admin.py
 msgid "Hardcover token expires"
 msgstr "El token de Hardcover caduca"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Configuración básica"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Configuración de la Interfaz de Usuario"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 "Columna personalizada No.%(column)d no existe en la base de datos calibre"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Editar usuarios"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Todo"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Usuario no encontrado"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} usuarios borrados con éxito"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Mostrar todo"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Petición mal formulada"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "El Nombre de Invitado no se puede cambiar"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "El Invitado no puede tener ese rol"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr ""
 "No queda ningún otro usuario administrador, no se puede quitar el rol de "
 "administrador"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "Valor tiene que ser verdadero o falso"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Rol inválido"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "El invitado no puede tener esta vista"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "Vista no válida"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 "La Configuración Regional del Invitado se determina automáticamente y no se "
 "puede establecer"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "No se ha especificado una Configuración Regional válida"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "No se ha indicado un idioma válido para el libro"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Parámetro no encontrado"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "La configuración de la Base de Datos no es escribible"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
@@ -243,61 +241,61 @@ msgstr ""
 "biblioteca existente: los libros pueden mantener su orden anterior hasta que "
 "vuelvas a intentarlo o los edites."
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Columna de lectura no válida"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Columna restringida no válida"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr "Configuración de Calibre-Web NextGen actualizada"
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "¿Realmente quieres borrar el Token de Kobo?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "¿Realmente deseas borrar este dominio?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "¿Realmente quieres borrar este usuario?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "¿Realmente quieres borrar esta estantería?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr ""
 "¿Realmente quieres cambiar la Configuración Regional de los usuarios "
 "seleccionados?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "¿Realmente quieres cambiar los idiomas visibles del libro de los usuarios "
 "seleccionados?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 "¿Realmente quieres cambiar el rol seleccionado del usuario seleccionado?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
 msgstr ""
 "¿Realmente quieres cambiar las restricciones de los usuarios seleccionados?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -305,25 +303,25 @@ msgstr ""
 "¿Realmente quieres cambiar las restricciones de visibilidad de los usuarios "
 "seleccionados?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "¿Realmente quieres cambiar el comportamiento de sincronización de estantería "
 "del usuario seleccionado?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
 msgstr ""
 "¿Seguro que quieres cambiar la exposición en OPDS de la estantería para el "
 "usuario o usuarios seleccionados?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "¿Realmente quieres cambiar la ubicación de la biblioteca Calibre?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
@@ -331,7 +329,7 @@ msgstr ""
 "Calibre-Web NextGen buscará portadas actualizadas y actualizará las "
 "miniaturas de portada; esto puede tardar un rato. ¿Continuar?"
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
@@ -339,29 +337,25 @@ msgstr ""
 "¿Seguro que quieres borrar la base de datos de sincronización de Calibre-Web "
 "NextGen para forzar una sincronización completa con tu lector Kobo?"
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Denegar"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Permitir"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "Se han borrado {} entradas de sincronización"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, python-brace-format
 msgid "Book {} not found"
 msgstr "Libro {} no encontrado"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
@@ -370,7 +364,7 @@ msgstr ""
 "Se ha borrado el estado de sincronización del libro {0} (usuario {1}); el "
 "dispositivo recibirá de nuevo el libro en la próxima sincronización"
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
@@ -380,75 +374,74 @@ msgstr ""
 "actualizó last_modified para que el dispositivo lo reciba en la próxima "
 "sincronización"
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Etiqueta no encontrada"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Acción no válida"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json no está configurado para la aplicación web"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "La ruta del Logfile no es válida. Por favor, introduce la ruta correcta"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "La ruta del Access Logfile no es válida. Por favor, introduce la ruta "
 "correcta"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 "Por favor, introduce un proveedor LDAP, Puerto, DN y el User Object "
 "Identifier"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Por favor, introduce una Cuenta de Servicio LDAP y su Contraseña"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "Por favor, introduce una Cuenta de Servicio LDAP"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "LDAP Group Object Filter necesita tener un identificador de formato \"%s\""
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "El LDAP Group Object Filter tiene un paréntesis no coincidentes"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "LDAP User Object Filter necesita tener un identificador de formato \"%s\""
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "El LDAP User Object Filter tiene un paréntesis no coincidentes"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "El filtro de usuarios LDAP necesita tener un identificador de formato \"%s\""
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "El filtro de usuarios LDAP  tiene paréntesis no coincidentes"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -456,29 +449,24 @@ msgstr ""
 "Ubicaciones del certificado de la CA del LDAP, el certificado o de la llave "
 "no válidos. Por favor, introduce la ruta correcta"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Añadir nuevo usuario"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Cambiar parámetros de correo"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "¡Éxito! Cuenta de Gmail verificada."
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "¡Ups! Error en la base de datos: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -486,52 +474,52 @@ msgstr ""
 "Correo electrónico de prueba en cola para enviar a %(email)s. Compruebe las "
 "tareas para ver el resultado"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Ocurrió un error enviando el correo electrónico de prueba: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Por favor, configure su correo electrónico primero..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Ajustes del servidor de correo electrónico actualizados"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 msgid "Email Your Users"
 msgstr "Enviar correo a tus usuarios"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr ""
 "Configura primero el servidor de correo en Editar configuración del servidor "
 "de correo."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr "Introduce un asunto para el correo electrónico del anuncio."
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 "Introduce el cuerpo del mensaje para el correo electrónico del anuncio."
 
-#: cps/admin.py:2060
+#: cps/admin.py
 msgid "Please set an email address on your own account first..."
 msgstr "Configura primero una dirección de correo en tu propia cuenta..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 msgid "Please select at least one recipient."
 msgstr "Selecciona al menos un destinatario."
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr "No hay destinatarios válidos: no se envió nada."
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -539,7 +527,7 @@ msgstr ""
 "Correo electrónico de prueba de anuncio en cola para %(email)s: comprueba "
 "las tareas para ver el resultado."
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -548,167 +536,165 @@ msgstr ""
 "Correo electrónico de anuncio en cola para %(num)s destinatario(s): "
 "comprueba las tareas para ver la entrega."
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 "Se omitieron %(num)s dirección(es) por ser inválidas o estar duplicadas."
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "Editar  configuración de Tareas Programadas"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "Hora de inicio no válida para la tarea especificada"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "Duración no válida para la tarea especificada"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "Configuración de tareas programadas actualizada"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr ""
 "¡Ups! Ha ocurrido un error desconocido. Por favor, vuelva a intentarlo más "
 "tarde."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 msgid "title"
 msgstr "título"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Editar Usuario %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "¡Exito! Contraseña para el usuario %(user)s reinicializada"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr ""
 "¡Ups! Configura primero la configuración del servidor de correo SMTP..."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Visor del archivo de log"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Solicitando paquete de actualización"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Descargando paquete de actualización"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Descomprimiendo paquete de actualización"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Remplazando archivos"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Las conexiones con la Base de Datos están cerradas"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Deteniendo el servidor"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Actualización finalizada. Por favor, pulse OK y recargue la página"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Falló la actualización:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "Error HTTP"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Error de conexión"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Tiempo agotado mientras se trataba de establecer la conexión"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Error general"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr ""
 "La actualización del archivo no pudo guardarse en el directorio temporal"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "No se pudieron reemplazar los archivos durante la actualización"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "No se ha podido extraer al menos un usuario LDAP"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "No se ha podido crear al menos un usuario LDAP"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Error: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Error: el servidor LDAP no ha devuelto ningún usuario"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "No se ha encontrado al menos un usuario LDAP en la base de datos"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} Usuario importado con éxito"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr "La ruta de los libros no es válida"
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "La ruta de la Base de Datos no es válida. Por favor, introduce la ruta "
 "correcta"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "La Base de Datos no es escribible"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "La ruta del Keyfile no es válida. Por favor, introduce la ruta correcta"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "La ruta de Certfile no es válida. Por favor, introduce la ruta correcta"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
@@ -716,12 +702,12 @@ msgstr ""
 "La creación automática de usuarios no se puede habilitar sin habilitar la "
 "autenticación mediante proxy inverso"
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 "Auto-crear usuarios requiere un nombre de cabecera válido de proxy inverso"
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
@@ -729,7 +715,7 @@ msgstr ""
 "Formato de host de redirección OAuth no válido. Incluye la URL completa con "
 "protocolo (p. ej., https://tu-dominio.com)."
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
@@ -737,11 +723,11 @@ msgstr ""
 "El host de redirección OAuth no debe incluir una ruta. Usa solo la URL base "
 "(p. ej., https://tu-dominio.com)."
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr "La longitud de la contraseña debe estar entre 1 y 40 caracteres"
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
@@ -749,65 +735,65 @@ msgstr ""
 "La conversión a KEPUB no se puso en cola. Comprueba que la preferencia y la "
 "ruta de Kepubify estén activadas."
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "Configuración de la Base de Datos actualizada"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "Configuración de la Base de Datos"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "¡Ups! Por favor, rellena todos los campos."
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "El correo electrónico no tiene un dominio válido"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Añadir un nuevo usuario"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Usuario '%(user)s' creado"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr ""
 "¡Ups! Existe una cuenta para este correo electrónico o nombre de usuario."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Usuario '%(nick)s' borrado"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "No puedes borrar al Usuario Invitado"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "No queda ningún usuario administrador, no se puede borrar al usuario"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "El correo electrónico no puede estar vacío y debe ser válido"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Usuario '%(nick)s'  actualizado"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr "Conexión correcta! OIDC discovery endpoint es accesible.%(endpoints)s"
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
@@ -815,12 +801,12 @@ msgstr ""
 "Conexión fallida: OIDC discovery endpoint no encontrados (404). Revisa si la "
 "URL base es correcta."
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr "Error de conexión: el servidor devolvió el código de estado %(code)s"
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
@@ -828,14 +814,14 @@ msgstr ""
 "Error de conexión: no se pudo conectar al servidor. Comprueba la URL y la "
 "conectividad de red."
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 "Error de conexión: se agotó el tiempo de espera de la solicitud. Puede que "
 "el servidor esté lento o no sea accesible."
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
@@ -843,12 +829,12 @@ msgstr ""
 "Error de conexión: el servidor devolvió un JSON no válido. Puede que esto no "
 "sea un endpoint OIDC."
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Error de conexión: %(error)s"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
@@ -857,31 +843,31 @@ msgstr ""
 "A los metadatos les faltan campos obligatorios de OIDC: %(fields)s. Puede "
 "que esto no sea un endpoint de metadatos OIDC válido."
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 "¡La URL de metadatos es válida! Se han encontrado %(count)s endpoints de "
 "OAuth."
 
-#: cps/admin.py:3322
+#: cps/admin.py
 msgid " User info endpoint is available."
 msgstr " Hay un endpoint de información de usuario disponible."
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 " Nota: Endpoint de Información de Usuario no encontrado - esto puede causar "
 "errores de autenticación."
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 "URL de Metadatos no encontrada (404). Por favor revisa que la URL sea "
 "correcta."
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
@@ -889,50 +875,50 @@ msgstr ""
 "Error de conexión: no se pudo conectar a la URL de metadatos. Comprueba la "
 "URL y la conectividad de red."
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr "Error de conexión: tiempo de espera de la solicitud agotado."
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr "Error de conexión: JSON no válido en la respuesta."
 
-#: cps/admin.py:3340
+#: cps/admin.py
 msgid "An unknown error occurred."
 msgstr "Ha ocurrido un error desconocido."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 msgid "Restore already in progress."
 msgstr "Ya hay una restauración en curso."
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 "Restauración fallida: La ruta de la biblioteca de Calibre no está "
 "configurada."
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr "Restauración fallida: metadata.db no encontrado en %(path)s"
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr "Restauración fallida: app.db no encontrado en %(path)s"
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Error al restaurar: %(err)s"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 "Restauración completada pero la limpieza de app.db ha fallado. Ver logs para "
 "más detalles."
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
@@ -941,199 +927,198 @@ msgstr ""
 "Restauración completa. Logs de Copia de Seguridad y Restauración guardado en "
 "%(dir)s. Todos los libros linkados fueron restablecidos."
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr "Importar anotaciones de Kobo"
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 msgid "No file uploaded."
 msgstr "No se ha subido ningún archivo."
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr "El archivo supera los %(max)d MB."
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr "El archivo subido no es una base de datos SQLite."
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr "Anotaciones: %(title)s"
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr "Checo"
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr "Alemán"
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr "Griego"
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr "Español"
 
-#: cps/constants.py:265
+#: cps/constants.py
 msgid "Finnish"
 msgstr "Finlandés"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr "Francés"
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr "Gallego"
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr "Indonesio"
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr "Italiano"
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr "Japonés"
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr "Camboyano"
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr "Coreano"
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr "Neerlandés"
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr "Noruego"
 
-#: cps/constants.py:276
+#: cps/constants.py
 msgid "Polish"
 msgstr "Polaco"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr "Portugués (Brasil)"
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr "Ruso"
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr "Eslovaco"
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr "Sueco"
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr "Turco"
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr "Vietnamita"
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr "Chino (Simplificado, China)"
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr "Chino (Tradicional, Taiwán)"
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "no instalado"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Faltan permisos de ejecución"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr "Volver a editar metadatos"
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr "Volver al libro"
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, python-format
 msgid "Change cover — %(title)s"
 msgstr "Cambiar portada — %(title)s"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr "La portada de este libro está bloqueada. Desbloquéala primero."
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr "Proporciona una URL de portada."
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr "Este libro no tiene una portada incrustada que se pueda extraer."
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 msgid "Unknown cover source."
 msgstr "Fuente de portada desconocida."
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr "No se pudo guardar el estado de bloqueo."
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr "Solo se pueden previsualizar URLs http(s)."
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr "No se pudo generar la vista previa del eReader."
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr "No se pudo cargar una imagen de origen para previsualizar."
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr "No se pudo guardar la portada."
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr "El cambio de tema está deshabilitado temporalmente hasta v5.0.0"
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
@@ -1141,273 +1126,264 @@ msgstr ""
 "Actualización de la biblioteca 🔄 Comprobando si hay algún libro que se haya "
 "pasado por alto, por favor, espere..."
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 "Expresión cron no válida para los escaneos de duplicados. Los cambios no se "
 "guardaron."
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr "Configuración de usuario de Calibre-Web NextGen"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr "Marca de tiempo"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Book ID"
 msgstr "ID"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Título"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Book Author"
 msgstr "Autor"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr "Tipo de disparador"
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Filepath"
 msgstr "Ruta de archivo"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Filename"
 msgstr "Nombre del archivo"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr "¿Manual?"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr "N.º Correcciones"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr "¿Se ha hecho una copia de seguridad del original?"
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr "Correcciones Aplicadas"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr "Formato original"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "End Format"
 msgstr "Formato final"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 msgid "Unknown User"
 msgstr "Usuario desconocido"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr "Estadísticas y actividad de Calibre-Web NextGen"
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr "Calibre-Web NextGen - Historial completo de aplicación de reglas"
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 "Calibre-Web NextGen - Historial completo de aplicación de reglas (con rutas)"
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr "Calibre-Web NextGen - Historial completo de importaciones"
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr "Calibre-Web NextGen - Historial completo de conversiones"
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 "Calibre-Web NextGen - Historial completo del corrector de EPUB (sin rutas ni "
 "correcciones)"
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 "Calibre-Web NextGen - Historial completo del corrector de EPUB (con rutas y "
 "correcciones)"
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 "✅ ¡Todos los servicios de monitorización están funcionando correctamente! 👍"
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 "🔴 El servicio de importación está funcionando, pero el detector de cambios "
 "en los metadatos no"
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 "🔴 El detector de cambios de metadatos está funcionando, pero el servicio de "
 "importación no"
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 "⛔ Ni el servicio de importación ni el detector de cambios en los metadatos "
 "están en funcionamiento"
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr "Ha ocurrido un error"
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr "Calibre-Web NextGen - Convertir biblioteca"
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr "Calibre-Web NextGen - Servicio de corrección de EPUB"
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 "La herramienta Single-book EPUB Fixer no es compatible con las bibliotecas "
 "de Google Drive."
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 msgid "Invalid book selection."
 msgstr "Selección de libro no válida."
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr "Libro no encontrado."
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 msgid "Selected book has no EPUB format."
 msgstr "El libro seleccionado no tiene formato EPUB."
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 msgid "EPUB file not found on disk."
 msgstr "Archivo EPUB no encontrado en disco."
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 msgid "EPUB Fixer started for selected book."
 msgstr "Corrector de EPUB iniciado para el libro seleccionado."
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr "No se pudo iniciar EPUB Fixer para el libro seleccionado."
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr "Calibre-Web NextGen - Aplicación de portada y metadatos"
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr "Ya hay una ejecución de aplicación en curso."
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr "No se pudo iniciar la ejecución de aplicación."
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr "Debes ser un administrador para acceder a esta página."
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr "Se requieren tanto el nombre de usuario como los datos de la imagen."
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr "Formato de datos de imagen no válido. Debe ser una imagen válida."
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr "Tipo de imagen no compatible. Solo se permiten PNG y JPEG."
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr "La imagen es demasiado grande. Usa una imagen de menos de 500 KB."
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr "Datos de imagen Base64 no válidos."
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 msgid "Invalid image data format."
 msgstr "Formato de datos de imagen no válido."
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr "Error al validar los datos de la imagen."
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr "Imagen de perfil actualizada correctamente."
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr "Gestión de foto de perfil de Calibre-Web NextGen (en desarrollo)"
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Ninguno"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 msgid "Duplicate Books"
 msgstr "Libros Duplicados"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr "El grupo de duplicados ya se ha descartado"
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 msgid "Duplicate group dismissed"
 msgstr "Grupo de duplicados descartado"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 msgid "Duplicate group restored"
 msgstr "Grupo de duplicados restaurado"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr "No se ha descartado el grupo de duplicados"
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 msgid "Duplicate scan queued"
 msgstr "Escaneo de duplicados en cola"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr "Escaneo de duplicados completado (modo alternativo)."
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 msgid "Invalid resolution strategy"
 msgstr "Estrategia de resolución no válida"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
@@ -1415,96 +1391,93 @@ msgstr ""
 "La carpeta de ingesta no tiene permisos de escritura. Compruebe los permisos "
 "del volumen /cwa-book-ingest."
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr "ID del libro faltante o no válido para la carga del formato"
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr "No se puede subir el formato: el libro ya no existe en la biblioteca"
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Carga completada, procesando, por favor espere..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 msgid "Failed to queue upload for processing"
 msgstr "No se pudo poner en cola la carga para su procesamiento"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Falta el formato de origen o destino para la conversión"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "Libro puesto a la cola para su conversión a %(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Ocurrió un error al convertir este libro: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "No se permite subir archivos de este tipo a este servidor"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr ""
 "No se permite subir archivos con la extensión '%(ext)s' a este servidor"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "El archivo a subir debe tener una extensión"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 "¡Ups! El libro seleccionado no está disponible. El archivo no existe o no es "
 "accesible"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "El usuario no tiene derecho a subir portadas"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 "La portada está bloqueada. Desbloquéala primero en la página del selector de "
 "portadas."
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 "Los identificadores no distinguen entre mayúsculas y minúsculas, "
 "sobrescribiendo el identificador antiguo"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "'%(langname)s' no es un idioma válido"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Metadatos actualizados con éxito"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "Error al editar el libro: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1512,75 +1485,75 @@ msgstr ""
 "El libro cargado probablemente existe en la biblioteca, considera cambiarlo "
 "antes de subirlo de nuevo: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "El archivo %(filename)s no pudo guardarse en el directorio temporal"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Fallo al mover el archivo de portada %(file)s: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Formato de libro borrado con éxito"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Libro borrado con éxito"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "No tienes permisos para borrar libros"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "editar metadatos"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "Índice de la serie: %(seriesindex)s no es un número válido, omitiendo"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr "El usuario no tiene derecho a subir formatos de archivo adicionales"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Fallo al crear la ruta %(path)s (Permiso Denegado)"
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Fallo al guardar el archivo %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Archivo con formato %(ext)s añadido a %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 msgid "Book not found"
 msgstr "Libro no encontrado"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr "El libro no tiene formatos de archivo en disco desde los que recargar"
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "Archivo del libro no encontrado en disco: %(path)s"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr "No se pudieron analizar los metadatos del archivo %(format)s: %(err)s"
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
@@ -1588,23 +1561,23 @@ msgstr ""
 "No se pudo renombrar la carpeta del libro para que coincida con los "
 "metadatos recargados: %(err)s"
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr "No se pudieron guardar los metadatos recargados: %(err)s"
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr "Se recargaron %(n)d campo(s) desde el archivo %(fmt)s en disco"
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 "Los metadatos en disco coinciden con los actuales: no se actualizó ningún "
 "campo"
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1612,7 +1585,7 @@ msgstr ""
 "La configuración de Google Drive no se ha completado, intente desactivar y "
 "activar Google Drive nuevamente"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1620,89 +1593,88 @@ msgstr ""
 "El dominio Callback no se ha verificado, siga los pasos para verificarlo en "
 "la consola de desarrollador de Google"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr "Este correo electrónico se ha enviado a través de Calibre-Web NextGen."
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr "Correo electrónico de anuncio para %(email)s"
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "%(format)s formato no encontrado para el ID del libro: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(format)s no encontrado en Google Drive: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s no encontrado: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "Enviar al eReader"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "Se agotó el tiempo de conversión para el libro con ID: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "Error de conversión para el libro con ID: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr "Correo electrónico de prueba de Calibre-Web NextGen"
 
-#: cps/helper.py:387
+#: cps/helper.py
 msgid "Test Email"
 msgstr "Comprobar correo electrónico"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr "Primeros pasos con Calibre-Web NextGen"
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Correo electrónico de registro para el usuario: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Convertir %(orig)s a %(format)s y enviar al eReader"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Enviado %(format)s al eReader"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s enviado al eReader"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr ""
 "El archivo solicitado no puede ser leído. ¿Quizás existen problemas con los "
 "permisos?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "No se pudo establecer el estado de lectura: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
@@ -1710,12 +1682,12 @@ msgstr ""
 "Fallo al intentar borrar la carpeta del libro %(id)s, la ruta tiene "
 "subcarpetas: %(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "Error al borrar el libro %(id)s: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1724,7 +1696,7 @@ msgstr ""
 "Borrando el libro %(id)s solo de la base de datos; la ruta del libro no es "
 "válida: %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
@@ -1732,101 +1704,101 @@ msgstr ""
 "Renombrar el autor de: '%(src)s' a '%(dest)s' ha fallado con el error: "
 "%(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Archivo %(file)s no encontrado en Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Renombrar el  título de: '%(src)s' a '%(dest)s' ha fallado con el error: "
 "%(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "La ruta %(path)s del libro no fue encontrada en Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr ""
 "Se ha encontrado una cuenta existente para esta dirección de correo "
 "electrónico"
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Este nombre de usuario ya está en uso"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr "Formato de la dirección de correo no válido"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr "La contraseña no cumple con las reglas de validación de contraseñas"
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 "El módulo Python 'advocate' no está instalado, pero es necesario para subir "
 "portadas"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Error al descargar la portada"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr "La imagen de portada supera el tamaño máximo de %(size)s MB"
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr "El archivo de la portada no es una imágen válida o no se pudo guardar"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Error en el formato de la portada"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
 msgstr ""
 "No se permite acceder a localhost ni a la red local para subir portadas"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Error al crear una ruta para la portada"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "Sólo se admiten como portada los archivos jpg/jpeg/png/webp/bmp"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "Contenido del archivo de portada no válido"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Sólo se admiten los archivos jpg/jpeg como portada"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr "Portada"
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "No se encuentra el archivo binario UnRar"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr "Error ejecutando UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
@@ -1835,37 +1807,37 @@ msgstr ""
 "Arquitectura no compatible detectada: %(arch)s. Calibre-Web NextGen está "
 "optimizado para x86_64 y aarch64."
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr "No se pudo encontrar el directorio especificado"
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr "Por favor, especifique un directorio, no un archivo"
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr "Los binarios de Calibre no son viables"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr "Faltan binarios de calibre: %(missing)s"
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Faltan permisos de ejecución: %(missing)s"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr "Error ejecutando Calibre"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr "Poner en cola todos los libros para la copia de seguridad de metadatos"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
@@ -1873,36 +1845,36 @@ msgstr ""
 "Accede a Calibre-Web NextGen desde una dirección distinta de localhost para "
 "obtener un api_endpoint válido para el dispositivo Kobo"
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Configuración de Kobo"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr "Añadidos recientemente"
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr "Mejor valorados"
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr "Leyendo actualmente"
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr "Pendientes de leer"
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr "Publicaciones recientes"
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Registrado con %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
@@ -1912,13 +1884,13 @@ msgstr ""
 "una discrepancia en la configuración de los scopes. Revisa la configuración "
 "de scopes de OAuth o contacta con tu administrador."
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 "Error de inicio de sesión: el token OAuth ha caducado. Intenta iniciar "
 "sesión de nuevo."
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
@@ -1927,7 +1899,7 @@ msgstr ""
 "usuario del proveedor OAuth. Inténtalo de nuevo o contacta con el "
 "administrador."
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
@@ -1935,7 +1907,7 @@ msgstr ""
 "Inicio de sesión fallido: El proveedor OAuth devolvió datos de perfil de "
 "usuario no válidos. Contacta con el administrador."
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1946,39 +1918,39 @@ msgstr ""
 "campos obligatorios: %(fields)s. Revisa tu configuración de OAuth o contacta "
 "con tu administrador."
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr "Fallida para link OAuth cuenta. Por favor intenta de nuevo."
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 "Error al iniciar sesión: tu cuenta no tiene permiso para acceder a esta "
 "aplicación."
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 "OAuth error: Proveedor returned no válido usuario information. Por favor "
 "intenta de nuevo."
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr "Esta cuenta de %(oauth)s ya está vinculada a otro usuario"
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "¡Éxito! Has iniciado sesión como: %(nickname)s"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Enlazado a %(oauth)s con éxito"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1989,58 +1961,58 @@ msgstr ""
 "cuenta de %(provider)s. Contacta con tu administrador para crear una cuenta "
 "o vincular tu cuenta existente."
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 "OAuth autenticación fallida. Por favor intenta de nuevo o contact "
 "administrator."
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 msgid "OAuth system error. Please contact administrator."
 msgstr "Error del sistema OAuth. Contacta con el administrador."
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "Desenlazado a %(oauth)s con éxito"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Desenlazar a %(oauth)s fallido"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "No enlazado con %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Error al iniciar sesión con GitHub."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Error al obtener la información del usuario de GitHub."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Error al iniciar sesión con Google."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Error al obtener información del usuario de Google."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 msgid "Failed to log in with Generic OAuth."
 msgstr "No se ha podido iniciar sesión con OAuth genérico."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 "OAuth autenticación fallida: Token validation error. Por favor intenta de "
 "nuevo."
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
@@ -2048,7 +2020,7 @@ msgstr ""
 "La autenticación OAuth falló debido a un error inesperado. Contacta con el "
 "administrador."
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
@@ -2058,204 +2030,197 @@ msgstr ""
 "repetidamente, configura el ajuste 'OAuth Redirect Host' en Admin > Basic "
 "Configuration > OAuth."
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "Error en GitHub Oauth. Por favor, vuelva a intentarlo más tarde."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "Error GitHub Oauth: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Error en Google Oauth. Por favor, vuelva a intentarlo más tarde."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Error Google Oauth: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr "Error de Oauth: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "Libros Alfabéticos"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "Libros ordenados alfabéticamente"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Libros Populares"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "Publicaciones populares de este catálogo basadas en las Descargas."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Libros Mejor Valorados"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Publicaciones populares del catálogo basados en la Valoración."
 
-#: cps/opds.py:182
+#: cps/opds.py
 msgid "Recently added Books"
 msgstr "Libros añadidos recientemente"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Los últimos Libros"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Libros al Azar"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Mostrar Libros al Azar"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Libros Leídos"
 
-#: cps/opds.py:201
+#: cps/opds.py
 msgid "Books currently being read"
 msgstr "Libros que se están leyendo actualmente"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Libros No Leídos"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Autores"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Libros ordenados por autor"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Editores"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Libros ordenados por editor"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Categorías"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Libros ordenados por categorías"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Series"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Libros ordenados por series"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Idiomas"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Libros ordenados por Idioma"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Valoraciones"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Libros ordenados por Valoración"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Formatos de archivo"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Libros ordenados por formato de archivo"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Estanterías"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "Libros organizados en estanterías"
 
-#: cps/opds.py:260
+#: cps/opds.py
 msgid "Magic Shelves"
 msgstr "Estanterías mágicas"
 
-#: cps/opds.py:261
+#: cps/opds.py
 msgid "Books organized in magic shelves"
 msgstr "Libros organizados en estanterías mágicas"
 
-#: cps/opds.py:317
+#: cps/opds.py
 msgid "description"
 msgstr "descripción"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} Estrellas"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Buscar"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Inicio de sesión"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Token no encontrado"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "El token ha expirado"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "¡Éxito! Por favor regrese a su dispositivo"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
@@ -2264,109 +2229,108 @@ msgstr ""
 "ejecutar comprobaciones rápidas de duplicados tras importaciones y cambios "
 "de metadatos. "
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Libros"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Mostrar libros recientes"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Mostrar Libros Populares"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Libros Descargados"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Mostrar Libros Descargados"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Mostrar libros mejor valorados"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 msgid "Show Read and Unread"
 msgstr "Mostrar Leídos y No Leídos"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Mostrar No Leídos"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Descubrir"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Category Section"
 msgstr "Mostrar Sección de Categorías"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Series Section"
 msgstr "Mostrar Sección de Series"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Author Section"
 msgstr "Mostrar Sección de Autores"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Publisher Section"
 msgstr "Mostrar Sección de Editores"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Language Section"
 msgstr "Mostrar Sección de Idiomas"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Ratings Section"
 msgstr "Mostrar Sección de Valoraciones"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show File Formats Section"
 msgstr "Mostrar Sección de Formatos de Archivo"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Libros Archivados"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Archived Books"
 msgstr "Mostrar Libros Archivados"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr "Favoritos"
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr "Mostrar favoritos"
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Lista de Libros"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Mostrar Lista de Libros"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr "Duplicados"
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 msgid "Show Duplicate Books"
 msgstr "Mostrar Libros Duplicados"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr "Calibre-Web NextGen %(latest)s está disponible; tienes la %(current)s."
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
@@ -2375,396 +2339,395 @@ msgstr ""
 "Ayuda a mejorar las traducciones al %(language)s de Calibre-Web NextGen: aún "
 "quedan %(count)s cadenas por traducir en tu idioma."
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Publicado después de "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Publicado antes de "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Valoración <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Valoración >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Estado de Lectura = '%(status)s'"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 "Error al buscar columnas personalizadas; reinicia Calibre-Web.Error en la "
 "búsqueda de columnas personalizadas. Por favor, reinicia Calibre-Web"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Búsqueda avanzada"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Estantería especificada no válida"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "Lo sentimos, no tiene permisos para añadir un libro a esa estantería"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "El libro ya forma parte de la estantería: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 "%(book_id)s es un identificador de libro no válido. No se ha podido añadir a "
 "la estantería"
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "El libro fue añadido a la estantería: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "No tienes permiso para añadir un libro a la estantería"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Los libros ya forman parte de la estantería: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "Los libros han sido añadidos a la estantería: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "No se pudieron añadir libros a la estantería: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 msgid "Invalid series specified"
 msgstr "Serie especificada no válida"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "No hay libros visibles de la serie: %(name)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr ""
 "Todos los libros de la serie «%(name)s» ya están en la estantería: %(sname)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr ""
 "%(count)d libros de la serie «%(name)s» añadidos a la estantería: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "El libro fue quitado de la estantería: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "Lo siento, no tienes permiso para remover un libro de esta estantería"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Crear una Estantería"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Lo siento, no tienes permiso para editar esta estantería"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Editar una estantería"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "Error al borrar la estantería"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "Estantería borrada con éxito"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Cambiar orden de la estantería: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "Lo siento, no tienes permisos para crear una estantería pública"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Estantería %(title)s creada"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Estantería %(title)s cambiada"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Ha ocurrido un error"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "Ya existe una estantería pública con el nombre '%(title)s'."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "Ya existe una estantería privada con el nombre '%(title)s'."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Estantería: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Error al abrir una estantería. La estantería no existe o no es accesible"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr "Modo de orden no válido: %(mode)s"
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr "Payload no válido: 'order' debe ser una lista"
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr "No se pudo guardar el orden"
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 msgid "Reorder Shelves"
 msgstr "Reordenar estanterías"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr "Nombre (A → Z)"
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr "Nombre (Z → A)"
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr "Cantidad de libros (de más a menos)"
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr "Cantidad de libros (de menos a más)"
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr "Creado (más reciente → más antiguo)"
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr "Creado (más antiguo → más reciente)"
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr "Modificado (más reciente → más antiguo)"
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr "Modificado (más antiguo → más reciente)"
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr "Manual (arrastra abajo)"
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr "Leer ahora"
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr "Abrir detalles de {title}"
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr "Leer {title}"
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr "Estándar (usuario / contraseña)"
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr "LDAP"
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr "OAuth / OpenID Connect"
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Anónimo"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "No autenticado"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr "Simple (cuenta de servicio)"
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr "Orden de la serie"
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr "Orden de la serie (inverso)"
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr "Añadir etiqueta"
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr "Nueva etiqueta"
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr "Quitar etiqueta"
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr "Quitar etiqueta {name}"
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr "Renombrar etiqueta {name}"
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr "Nombre de la etiqueta"
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr "El nombre de la etiqueta no puede estar vacío"
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr "Guardar nombre de la etiqueta"
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr "Seleccionar formato"
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr "No se pudo renombrar la etiqueta"
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr "Etiqueta renombrada a {name}"
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr "Debes haber iniciado sesión"
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr "No tienes permiso para editar metadatos"
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr "Ya existe una etiqueta con ese nombre"
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr "El nombre de la etiqueta debe ser texto"
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr "El nombre de la etiqueta no puede contener comas"
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr "Introduce un nombre de etiqueta válido"
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr "No se pudo cargar esta página"
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr "Página no encontrada"
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr "Quitar valoración"
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr "Sin valorar"
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Sí"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "No"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr "Cuerpo del mensaje de correo electrónico"
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr "Valorado con {rating} de 5"
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr "Más de {name}"
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
@@ -2773,143 +2736,141 @@ msgstr ""
 "¿Combinar {n} libros en el primero seleccionado? Los demás se borrarán "
 "después de copiar sus formatos."
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr "Aplicar a {n} libros"
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr "Condición de coincidencia"
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr "Campo de la regla"
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr "Operador de la regla"
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr "No se pudieron cargar las reglas de la estantería inteligente."
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr "Tiene portada"
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr "Índice de la serie"
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Leer estado"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr "Tiene ID de Hardcover"
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr "En los últimos N días"
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr "No en los últimos N días"
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr "es antes de / menor que"
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr "es en o antes de / como mucho"
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr "es después de / mayor que"
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr "es en o después de / como mínimo"
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr "está entre"
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr "no está entre"
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr "no empieza por"
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr "no termina en"
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr "está vacío"
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr "no está vacío"
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr "Apariencia"
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Tema"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr "Sistema"
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Claro"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Oscuro"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "Sepia"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr "Alto contraste"
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr "Medianoche (AMOLED)"
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr "Coincide con el ajuste claro u oscuro de tu dispositivo"
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr "Tema guardado."
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr "No se pudo guardar el tema."
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr "Tema predeterminado para cuentas nuevas"
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
@@ -2917,169 +2878,159 @@ msgstr ""
 "Se aplica a las cuentas creadas a partir de ahora. Cada usuario elige el "
 "suyo en Cuenta → Tema."
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr "Añadir un formato"
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr "Añadir regla"
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Añadir a la estantería"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr "Añade el tuyo"
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr "Etiqueta de la contraseña de aplicación"
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr "Contraseñas de aplicación"
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Autor"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr "Autores (separados por &)"
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr "Volver a iniciar sesión"
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr "Azul"
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr "Contenido del libro"
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Navegar"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr "Cambiar contraseña"
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Cerrar"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr "Cerrar menú"
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr "Contenidos"
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr "Error al convertir."
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr "Convertir a"
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr "Convertir a formato"
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr "Copiar"
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr "No se pudo cambiar la contraseña."
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr "No se pudo crear."
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr "No se pudo obtener la portada."
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr "No se pudieron cargar los metadatos."
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr "No se pudo cargar el archivo del libro ({status})"
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr "No se pudo cargar tu cuenta."
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr "No se pudo guardar."
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr "URL de la imagen de portada"
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr "Error al actualizar la portada."
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr "Portada actualizada."
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr "Crear estantería inteligente"
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr "Crea tu cuenta"
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr "Tema oscuro"
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Borrar"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr "Borrar libro"
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
@@ -3088,488 +3039,481 @@ msgstr ""
 "¿Borrar «{title}»? Esto elimina permanentemente el libro y todos sus "
 "archivos de tu biblioteca. Esta acción no se puede deshacer."
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr "Borrando…"
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr "No se pudo borrar este libro."
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 "¿Borrar el archivo {fmt}? El libro se conserva; solo se borra este formato."
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr "Borrar {fmt}"
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr "¿Borrar {n} libro(s)? Esta acción no se puede deshacer."
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr "La descripción contiene"
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr "Deseleccionar {title}"
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr "Editar metadatos"
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr "Editar {title}"
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr "Mostrando tu vista de biblioteca predeterminada."
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr "Mostrar todos los libros"
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr "Editar vista predeterminada"
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr "Error al cargar los libros."
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr "Error al abrir el libro."
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr "Generar"
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr "Verde"
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr "Ayuda"
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr "Color de resaltado"
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr "Importar desde Kobo"
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr "Idioma de la interfaz"
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr "Usuario o contraseña incorrectos."
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr "Fuente del cuerpo de la interfaz"
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr "Fuente de visualización de la interfaz"
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr "Predeterminada (Optima / Sans-Serif)"
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr "Predeterminada (Serif tipo libro)"
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr "Sans-Serif del sistema"
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr "Serif tipo libro"
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr "Monoespaciada"
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr "Etiqueta (p. ej. KOReader en el teléfono)"
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr "Idiomas (separados por comas)"
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr "Tema claro"
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr "Error al iniciar sesión."
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr "Marcar como leído"
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr "Marcar como no leído"
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Fusionar"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr "Metadatos aplicados a {n} libro(s)."
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 "Nueva contraseña para «{label}»; cópiala ahora, no volverá a mostrarse:"
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr "Las contraseñas nuevas no coinciden."
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr "No hay libros aquí."
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr "Sin resultados para «{q}»."
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr "Sin sugerencias"
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr "No hay libros {filter} aquí."
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr "Contraseña cambiada."
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr "Pegar URL"
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr "Estantería privada"
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr "Perfil"
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr "Perfil guardado."
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr "Estantería pública"
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Editor"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr "Editoriales (separadas por comas)"
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Leído"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr "Progreso de lectura"
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr "Rojo"
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr "Error en el registro."
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr "Quitar {name}"
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr "Error en la solicitud."
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr "Restablecer"
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr "Restablece tu contraseña"
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr "Revocar {label}"
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr "Guardar cambios"
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr "Error al guardar."
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr "Guardar perfil"
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr "Guardado."
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr "Guardando…"
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr "Error en la búsqueda."
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr "Buscar metadatos"
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr "Proveedores de metadatos"
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr "Cargando proveedores…"
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr "No se pudieron cargar los proveedores."
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr "No se pudo actualizar el proveedor."
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr "{provider}: {state}"
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr "Activado"
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr "Desactivado"
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr "Resultados de la búsqueda"
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr "Buscar en la biblioteca"
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr "Seleccionar {title}"
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr "Tema sepia"
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr "Posición {n} en la serie"
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr "{series} n.º {n}"
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr "Error al iniciar sesión. Inténtalo de nuevo."
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr "Saltar al contenido"
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr "Algunos campos no se pudieron guardar."
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr "Tabla de contenidos"
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr "Etiquetas (separadas por comas)"
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Título"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr "No leído"
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr "Actualizar contraseña"
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Subir"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr "Elegir libros para subir"
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr "Error al subir."
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr "Subir imagen"
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr "Subiendo…"
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr "Amarillo"
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr "p. ej. MOBI"
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr "Lector de {format}"
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr "Clave de API de {name}"
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr "{n} libro(s) añadido(s) a la estantería."
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr "{n} libro(s) borrado(s)."
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr "{n} marcado(s) como leído(s)."
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr "{n} marcado(s) como no leído(s)."
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr "{n} seleccionado(s)"
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr "{pct}% leído"
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr "Novedades"
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr "Ayuda — nuevas actualizaciones disponibles"
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 "Las últimas funciones y correcciones de Calibre-Web NextGen, de más reciente "
 "a más antigua."
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr "{n} actualización"
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr "{n} actualizaciones"
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 "Aún no hay notas de la versión; vuelve a comprobarlo después de la próxima "
 "actualización."
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
@@ -3577,251 +3521,248 @@ msgstr ""
 "La interfaz está traducida a tu idioma; estas notas de actualización están "
 "escritas en inglés."
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr "Lectura"
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr "Vista de cuadrícula"
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr "Biblioteca"
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr "Vista de lista"
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr "Sincronizar"
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Cuenta"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Administrador"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr "Bajo el capó"
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr "Abrir tu biblioteca"
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr "Explorar etiquetas"
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr "Abrir la vista de tabla"
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr "Revisar duplicados"
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr "Abrir tus estanterías"
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr "Gestionar sincronización y contraseñas de aplicación"
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr "Comprobar la dirección de tu eReader"
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr "Crear una contraseña de aplicación"
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr "Explorar series"
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr "Explorar autores"
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr "Explorar idiomas"
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr "Abrir vista de tabla"
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr "Abrir Administración"
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr "Abrir configuración de la cuenta"
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr "Explorar Descubrir"
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr "Explorar tu biblioteca"
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr "Ir a Subir"
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr "Abrir búsqueda"
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr "Ediciones"
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr "Volver a la nueva interfaz"
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr "Volver a los resultados"
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr "No se han encontrado ediciones para este libro."
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr "Ver todos los detalles"
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr "Detalles del resultado"
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Publicado"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr "Formato"
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Origen"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr "Personalizar"
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr "Personalizar barra lateral"
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr "Personalizar navegación"
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr "Hecho"
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr "Restablecer valores predeterminados"
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr "Mostrado siempre"
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 "Editando la barra lateral. Reordena u oculta secciones y luego pulsa Hecho."
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr "Edición cancelada."
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 "Arrastra para reordenar. Pulsa ✕ para ocultar una sección. Las teclas de "
 "flecha mueven el elemento enfocado."
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr "Barra lateral guardada."
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr "Barra lateral restablecida a los valores predeterminados."
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr "{label} movido a la posición {pos} de {total}"
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 "Reordenar {label} (posición {pos} de {total}). Usa las teclas de flecha para "
 "mover."
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr "Borrar {label}"
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr "Restaurar {label}"
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr "{label} oculto"
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr "{label} restaurado"
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr "No se pudo guardar la barra lateral. Inténtalo de nuevo."
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr "Actualizar biblioteca"
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr "<"
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr "="
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ">"
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
@@ -3829,42 +3770,41 @@ msgstr ""
 "Se necesita un escaneo completo único de duplicados. Ejecútalo desde la "
 "configuración de CWA y vuelve aquí."
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr "Fecha de adición"
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr "¿Borrar «{name}»? Se quitará de {count} libro, que se conservará."
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr "¿Borrar «{name}»? Se quitará de {count} libros, que se conservarán."
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr "Descartar mensaje de apoyo a Ko-fi"
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr "Descartar aviso de ayuda"
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr "Abrir Ko-fi →"
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr "Fecha de publicación"
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr "¡Apóyanos en Ko-fi!"
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
@@ -3872,90 +3812,90 @@ msgstr ""
 "Estos abren las páginas de configuración completas. Los cambios allí se "
 "aplican a todo el servidor."
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr "«{name}» ya existe en {count} libro. ¿Fusionar esta etiqueta con ella?"
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 "«{name}» ya existe en {count} libros. ¿Fusionar esta etiqueta con ella?"
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr "empieza por"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr "contiene"
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr "no contiene"
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr "termina en"
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr "en los últimos N días"
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr "no es"
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr "es"
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr "no en los últimos N días"
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr "en o después de"
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr "en o antes de"
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr "≤"
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr "≥"
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr "(cambiar portada)"
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr "2:3 (portada de editorial: sin relleno para portadas típicas)"
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr "3:4 (genérico)"
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 "Ya hay un escaneo de duplicados en curso. Esta lista se actualizará cuando "
 "termine."
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr "Una selección aleatoria de tu biblioteca"
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
@@ -3963,173 +3903,169 @@ msgstr ""
 "Se necesita un escaneo completo único de duplicados. Usa «Buscar duplicados» "
 "arriba para ejecutarlo."
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr "Claves de API"
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "Acerca de"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr "Configuración de la cuenta"
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr "Cuenta: {name}"
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr "Añadir identificador"
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr "Añadir a favoritos"
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr "Grupo de administración"
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr "Búsqueda avanzada"
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr "Todas las estanterías"
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr "Permitir inicio de sesión remoto (enlace mágico)"
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr "Grupos permitidos (separados por comas)"
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr "Cualquiera"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr "Cualquier formato"
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr "Cualquier idioma"
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr "Cualquier serie"
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr "Cualquier etiqueta"
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr "Aplicar seleccionados"
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 "Aplicar a todos los seleccionados (solo cambian los campos rellenados; "
 "sustituye los valores existentes):"
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr "Aplicando…"
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr "Archivar"
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Archivado"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr "Preguntar en Discord"
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr "Autenticación"
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr "Autenticación y seguridad"
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr "Autor A-Z"
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr "Autor Z-A"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr "Autorizado; iniciando sesión…"
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr "URL de autorización"
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr "Crear usuarios automáticamente"
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr "Crear usuarios automáticamente al iniciar sesión por primera vez"
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr "Volver a la biblioteca"
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr "Volver a la vista clásica"
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr "DN base"
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr "Configuración básica"
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr "Predeterminado del libro"
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr "Densidad de libros"
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr "Libro {number}"
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr "Libros por página"
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
@@ -4138,489 +4074,475 @@ msgstr ""
 "del dispositivo en su siguiente sincronización. Siguen estando en tu "
 "biblioteca aquí."
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr "Proveedores integrados (déjalo en blanco para desactivar):"
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr "Acciones masivas"
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr "Ruta del certificado CA"
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr "Configuración de CWA (ingesta/conversión)"
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr "Puede subir libros"
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr "Cancelar cambio de nombre"
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr "Cancelar edición del título"
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr "Cancelar {task}"
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr "Ruta del archivo de certificado"
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr "Ruta del certificado"
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr "Cambiar portada"
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr "Comprobando…"
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr "Elegir una portada"
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr "Elegir una imagen de portada para subir"
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr "Elegir una imagen…"
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr "Elegir campos"
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr "Elige tu tema"
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr "Quitar valor predeterminado"
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr "Quitar selección"
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr "ID de cliente"
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr "Secreto de cliente"
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr "Secreto de cliente (déjalo en blanco para mantenerlo)"
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr "Cerrar lector"
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr "Columnas"
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr "Cómoda"
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr "Compacta"
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr "Configurado"
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr "Confirmar borrado de la etiqueta {name}"
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr "Confirmar nueva contraseña"
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "Convertir"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr "Convertir antes de enviar"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr "Convertir desde"
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr "Copiado al portapapeles"
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr "Copiar enlace"
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr "No se pudo crear la estantería."
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr "No se pudo crear la estantería."
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr "No se pudo borrar la estantería."
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr "No se pudo borrar la etiqueta"
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr "No se pudieron cargar los candidatos."
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr "No se pudieron cargar los duplicados."
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr "No se pudieron cargar los subrayados."
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr "No se pudieron cargar las estadísticas."
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr "No se pudieron cargar las tareas."
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr "No se pudo cargar este archivo de texto."
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr "No se pudieron cargar los usuarios."
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr "No se pudo leer este archivo de cómic."
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr "No se pudieron recargar los metadatos"
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr "No se pudo renombrar la estantería."
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr "No se pudo restablecer la contraseña."
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr "No se pudo guardar el orden."
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr "No se pudo guardar la configuración del lector."
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr "No se pudo guardar el filtro de biblioteca predeterminado."
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr "No se pudo guardar la estantería."
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr "No se pudo guardar el título."
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr "No se pudo guardar tu posición de lectura."
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr "No se pudo iniciar el escaneo de duplicados."
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr "No se pudo actualizar la estantería."
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr "No se pudo actualizar la configuración de tu cuenta."
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr "No se pudo iniciar un enlace mágico. Inténtalo de nuevo."
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr "Portada bloqueada"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr "Portada no accesible"
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr "Portada actualizada a partir del resultado seleccionado."
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr "Crear"
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr "Crear cuenta"
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr "Crear una cuenta"
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr "Error al crear."
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr "Crear estantería y añadir libro"
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr "Crear usuario"
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr "{name} creado."
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr "Creando…"
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr "Actual"
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr "Portada actual"
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr "Contraseña actual"
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr "Leyendo actualmente"
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr "Color de borde personalizado"
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr "Columnas personalizadas"
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr "Ruta de la base de datos y la biblioteca"
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr "Fecha de añadido"
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr "Predeterminada (Sans-Serif del sistema)"
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr "Idioma predeterminado del libro"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr "Idioma predeterminado de la interfaz"
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr "Filtro de biblioteca predeterminado eliminado."
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr "Filtro de biblioteca predeterminado guardado."
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr "Roles predeterminados para nuevos usuarios de OAuth:"
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 "Los valores predeterminados están en Administración → Configuración → "
 "Sincronización con Kobo."
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr "Borrar libros"
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr "Error al borrar."
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr "¿Borrar la estantería «{name}»? Esta acción no se puede deshacer."
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr "Borrar etiqueta {name}"
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr "¿Borrar esta estantería inteligente? Tus libros no se ven afectados."
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 "¿Borrar al usuario «{name}»? También se borran sus estanterías y datos de "
 "lectura."
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr "Borrar {name}"
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr "Etiqueta {name} borrada"
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr "{name} borrado."
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr "Densa"
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Descripción"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr "Desactivar el inicio de sesión estándar con contraseña"
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr "Selección de Descubrir actualizada."
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr "Descubrir - Selección aleatoria"
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr "Descartar"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr "Descartar este grupo"
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr "Documentación"
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr "Reordenación terminada"
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Descargar"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr "Suelta los archivos aquí, o haz clic para elegirlos"
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr "Libros duplicados"
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr "Configuración de detección de duplicados"
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
@@ -4628,289 +4550,285 @@ msgstr ""
 "Escaneo de duplicados iniciado. Se ejecuta en segundo plano; esta lista se "
 "actualizará cuando termine."
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr "Vista previa en eReader"
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr "Cada tipo (isbn, amazon, google, doi…) puede aparecer una vez."
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr "Desenfoque de borde: borde bokeh suave"
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr "Espejo de borde: extiende la ilustración (recomendado)"
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Editar"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr "Editar estanterías públicas"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr "Editar estantería inteligente"
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr "Editar título de {title}"
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "Correo electrónico"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr "Servidor de correo (SMTP)"
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr "Correo electrónico (opcional)"
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr "Claim de correo electrónico"
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr "Enviarme un restablecimiento por correo"
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr "Configuración de correo guardada."
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Activar la sincronización con Kobo"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Encriptado"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr "Caduca en"
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr "Exponer solo las estanterías seleccionadas a través de OPDS"
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr "Error al cargar las estanterías."
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr "Error al cargar."
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr "Favorito"
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr "Marcado como favorito"
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr "Obtener"
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr "Obtener metadatos de la web"
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr "Archivos"
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 "Los archivos se ponen en cola para el proceso de ingesta de la biblioteca y "
 "aparecen una vez importados."
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr "Estilo de relleno"
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr "Filtrar {items}"
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr "Filtrar {items}…"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr "Familia tipográfica"
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr "Tamaño de fuente"
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr "¿Olvidaste tu contraseña?"
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr "Formato en cola; aparecerá una vez procesado."
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr "Formatos"
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr "Formatos — excluir"
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr "Formatos — incluir"
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr "Dirección de origen"
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr "Tabla completa de usuarios y restricciones"
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr "Generar un enlace nuevo"
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr "Ponle un nombre a tu estantería inteligente."
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr "Ir a tu biblioteca"
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr "Degradado: transición superior/inferior ajustada a la paleta"
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr "Claim de grupo"
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr "Campo de miembros del grupo"
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr "Nombre del grupo"
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr "Filtro de objeto de grupo"
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr "Se permite HTML y se sanea al mostrarlo."
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr "Nombre de la cabecera"
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr "Ayuda y soporte"
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr "Menú de ayuda"
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr "Oculto"
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "Ocultar"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr "Ocultar la sección Descubrir"
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr "Ocultar campos"
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr "Ocultar contraseña"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr "Subrayado"
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr "Subrayados"
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr "Popular"
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr "Popular — Más descargados"
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr "Icono"
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr "Tipo de identificador"
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr "Valor del identificador"
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Identificadores"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr "Importado como"
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr "En tu libro"
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
@@ -4918,338 +4836,337 @@ msgstr ""
 "La lectura en el navegador admite EPUB por ahora. Usa la descarga o el "
 "lector clásico para otros formatos."
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr "Emisor / URL base"
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr "Puede que se haya movido, o que siga estando en la interfaz clásica."
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr "Progreso de KOReader"
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr "Ruta del archivo de clave"
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr "Ruta de la clave"
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr "Kobo Libra Color / Libra 2 (1264×1680)"
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr "Sincronización con Kobo activada"
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Idioma"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr "Idiomas — incluir"
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr "Última modificación"
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr "Última sincronización"
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr "Configuración de la biblioteca"
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr "Altura de línea"
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr "Cargar más"
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr "Cargando"
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr "Cargando nueva selección de Descubrir."
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr "Cargando…"
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr "Bloquear portada"
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr "Texto del botón de inicio de sesión"
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr "Método de inicio de sesión"
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr "Iniciar sesión con"
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr "Registros"
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr "Se ve bien"
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr "Baja resolución"
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr "Enlace mágico"
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr "Código QR del enlace mágico"
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr "Hacer privada"
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr "Hacer pública"
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr "Hacer esta mi vista de biblioteca predeterminada"
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr "Gestionar el rol de administrador desde el grupo de OAuth"
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr "Gestionar estanterías"
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr "Marcar como leído"
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr "Marcar como no leído"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr "Coincidencia"
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr "Máx"
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr "Máximo de autores mostrados"
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr "Valoración máxima"
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr "Filtro de usuarios miembros"
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr "Fusionar en {name}"
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr "Fusionado en {name}"
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr "URL de metadatos (autodescubrimiento OIDC)"
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr "Mín"
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr "Valoración mínima"
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 "Más opciones de portada (proveedores de búsqueda, vista previa en eReader)"
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr "Más configuración del servidor"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr "Bajar"
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr "Subir"
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr "Mi cuenta"
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr "Nombre"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr "¿Necesitas informar de un problema? Prueba la nueva"
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr "Nuevo"
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr "Contraseña nueva"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr "Nombre de la estantería nueva"
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr "Nombre de la estantería nueva…"
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr "Nueva estantería…"
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr "Nueva estantería inteligente"
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr "Usuario nuevo"
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr "Más recientes"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr "Publicación más reciente"
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr "Página siguiente"
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr "Ningún libro coincide con esta estantería inteligente por ahora."
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr "Ningún libro coincide con esos criterios."
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr "Aún no se han encontrado candidatos. Prueba otra búsqueda o actualiza."
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr "No se ha encontrado contenido."
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr "No se han encontrado grupos de duplicados."
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr "Sin etiquetas excluidas"
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 "Aún no hay subrayados. Subraya mientras lees, o impórtalos desde un "
 "dispositivo Kobo."
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr "No hay {items} que coincidan con «{query}»."
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr "No se han encontrado páginas en este cómic."
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr "Aún no hay estanterías; crea una debajo."
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 "Aún no hay estanterías. Crea una arriba para empezar a coleccionar libros."
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr "Ninguna fuente necesita una clave."
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr "No hay tareas en ejecución."
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr "Aún no hay {items}."
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr "No configurado"
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr "Sin definir"
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr "Más antiguos"
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr "Publicación más antigua"
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
@@ -5257,56 +5174,56 @@ msgstr ""
 "En otro dispositivo donde ya hayas iniciado sesión, escanea este código o "
 "abre el enlace de abajo para autorizar este dispositivo."
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr "Abrir cuenta"
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr "Abrir lector clásico"
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr "Abrir navegación"
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr "Abrir lector"
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr "Abrir la interfaz clásica"
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr "Abre el enlace de abajo en tu dispositivo con sesión iniciada."
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr "Servidor OpenLDAP"
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr "Se abre en la vista clásica"
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr "Lector de PDF"
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr "Márgenes de página"
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr "Tema de la página"
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr "Página {number}"
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
@@ -5314,17 +5231,16 @@ msgstr ""
 "Las páginas marcadas abajo se abren en la vista clásica. Los cambios allí se "
 "aplican a todo el servidor."
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Contraseña"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr "Contraseña (déjala en blanco para mantenerla)"
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
@@ -5332,160 +5248,155 @@ msgstr ""
 "Elige una portada de cualquier fuente compatible, pega una URL, sube un "
 "archivo o usa la portada incrustada en el propio libro."
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 "Elemento tomado: {label}. Arrastra para reordenar, suelta para colocarlo."
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Puerto"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr "Preparando tu enlace mágico…"
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr "Página anterior"
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Progreso"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr "Pública"
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr "Publicado después de"
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr "Publicado antes de"
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr "Libros aleatorios mostrados"
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Valoración"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr "Valoración (estrellas)"
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr "Estado de lectura"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr "Filtro de estado de lectura"
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr "Configuración del lector guardada."
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr "Apariencia de lectura"
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr "Destinatario(s)"
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr "Host de redirección (URL completa)"
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr "Actualizar"
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr "Registrando…"
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr "Recargar"
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr "Recargar metadatos desde el disco"
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr "Recargando…"
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr "Recordarme"
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr "Quitar de favoritos"
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr "Quitar de la estantería"
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr "Quitar subrayado"
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr "Quitar identificador"
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr "Quitar regla"
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr "Renombrar"
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr "Reordenar"
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr "¿Sustituir la portada por esta?"
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr "¿Sustituir portada?"
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr "Informar de un problema en Discord"
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr "Informar de un problema en GitHub"
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr "Requerir pertenencia a un grupo"
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr "Restablecer contraseña de {name}"
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
@@ -5494,374 +5405,372 @@ msgstr ""
 "¿Restablecer la contraseña de {name}? Su contraseña actual dejará de "
 "funcionar y se le enviará una nueva por correo."
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr "Inicio de sesión con cabecera de proxy inverso"
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr "Filas por carga"
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr "Tiempo de ejecución"
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr "Servidor SMTP"
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Guardar"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr "Guardar configuración de correo"
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr "Guardar nombre"
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr "Guardar configuración de seguridad"
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr "Guardar configuración"
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 "Guardado. Reinicia el servidor para que los cambios de inicio de sesión "
 "surtan efecto."
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr "Buscar duplicados"
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr "Tareas programadas"
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr "Ámbitos (scopes)"
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr "Buscar título, autor…"
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr "Buscando en todas las fuentes…"
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr "Buscando…"
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr "Configuración de seguridad guardada."
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr "Comprueba cómo se ve cada portada con relleno para tu dispositivo"
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "Seleccionar"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr "Seleccionar varios"
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr "Enviar"
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr "Error al enviar."
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr "Enviar a eReader"
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr "Correo de envío a eReader"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr "Enviando…"
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr "Índice de la serie"
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr "Vista de series"
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr "Series — incluir"
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr "Servir por HTTPS"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr "SSL / HTTPS del servidor"
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr "Anuncio del servidor (visible para todos los usuarios)"
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr "Host del servidor"
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr "Cuenta de servicio (DN)"
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr "Contraseña de servicio"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr "Contraseña de servicio (déjala en blanco para mantenerla)"
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 "Define una URL de metadatos para autocompletar los endpoints de abajo, o "
 "introdúcelos manualmente."
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr "Configuración guardada."
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr "Nombre de la estantería"
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr "Estantería no encontrada."
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr "Mostrar la sección Descubrir"
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr "Mostrar los botones «Leer ahora» y «Editar»"
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr "Mostrar vista de tabla"
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr "Mostrar las {count} etiquetas"
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr "Mostrar todos los {items}"
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr "Mostrar libros en el idioma"
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr "Mostrar vistas previas en eReader en cada candidato"
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr "Mostrar menos etiquetas"
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr "Mostrar libros ocultos"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr "Mostrar contraseña"
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr "Aleatorizar selección"
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr "Iniciar sesión con un enlace mágico"
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr "Cerrar sesión"
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr "Iniciando sesión…"
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr "Título del sitio"
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr "Estantería inteligente no encontrada."
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr "Estanterías inteligentes"
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr "Sólido: color medio de la portada"
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr "Sólido: color personalizado"
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr "Sólido: color más frecuente de la portada"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr "Algunas fuentes necesitan una clave para obtener mejores portadas"
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr "Algo salió mal"
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr "Algo salió mal. Inténtalo de nuevo."
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr "Orden de clasificación"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr "Detalles de la fuente"
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr "Empezado a leer"
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr "Iniciando escaneo…"
 
 # "Last-Translator: victorhck <victorhck@mailbox.org>\n"
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr "Panel de estadísticas"
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Estado"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr "Apoyar en Ko-fi →"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr "Sincronizar solo mis estanterías seleccionadas"
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr "Sincronizar solo las estanterías seleccionadas con Kobo"
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr "Vista de tabla"
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr "Etiqueta"
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr "Etiquetas — excluir"
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr "Etiquetas — incluir"
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr "Relación de aspecto objetivo"
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Tarea"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Tareas"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr "Detalles técnicos"
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr "Esa URL no es una imagen utilizable."
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr "Este formato se abre en el lector a pantalla completa."
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 "Este enlace mágico ha caducado. Genera uno nuevo para volver a intentarlo."
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr "Esta página no existe aquí."
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
@@ -5869,78 +5778,77 @@ msgstr ""
 "Esta página tuvo un error y no se pudo mostrar. Tu biblioteca está bien; "
 "normalmente basta con recargar."
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 "Esta estantería está vacía. Añade libros desde la página de cualquier libro."
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr "Título A-Z"
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr "Título Z-A"
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr "Título, autor o ISBN"
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr "URL del token"
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr "Mejor valorados"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr "Confiar en la cabecera de autenticación"
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr "Configuración de interfaz / visualización"
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr "Desarchivar"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr "Mostrar de nuevo"
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr "Desbloquea la portada de arriba para aplicar una nueva."
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr "Desbloquea la portada para cambiarla"
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr "Sin título"
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr "Error al actualizar."
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr "Subir como portada"
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr "Subir libros"
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 "La subida de archivos no está disponible para tu cuenta en este servidor."
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
@@ -5948,70 +5856,67 @@ msgstr ""
 "Úsalas para conectar lectores OPDS o la sincronización de KOReader sin tu "
 "contraseña principal."
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr "Usar esta portada"
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Usuario"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr "Administración de usuarios"
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr "Filtro de objeto de usuario"
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr "URL de información de usuario"
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr "Claim de nombre de usuario"
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr "Versiones"
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Vista"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr "Configuración de la vista"
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr "Visor"
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr "Esperando tu autorización…"
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 "Cuando está bloqueada, la obtención de metadatos no sobrescribirá esta "
 "portada."
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr "Cuándo se sincronizó por primera vez el progreso de lectura"
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
@@ -6021,190 +5926,189 @@ msgstr ""
 "marcar esta estantería no hace nada por sí solo. Cambia tu cuenta a "
 "sincronización solo por estanterías para que surta efecto."
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr "Tu biblioteca"
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr "Tu navegador no puede reproducir este formato de audio."
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr "Tu biblioteca digital personal"
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 "Se muestra tu dirección de eReader guardada; cámbiala solo para este envío."
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr "todas las reglas"
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr "cualquier regla"
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr "libros"
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr "libros coinciden"
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr "copias"
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr "eReader"
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr "p. ej. Ciencia ficción sin leer"
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr "Asunto del correo al eReader"
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr "compartido"
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr "hasta"
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr "tipo (isbn, amazon, doi…)"
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr "valor"
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr "tú"
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr "{count} libro"
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr "{count} libros"
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr "{count} archivo en cola para importar"
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr "{count} archivo rechazado"
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr "{count} archivos en cola para importar"
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr "{count} archivos rechazados"
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr "{count} resultado"
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr "{count} resultados"
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr "{count} resultados para «{query}»"
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr "{field} (separado por comas)"
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr "{n} encontrado(s)"
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr "{ok} de {total} fuentes respondieron"
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr "…o pega una URL de imagen"
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr "← Volver al libro"
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr "← Volver a iniciar sesión"
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr "← Biblioteca"
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Esperando"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Fallido"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Comenzado"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Terminado"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "Finalizado"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Estado desconocido"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Dato inesperado mientras se leía la información de actualización"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr ""
 "Actualización no disponible. Ya tienes instalada la versión más reciente"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6212,16 +6116,16 @@ msgstr ""
 "Una nueva actualización está disponible. Haz clic en el botón de abajo para "
 "actualizar a la versión más reciente."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "No se puede conseguir información sobre la actualización"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr ""
 "Haz clic en el botón de abajo para actualizar a la última versión estable."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6230,104 +6134,104 @@ msgstr ""
 "Hay una nueva actualización disponible. Haz clic en el botón de abajo para "
 "actualizar a la versión: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "No hay información del lanzamiento disponible"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Descubrir (Libros al Azar)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Libros Populares (Los Más Descargados)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "Libros descargados por %(user)s"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Autor/es: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Editor/es: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Series: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "Valoración: Ninguna"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Valoración: %(rating)s estrellas"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Formato del archivo: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Categoría : %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Idioma: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 msgid "Favorite Books"
 msgstr "Libros favoritos"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 msgid "Hidden Books"
 msgstr "Libros ocultos"
 
-#: cps/web.py:1193
+#: cps/web.py
 msgid "Error loading magic shelf"
 msgstr "Error al cargar la estantería mágica"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr "Estantería mágica&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr "No se proporcionaron reglas"
 
-#: cps/web.py:1400
+#: cps/web.py
 msgid "Invalid rules format"
 msgstr "Formato de reglas no válido"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr "Error al procesar las reglas"
 
-#: cps/web.py:1426
+#: cps/web.py
 msgid "Invalid request"
 msgstr "Petición inválida"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr "El nombre y las reglas son obligatorios"
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr "El nombre de la estantería es demasiado largo (máximo 100 caracteres)."
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
@@ -6336,47 +6240,47 @@ msgstr ""
 "globalmente: esta estantería no llegará a tu Kobo hasta que se active "
 "«Sincronizar estanterías mágicas con Kobo» en la configuración de CWA."
 
-#: cps/web.py:1521
+#: cps/web.py
 msgid "Error creating shelf"
 msgstr "Error al crear la estantería"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 msgid "Create Magic Shelf"
 msgstr "Crear una Magic Shelf"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr "Permiso denegado para cambiar el estado público"
 
-#: cps/web.py:1587
+#: cps/web.py
 msgid "Shelf name is required"
 msgstr "El nombre de la estantería es obligatorio"
 
-#: cps/web.py:1647
+#: cps/web.py
 msgid "Error updating shelf"
 msgstr "Error al actualizar la librería"
 
-#: cps/web.py:1652
+#: cps/web.py
 msgid "Edit Magic Shelf"
 msgstr "Editar Magic Shelf"
 
-#: cps/web.py:1668
+#: cps/web.py
 msgid "Shelf not found"
 msgstr "Estantería no encontrada"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr "Permiso denegado"
 
-#: cps/web.py:1704
+#: cps/web.py
 msgid "Shelf duplicated successfully"
 msgstr "Estantería duplicada correctamente"
 
-#: cps/web.py:1710
+#: cps/web.py
 msgid "Error duplicating shelf"
 msgstr "Error duplicando la estantería"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
@@ -6384,108 +6288,106 @@ msgstr ""
 "Las estanterías del sistema no se pueden borrar. Puedes ocultarlas en la "
 "configuración de tu perfil de usuario."
 
-#: cps/web.py:1755
+#: cps/web.py
 msgid "Error deleting shelf"
 msgstr "Error al borrar la estantería"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 "No puedes ocultar tus propias estanterías. Elimínalas si no las quieres."
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr "La estantería ya está oculta"
 
-#: cps/web.py:1795
+#: cps/web.py
 msgid "Error hiding shelf"
 msgstr "Error al ocultar la estantería"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr "No se ocultó la estantería"
 
-#: cps/web.py:1818
+#: cps/web.py
 msgid "Error unhiding shelf"
 msgstr "Error al mostrar la estantería"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Descargas"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Lista de formatos"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Por favor, configura los parámetros del servidor SMTP primero..."
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 "¡Ups! Por favor, actualiza tu perfil con una dirección de correo valida para "
 "tu eReader..."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "¡Éxito! Libro puesto en la cola de envío a %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "¡Ups! Ha sucedido un error en el envío del libro: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr "No se han seleccionado direcciones de correo electrónico"
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr "Correos electrónicos adicionales están desactivados para tu cuenta."
 
-#: cps/web.py:2500
+#: cps/web.py
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr ""
 "¡Éxito! Libro en cola para enviar a la(s) dirección(es) seleccionada(s)."
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr "Por favor, espere un minuto para registrar al siguiente usuario"
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Registro"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr ""
 "Error de conexión con el limiter backend. Por favor, contacta a tu "
 "administrador"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr ""
 "¡Ups! El servidor de correo no está configurado. Por favor, contacta a tu "
 "administrador."
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "¡Ups! Su correo electrónico no está permitido."
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr ""
 "¡Éxito! Se ha enviado un correo electrónico de confirmación a su cuenta de "
 "correo."
 
-#: cps/web.py:2624
+#: cps/web.py
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
@@ -6493,7 +6395,7 @@ msgstr ""
 "Bucle de autenticación detectado. Por favor, póngase en contacto con su "
 "administrador."
 
-#: cps/web.py:2704
+#: cps/web.py
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
@@ -6501,28 +6403,28 @@ msgstr ""
 "La autenticación OAuth no está configurada correctamente. Contacta con el "
 "administrador."
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr "No se puede activar la autenticación LDAP"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr "El inicio de sesión estándar está deshabilitado."
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr "Por favor, espere un minuto antes de volver a iniciar sesión"
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr "El nombre de usuario no puede estar vacío"
 
-#: cps/web.py:2756
+#: cps/web.py
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "has iniciado sesión como : '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
@@ -6531,7 +6433,7 @@ msgstr ""
 "¡Bienvenido! Tu cuenta se ha creado automáticamente. Has iniciado sesión "
 "como: '%(nickname)s'"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
@@ -6539,7 +6441,7 @@ msgstr ""
 "Autenticación correcta, pero ha fallado la creación de la cuenta. Por favor, "
 "contacta con tu administrador."
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
@@ -6547,7 +6449,7 @@ msgstr ""
 "Autenticación correcta, pero no se encontró una cuenta local. Contacta con "
 "tu administrador para crear tu cuenta."
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6556,592 +6458,563 @@ msgstr ""
 "Inicio de sesión alternativo como: '%(nickname)s', no se puede acceder al "
 "servidor LDAP o el usuario es desconocido"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr "No se pudo iniciar sesión: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 msgid "Wrong Username or Password"
 msgstr "Usuario o contraseña incorrectos"
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr "Una nueva contraseña se ha enviado a su cuenta de correo electrónico"
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr ""
 "Ha ocurrido un error desconocido. Por favor, vuelva a intentarlo más tarde."
 
-#: cps/web.py:2838
+#: cps/web.py
 msgid "Please enter valid username to reset password"
 msgstr "Por favor, introduce un usuario válido para restablecer la contraseña"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "Has iniciado sesión como : '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 msgid "Success! Profile Updated"
 msgstr "¡Éxito! Perfil actualizado"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "¡Ups! Ya existe una cuenta para esa dirección de correo electrónico."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 "La etiqueta de la contraseña de aplicación debe tener entre 1 y 64 "
 "caracteres."
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr "Contraseña de aplicación «%(label)s» revocada."
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr "ID inválido del libro."
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr "No se pudo borrar la etiqueta"
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr "Plugin de Sincronización de KOReader"
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr ""
 "No se ha encontrado ningún archivo gmail.json válido con información OAuth"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr "Sincronizando anotaciones con servicios de lectura"
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr "Sincronización de anotaciones"
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr "Obteniendo automáticamente los IDs de Hardcover"
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 msgid "Preparing to send to eReader..."
 msgstr "Preparando el envío al eReader..."
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr "Comprobando formatos disponibles..."
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 msgid "Sending to eReader..."
 msgstr "Enviando al eReader..."
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 msgid "Auto-send completed successfully"
 msgstr "Enviado automático completado correctamente"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr "Auto enviar"
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr "Borrar el contenido de la carpeta temporal"
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s enviar al E-Reader"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Calibre conversor de eBook %(tool)s no encontrado"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "%(format)s formato no encontrado en disco"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "El conversor de eBook falló con un error desconocido"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Kepubify-converter falló: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr "Kepubify generó un archivo KEPUB no válido"
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "No se encuentra el archivo convertido o hay más de un archivo en la carpeta "
 "%(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre falló con el error: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Falló conversor de eBook: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Reconectando la base de datos de Calibre"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr "Limpiar referencias de libros archivados"
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan"
 msgstr "Escaneo de duplicados"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr "Escaneo de duplicados omitido: importación en curso"
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr "Construyendo el índice de duplicados"
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr "Construyendo el índice de duplicados: %(processed)s/%(total)s libros"
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr "Construyendo el índice de duplicados: sin libros"
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 msgid "Finding duplicate groups"
 msgstr "Buscando grupos de duplicados"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 msgid "Updating duplicate cache"
 msgstr "Actualizando la caché de duplicados"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Escaneo de duplicados pendiente: se requiere un escaneo manual"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr "Escaneo de duplicados completado: %(count)s grupos"
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr "Escaneo de duplicados completado: %(count)s grupos nuevos"
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 "Escaneo de duplicados completado: %(count)s grupos resueltos automáticamente"
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr "Sincronizando adiciones de estanterías con Hardcover"
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 msgid "Hardcover Sync"
 msgstr "Sincronización con Hardcover"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr "Convertir libros de Kobo sin KEPUB"
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr "Kepubify no está configurado"
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr "Fallaron %(count)d conversión(es) a KEPUB"
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "Correo electrónico"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr "Copia de seguridad de metadatos"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr "Convertir biblioteca – ejecución completa"
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 msgid "Convert Library"
 msgstr "Convertir librería"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr "Reparador de EPUB – ejecución completa"
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr "Reparador de EPUB"
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "Generadas %(count)s miniaturas de portada"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "Miniaturas de Portadas"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "Se han generado {0} miniaturas de la series"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "Borrar la caché de miniaturas de la portada"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 msgid "Book organizer"
 msgstr "Organizador de libros"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 msgid "Change sort order"
 msgstr "Cambiar el orden de clasificación"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 msgid "Select multiple books"
 msgstr "Seleccionar varios libros"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 msgid "Display settings"
 msgstr "Configuración de visualización"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 msgid "Cover Settings"
 msgstr "Configuración de portada"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr "Ocultar insignias de estantería en las portadas"
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 msgid "Selection actions"
 msgstr "Acciones de selección"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 msgid "Add to Shelf"
 msgstr "Añadir a la estantería"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Público)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr "Marcar"
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 msgid "Downloads, fewest first"
 msgstr "Descargas, de menos a más"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 msgid "Downloads, most first"
 msgstr "Descargas, de más a menos"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 msgid "Date added, newest first"
 msgstr "Fecha de adición, más reciente primero"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 msgid "Date added, oldest first"
 msgstr "Fecha de adición, más antigua primero"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr "Título A → Z"
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr "Título Z → A"
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 msgid "Author A → Z"
 msgstr "Autor A → Z"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 msgid "Author Z → A"
 msgstr "Autor Z → A"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 msgid "Published, newest first"
 msgstr "Publicación, más reciente primero"
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 msgid "Published, oldest first"
 msgstr "Publicación, más antigua primero"
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr "Número de serie, ascendente"
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr "Número de serie, descendente"
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 msgid "Added to shelf, newest first"
 msgstr "Añadido a la estantería, más reciente primero"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 msgid "Added to shelf, oldest first"
 msgstr "Añadido a la estantería, más antiguo primero"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr "Usuarios&nbsp;&nbsp;👤"
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "Enviar al correo del eReader"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 msgid "Send to eReader Subject"
 msgstr "Asunto de Send to eReader"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Ver libros"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Estantería Pública"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr "Gestionar Imágenes de Perfil"
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "Importar usuarios LDAP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Configuración del Servidor de Correo Electrónico&nbsp;&nbsp;📬"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "Servidor SMTP"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "Puerto SMTP"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "Login SMTP"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Desde el correo"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr "Servicio de Correo"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail por Oauth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr "Configuración&nbsp;&nbsp;⚙️"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Directorio de la Base de Datos de Calibre"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Nivel de Registro"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Puerto Externo"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Libros por Página"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Subidas"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Navegación Anónima"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Registro Público"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Inicio de sesión remoto con Magic Link"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Inicio de sesión con Proxy Inverso"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Nombre de Cabecera de Proxy Inverso"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr "Configuración de NextGen"
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Editar la Configuración Básica"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Editar la Configuración de la Interfaz de Usuario"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Editar la Configuración de la Base de Datos de Calibre"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "Tareas Programadas&nbsp;&nbsp;⌛"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "Hora de inicio"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "Duración máxima"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr "Actualización programada de miniaturas"
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "Generar miniaturas de portadas de series"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Reconectar la base de datos de Calibre"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr "Generar archivos de copia de seguridad de metadatos"
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "Actualizar caché de miniaturas"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr "Funciones de administración de NextGen&nbsp;&nbsp;⚡"
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr "Mostrar estadísticas de NextGen"
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr "Comprobar el estado de NextGen"
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 msgid "Setup KOReader Sync"
 msgstr "Configurar Sincronización de KOReader"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr "Servicio de conversión de biblioteca de NextGen"
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr "Servicio de corrección de EPUB de NextGen"
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr "Aplicación de portada y metadatos de NextGen"
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr "GitHub de NextGen"
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr "Servidor de Discord de NextGen"
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr "Ejecutar Hardcover Auto-Fetch"
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Administración&nbsp;&nbsp;🚀"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
@@ -7149,88 +7022,87 @@ msgstr ""
 "Saneado: seguro para adjuntar a un issue público de GitHub. Se eliminan "
 "contraseñas, tokens, IPs y rutas de instalación."
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr "Obtener paquete de soporte"
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 "Paquete completo sin censurar. Solo para uso privado del administrador; "
 "contiene secretos e IPs."
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Descargar Paquete de Debug"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Ver archivos de registro"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Reiniciar Servicio"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Detener Servicio"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "Información Sobre la Versión&nbsp;&nbsp;📜"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Versión"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Detalles"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 msgid "Update available"
 msgstr "Actualización disponible"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 msgid "Update now"
 msgstr "Actualizar ahora"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Versión actual"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Comprobar actualizaciones"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Realizar actualización"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "¿Realmente quieres reiniciar?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "¿Estás seguro de que deseas apagar?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Actualizando. Por favor, no recargue la página"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7242,7 +7114,7 @@ msgstr ""
 "esta biblioteca se añadirán a tu cuenta; los libros cargados manualmente que "
 "no están en la biblioteca se omiten."
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
@@ -7250,182 +7122,169 @@ msgstr ""
 "El archivo se analiza en memoria y se elimina al terminar la importación. "
 "Nunca se almacena en el servidor."
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr "KoboReader.sqlite"
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr "Importar"
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr "Resumen de la importación"
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr "subrayados nuevos importados"
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr "ya importados (omitidos)"
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 msgid "for books not in this library (skipped)"
 msgstr "para libros que no están en esta biblioteca (omitidos)"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr "ocultos en el dispositivo (omitidos)"
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr "entradas totales vistas"
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Cargando..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 msgid "Import failed."
 msgstr "Error al importar."
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 msgid "Network error."
 msgstr "Error de red."
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr "Exportar Markdown"
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr "Exportar CSV"
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr "Exportar JSON"
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr "Abrir libro"
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr "%(count)d subrayados"
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr "Nota:"
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr "Progreso del capítulo: %(pct)d%%"
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Source: %(s)s"
 msgstr "Fuente: %(s)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr "Aún no hay anotaciones en este libro."
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "via"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "En la Biblioteca"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "reducir"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Más de"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Borrar Libro"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Borrar formatos:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Convertir formato de libro:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Convertir desde:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr "selecciona una opción"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Convertir a:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Convertir libro"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Error"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Subir formato"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "ID de Series"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Fecha de Publicación"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Tipo de Identificador"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Valor de Identificador"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Borrar"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Añadir Identificador"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
@@ -7433,55 +7292,55 @@ msgstr ""
 "Elige una portada de cualquier fuente, pega una URL, sube un archivo o usa "
 "la portada incrustada."
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Obtener portada desde URL (JPEG - la imagen será descargada y almacenada en "
 "la base de datos)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Subir portada desde un disco local"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 msgid "Hardcover Sync Blacklist"
 msgstr "Lista negra de sincronización con Hardcover"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr "Bloquear que las anotaciones se sincronicen con Hardcover"
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr "Bloquear que el progreso de lectura se sincronice con Hardcover"
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Ver Libro al Guardar"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Obtener Metadatos"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Palabra clave"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "Buscar por palabras clave"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 "Los campos de metadatos seleccionados se aplicaron al formulario de edición."
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr "Claves de API"
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
@@ -7492,179 +7351,170 @@ msgstr ""
 "peticiones. Las claves se guardan una vez para toda la instancia; solo "
 "administradores."
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Cargando..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr "Ordenar por:"
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr "Orden de proveedores (predeterminado)"
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr "Tamaño de portada: mayor primero"
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr "Tamaño de portada: menor primero"
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr "Aplicar"
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "¡Error en la búsqueda!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr ""
 "¡No se encontraron resultados! Por favor, intenta con otra palabra clave."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "Este campo es obligatorio"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr " Intercambiar autor y título"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 msgid "Select all"
 msgstr "Seleccionar todo"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr "Limpiar todo"
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 msgid "Update Title Sort automatically  "
 msgstr "Actualizar orden de título automáticamente "
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Actualizar orden de autor automáticamente"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Introduce título"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Introduce el orden del título"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Orden del título"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Introduce orden del autor"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Orden del autor"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Introduce los autores"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Introduce las categorías"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Introduce las series"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Introduce los idiomas"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Fecha de publicación"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Introduce los Editores"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Introducir comentarios"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Comments"
 msgstr "Comentarios"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 msgid "Archived?"
 msgstr "¿Archivado?"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 msgid "Read?"
 msgstr "¿Leído?"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "Introducir "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "¿Estás realmente seguro/a?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "Libros con título serán fusionados de:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "En el libro con el título:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr "Se borrarán los siguientes libros:"
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr "Se archivarán los siguientes libros:"
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr "Se desarchivarán los siguientes libros:"
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr "Se marcaran como leídos los siguientes libros:"
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr "Se marcaran como no leídos los siguientes libros:"
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Editar metadatos"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 "Edita los campos que desees modificar. Los campos en blanco se ignorarán:"
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
@@ -7672,32 +7522,31 @@ msgstr ""
 "Se admiten varios valores para Autores, Etiquetas/Categorías, Idiomas y "
 "Editoriales. Usa valores separados por comas (p. ej., \"Nombre1, Nombre2\")."
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 msgid "Select a Shelf"
 msgstr "Selecciona una Estantería"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr "Seleccione una estantería para añadir los libros seleccionados:"
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr "-- Selecciona una Estantería --"
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Añadir"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr ""
 "El servidor de correo aún no está configurado, así que no se pueden enviar "
 "anuncios."
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
@@ -7706,19 +7555,19 @@ msgstr ""
 "ponen en cola y se envían en segundo plano; comprueba las Tareas para ver el "
 "estado del envío."
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr "Asunto"
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr "Mensaje"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr "Escribe tu anuncio aquí. Se permite HTML (enlaces, negrita, listas)."
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
@@ -7727,48 +7576,48 @@ msgstr ""
 "destinatarios con clientes de correo de solo texto reciben automáticamente "
 "una versión de solo texto."
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr "Usar el texto actual del banner de anuncios"
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr "Destinatarios"
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 msgid "Select all users with an email address"
 msgstr "Seleccionar todos los usuarios con dirección de correo"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 "Ningún usuario tiene una dirección de correo configurada, así que aún no hay "
 "a quién enviar."
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr "Enviar anuncio"
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 msgid "Send test to me"
 msgstr "Enviarme una prueba a mí"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Regresar"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr "¿Enviar este anuncio a __NUM__ destinatario(s)?"
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr "Solución de problemas de tu base de datos"
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
@@ -7778,18 +7627,18 @@ msgstr ""
 "montar tu base de datos de Calibre (metadata.db) o, menos probablemente, un "
 "problema con tu app.db."
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr "Las causas más comunes incluyen:"
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 "NextGen y Calibre están usando la misma base de datos o biblioteca al mismo "
 "tiempo."
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
@@ -7799,7 +7648,7 @@ msgstr ""
 "red sin %(network_share_mode)s activado en tu configuración de Docker "
 "Compose."
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
@@ -7808,25 +7657,25 @@ msgstr ""
 "NextGen se está ejecutando sobre %(unionfs)s o %(mergerfs)s sin "
 "%(network_share_mode)s activado."
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr "La ruta a tu base de datos de Calibre ha cambiado o es incorrecta."
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 "El archivo de la base de datos de Calibre (metadata.db) falta o está dañado."
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 "Los permisos del archivo impiden el acceso a la base de datos de Calibre."
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr "Para resolver estos problemas, asegúrate de que:"
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
@@ -7834,7 +7683,7 @@ msgstr ""
 "Ninguna otra aplicación, incluido Calibre, accede a la misma base de datos "
 "de Calibre mientras NextGen está en ejecución."
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
@@ -7843,14 +7692,14 @@ msgstr ""
 "Si usas un recurso compartido de red, unionfs o mergerfs, activa "
 "%(network_share_mode)s en tu configuración de Docker Compose."
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 "La ruta de la base de datos de Calibre (metadata.db) es correcta y accesible "
 "para NextGen."
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
@@ -7858,12 +7707,12 @@ msgstr ""
 "El archivo de la base de datos de Calibre (metadata.db) existe y no está "
 "dañado. Prueba a abrirlo con Calibre para verificar su integridad."
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 "NextGen tiene permiso para acceder al archivo de la base de datos de Calibre."
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
@@ -7871,7 +7720,7 @@ msgstr ""
 "Si el problema persiste tras comprobar todo lo anterior, restaura tu base de "
 "datos de Calibre desde una copia de seguridad o crea una nueva."
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
@@ -7880,11 +7729,11 @@ msgstr ""
 "página para intentar reconstruir tu base de datos de Calibre a partir de los "
 "archivos OPF de tu biblioteca."
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Ubicación de la base de datos Calibre (archivo metadata.db)"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7911,7 +7760,7 @@ msgstr ""
 "crocodilestick/Calibre-Web-Automated/wiki/Configuration#database-"
 "configuration\">consulta aquí</a>."
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
@@ -7920,7 +7769,7 @@ msgstr ""
 "CAMBIES LAS RUTAS EN LA SECCIÓN DE VOLÚMENES AL LADO DERECHO DE LOS DOS "
 "PUNTOS.</b>"
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7938,7 +7787,7 @@ msgstr ""
 "de la biblioteca de abajo, y ahí introduce la ruta al resto de la "
 "biblioteca</b>"
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7957,11 +7806,11 @@ msgstr ""
 "        una vez que haya marcado la opción <b>Separar archivos de libros de "
 "la biblioteca</b>."
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr "Funcionalidad de Biblioteca Dividida"
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
@@ -7971,31 +7820,31 @@ msgstr ""
 "<code>metadata.db</code> debe permanecer en <code>/calibre-library</code>, "
 "sin embargo, los archivos de la biblioteca pueden estar donde usted desee"
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "¿Usar Google Drive?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Autenticar Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Carpeta de Google Drive para Calibre"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "Metadata Watch Channel ID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Revocar"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Reconectar la base de datos de Calibre"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -8013,98 +7862,98 @@ msgstr ""
 "antes de cualquier acción destructiva.</b> Se guardará un registro de la "
 "restauración junto a las copias de seguridad."
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 msgid "Are you sure? This cannot be undone."
 msgstr "¿Estás seguro? Está acción no es reversible."
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Restaurar la base de datos de Calibre"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr ""
 "La nueva ubicación de la base de datos no es válida. Por favor, introduzca "
 "una ruta válida."
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Usar autenticación estándar"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Usar autenticación LDAP"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Usar OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Configuración del Servidor"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Puerto del Servidor"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Ubicación del archivo de certificado SSL (déjelo vacío para servidores sin "
 "SSL)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Ubicación del archivo de claves SSL (déjelo vacío para servidores sin SSL)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Canal de Actualización"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Estable"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Nightly"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "Hosts de Confianza (Separados por Comas)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Configuración del archivo de registro"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr ""
 "Ubicación y nombre del archivo de registro (/dev/stdout para no registrar "
 "nada)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Habilitar registro de acceso"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr ""
 "Ubicación y nombre del archivo de registro de acceso (si no se especifica "
 "será access.log)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 msgid "Feature Configuration"
 msgstr "Configuración de las Funciones"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 "Convertir los caracteres no ingleses del título y el autor al guardar en el "
 "disco"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
@@ -8112,39 +7961,39 @@ msgstr ""
 "Incrustar metadatos en los archivos de eBooks al descargarlos, convertirlos "
 "o enviarlos por correo electrónico (requiere los binarios Calibre/Kepubify)."
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Permitir subidas"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr "(Asegúrate de que los usuarios también tienen permisos de subida)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Formatos de archivo permitidos para subida"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Permitir navegación anónima"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Permitir registro público"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "Utilizar correo electrónico como nombre de usuario"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Permitir inicio de sesión remoto con Magic Link"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr "Permitir a los usuarios ocultar libros de su biblioteca personal"
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -8157,15 +8006,15 @@ msgstr ""
 "que lo saca de su propio índice/búsqueda/OPDS sin afectar a otros usuarios. "
 "La recuperación se hace desde la página de perfil (enlace Libros ocultos)."
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Solicitudes proxy desconocidas a Kobo Store"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr "Generar y preferir KEPUB para el envío a Kobo"
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
@@ -8173,7 +8022,7 @@ msgstr ""
 "No se encontró Kepubify. Define su ruta en Binarios externos antes de que "
 "esta preferencia pueda convertir libros."
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
@@ -8181,27 +8030,27 @@ msgstr ""
 "Se crean los archivos KEPUB que falten para los libros ya enviados a un "
 "Kobo. El EPUB sigue siendo el formato de origen."
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr "Convertir ahora los KEPUB que faltan"
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Puerto externo del servidor (para llamadas API con reenvío de puertos)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 "Sincronizar anotaciones de Kobo con Hardcover (requiere una clave API por "
 "usuario)"
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 "Rellenar las portadas de los libros a la relación de aspecto de la pantalla "
 "de Kobo"
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
@@ -8212,60 +8061,60 @@ msgstr ""
 "aplica en el servidor; los archivos de portada originales en disco no se "
 "modifican."
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr "Kobo Libra Color / Libra 2 (1264x1680)"
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr "2:3 (portada de editorial, sin relleno para portadas típicas)"
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr "Sólido: color más frecuente de la portada"
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr "Sólido: color medio de la portada"
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr "Sólido: color personalizado"
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr "Color de borde personalizado (hex)"
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 "Solo se usa cuando el estilo de relleno es «Sólido: color personalizado». "
 "Formato: #RRGGBB."
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Usar Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "API Key de Goodreads"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 msgid "Enable Hardcover Sync"
 msgstr "Activar la sincronización con Hardcover"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 "Controla la obtención automática y la sincronización del progreso de lectura "
 "de Hardcover desde un solo ajuste."
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
@@ -8273,11 +8122,11 @@ msgstr ""
 "Gestionado por HARDCOVER_SYNC_ENABLED; cambia la variable de entorno para "
 "activar o desactivar la sincronización con Hardcover."
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr "API Key de Hardcover"
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
@@ -8285,7 +8134,7 @@ msgstr ""
 "Clave gratuita en https://hardcover.app/account/api — necesaria para los "
 "resultados de metadatos de Hardcover."
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
@@ -8293,7 +8142,7 @@ msgstr ""
 "Actualmente hay activo un token de la variable de entorno HARDCOVER_TOKEN. "
 "No se muestra aquí; una clave introducida en este campo lo sustituiría."
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
@@ -8302,32 +8151,32 @@ msgstr ""
 "HARDCOVER_TOKEN_FILE. No se muestra aquí; una clave introducida en este "
 "campo lo sustituiría."
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr "Estado del token: no configurado."
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr "Estado del token: válido."
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 msgid "Token status: rejected or expired."
 msgstr "Estado del token: rechazado o caducado."
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 "Estado del token: presente; la validación no está disponible temporalmente."
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr "Caducidad: no proporcionada por este token."
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 msgid "Google Books API Key"
 msgstr "Clave de API de Google Books"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8339,11 +8188,11 @@ msgstr ""
 "gratuita en https://console.cloud.google.com: activa la «Books API» y crea "
 "una clave de API."
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Permitir Autenticaciones con Proxy Inverso"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
@@ -8353,11 +8202,11 @@ msgstr ""
 "autenticación. Este es un método de autenticación, distinto del ajuste de "
 "seguridad HTTPS que aparece abajo."
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr "Usa via HTTPS"
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
@@ -8365,11 +8214,11 @@ msgstr ""
 "Habilita ajustes de cookies seguras (Secure, SameSite=Lax). Actívalo SOLO si "
 "accedes al servidor mediante HTTPS; de lo contrario, te quedarás sin acceso."
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr "Crear usuarios automáticamente desde el proxy inverso"
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
@@ -8379,79 +8228,79 @@ msgstr ""
 "del proxy inverso. Actívalo solo si la autenticación del proxy inverso está "
 "correctamente protegida."
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Tipo de inicio de sesión"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr "Usar OAuth (requiere HTTPS)"
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "Nombre de Host o dirección IP del servidor LDAP"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "Puerto del servidor LDAP"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "Encriptación LDAP"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Ruta LDAP CACertificate (Solo necesaria para certificado de autenticación de "
 "cliente)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Ruta LDAP Certificate (Solo necesaria para certificado de autenticación de "
 "cliente)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Ruta LDAP Keyfile (Solo necesaria para certificado de autenticación de "
 "cliente)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "Autenticación LDAP"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Simple"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "Nombre de usuario de administrador LDAP"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "Contraseña de administrador LDAP"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "Nombre distinguido LDAP (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "Filtro de objetos de usuario LDAP"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "¿El servidor LDAP es OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr "Crear usuarios automáticamente desde LDAP"
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
@@ -8459,44 +8308,44 @@ msgstr ""
 "Crea cuentas de usuario automáticamente cuando la autenticación LDAP tiene "
 "éxito para nuevos usuarios. Recomendado para entornos empresariales."
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr ""
 "La siguiente configuración es necesaria para la importación de usuarios"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "Filtro de objetos de grupo LDAP"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "Nombre de grupo LDAP"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "Campo de miembros de grupo LDAP"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "Filtro de detección LDAP Member User"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "Autodetectar"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "Filtro personalizado"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "Filtro LDAP Member User"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr "Importante:"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
@@ -8504,28 +8353,28 @@ msgstr ""
 "La autenticación OAuth requiere acceder a este servidor mediante HTTPS. Si "
 "usas HTTP, el inicio de sesión fallará."
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr "Proveedor genérico OAuth"
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr "URL de metadatos OAuth (para detección automática)"
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 msgid "Test Metadata"
 msgstr "Probar Metadatos"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 "Déjelo vacío para utilizar la configuración manual que aparece a continuación"
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr "Usar URL de endpoints manuales (anular la detección automática)"
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
@@ -8533,43 +8382,43 @@ msgstr ""
 "Marque esta opción para configurar manualmente los endpoints de OAuth "
 "individuales en lugar de utilizar la detección automática"
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 msgid "Manual Endpoint Configuration"
 msgstr "Configuración manual del endpoint"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr "URL base de OAuth"
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr "Authorización del endpoint"
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 msgid "Token Endpoint"
 msgstr "Token del Endpoint"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr "Información del Usuario del Endpoint"
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 msgid "Test Connection"
 msgstr "Probar Conexión"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 msgid "OAuth Scopes"
 msgstr "Scopes del OAuth"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr "Lista separada por espacios de los scopes OAuth"
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr "Host de redirección OAuth"
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
@@ -8579,7 +8428,7 @@ msgstr ""
 "errores de \"URI de redirección no válida\". Incluye el protocolo "
 "(https://). Déjalo vacío para usar la detección automática."
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
@@ -8587,39 +8436,39 @@ msgstr ""
 "Obligatorio si: accedes mediante varios nombres de host, estás detrás de un "
 "proxy inverso o recibes errores de \"URI de redirección no válida\"."
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 msgid "OAuth Client Id"
 msgstr "Id de Cliente OAuth"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 msgid "OAuth Client Secret"
 msgstr "Secreto de Cliente OAuth"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 msgid "Field Mapping Configuration"
 msgstr "Configuración del mapeo de campos"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 msgid "Username Field"
 msgstr "Campo de nombre de usuario"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr "Campo JWT para extraer el nombre de usuario"
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 msgid "Email Field"
 msgstr "Campo de correo electrónico"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr "Campo JWT para extraer el correo electrónico"
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 msgid "OAuth Group Claim"
 msgstr "Claim de grupo de OAuth"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
@@ -8627,11 +8476,11 @@ msgstr ""
 "Claim de OIDC que contiene los nombres de grupo. El claim puede ser una "
 "lista, o una cadena separada por comas o espacios."
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr "Requerir pertenencia a un grupo de OAuth"
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
@@ -8639,11 +8488,11 @@ msgstr ""
 "Cuando está activado, los usuarios de OAuth genérico deben ser miembros de "
 "al menos un grupo permitido antes de crear o iniciar sesión con una cuenta."
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr "Grupos de OAuth permitidos"
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
@@ -8652,11 +8501,11 @@ msgstr ""
 "sesión mediante OAuth genérico. Déjalo vacío solo si no se requiere "
 "pertenencia a un grupo."
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr "Grupo OAuth para administradores"
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
@@ -8666,46 +8515,46 @@ msgstr ""
 "vacío para desactivar la gestión de administradores por grupos, o usa el "
 "ajuste global en Configuración de seguridad para tener más control."
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Permisos predeterminados para nuevos usuarios de OAuth genérico"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Permitir Descargas"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Permitir Visor de eBooks"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Permitir Subidas de Archivos"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Permitir Editar"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Permitir Borrar Libros"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Permitir Cambiar la Contraseña"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Permitir Editar Estanterías Públicas"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
@@ -8716,54 +8565,54 @@ msgstr ""
 "privilegios de administrador cuando la gestión de administración basada en "
 "grupos de OAuth está activada. Los usuarios existentes no se modifican."
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr "Texto del botón de inicio de sesión"
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Obtener la Credencial OAuth de %(provider)s"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "Id de cliente de OAuth de %(provider)s"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "Secreto OAuth de Cliente de %(provider)s"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Binarios externos"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr "Ruta a los binarios de Calibre"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 msgid "Calibre E-Book Converter Settings"
 msgstr "Configuración del Conversor de E-Book de Calibre"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Ruta para el Conversor de E-Book de Kepubify"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 msgid "Location of Unrar binary"
 msgstr "Ubicación del binario de Unrar"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 msgid "Security Settings"
 msgstr "Configuración de seguridad"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr "Desactivar inicio de sesión estándar (usuario/contraseña)"
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
@@ -8772,11 +8621,11 @@ msgstr ""
 "iniciar sesión mediante OAuth o LDAP. Asegúrate de tener un método de inicio "
 "de sesión alternativo funcionando antes de activarlo."
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr "Habilitar la gestión del rol de administrador por grupos OAuth"
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8789,94 +8638,94 @@ msgstr ""
 "usuarios y evitar que los inicios de sesión por OAuth sobrescriban las "
 "asignaciones de roles locales."
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr "Limitar los intentos fallidos de inicio de sesión"
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr "Configurar el backend para el Limitador"
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr "Opciones para el backend del Limitador"
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 "Comprueba si las extensiones de los archivos coinciden con el contenido de "
 "los archivos al subirlos"
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 msgid "Session protection"
 msgstr "Protección de sesión"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr "Básica"
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr "Fuerte"
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 msgid "User Password policy"
 msgstr "Política de contraseñas de usuario"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr "Longitud mínima de contraseña"
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr "Exigir número"
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr "Exigir letras minúsculas"
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr "Exigir letras mayúsculas"
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 "Exigir caracteres (necesarios para caracteres chinos/japoneses/coreanos)"
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr "Exigir caracteres especiales"
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Ver configuración"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 "El título que se muestra en la pestaña del navegador y en la barra de "
 "navegación."
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 "Número de libros que se muestran por página en las vistas de lista (1-200)."
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Nº de libros aleatorios a mostrar"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr "Número de libros aleatorios mostrados en la página de inicio (1-30)."
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr ""
 "Nº de autores para mostrar antes de ocultar (0 = desactiva la ocultación)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
@@ -8884,15 +8733,15 @@ msgstr ""
 "Número máximo de autores que se muestran en los detalles del libro antes de "
 "truncar. Establécelo en 0 para desactivar."
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 msgid "Default Theme"
 msgstr "Tema predeterminado"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "caliBlur! Tema Oscuro"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
@@ -8900,40 +8749,40 @@ msgstr ""
 "Tema predeterminado para nuevos usuarios y navegación anónima. Los usuarios "
 "pueden elegir su tema preferido en su perfil."
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Expresión regular para ignorar columnas"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr "Patrón regex para ocultar columnas personalizadas en la interfaz."
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Enlazar a la columna de Calibre de leído/sin leer"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr ""
 "Sincronizar el estado de leído/no leído con una columna personalizada "
 "booleana de Calibre."
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Ver restricciones basadas en la columna de Calibre"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 "Restringir la visibilidad de los libros según los valores de una columna "
 "personalizada de texto de Calibre."
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Expresión regular para ordenar títulos"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
@@ -8941,15 +8790,15 @@ msgstr ""
 "Regex para eliminar prefijos de los títulos y ordenar correctamente (p. ej., "
 "\"The\", \"A\", \"An\")."
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 msgid "Site Customization"
 msgstr "Personalización del sitio"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr "Banner de anuncio del servidor"
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
@@ -8957,7 +8806,7 @@ msgstr ""
 "Déjalo en blanco para ocultar el banner. Se muestra en la parte superior de "
 "cada página hasta que cada usuario lo descarta."
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
@@ -8965,16 +8814,16 @@ msgstr ""
 "Hasta 500 caracteres. El HTML se escapa. Cada usuario descarta el banner de "
 "forma independiente; editar el texto vuelve a mostrarlo a todos."
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 msgid "Custom CSS"
 msgstr "CSS personalizado"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr "p. ej. .navbar { background: #2b2b2b; }"
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
@@ -8983,51 +8832,51 @@ msgstr ""
 "sobrescribe los temas integrados. Se aplica a todos los usuarios. Déjalo en "
 "blanco para desactivarlo."
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Ajustes por defecto para nuevos usuarios"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr "Estos ajustes se aplicarán a todas las cuentas de usuario creadas."
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 msgid "Permissions"
 msgstr "Permisos"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Usuario Administrador"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 msgid "Language & Display"
 msgstr "Idioma"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "Idioma por Defecto"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 msgid "Default interface language for new users."
 msgstr "Idioma predeterminado de la interfaz para usuarios nuevos."
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "Idioma visible predeterminado de los libros"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 msgid "Default book language filter for new users."
 msgstr "Filtro de idioma de libros predeterminado para usuarios nuevos."
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr "Configuración regional predeterminada de OPDS para clientes anónimos"
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr "(ninguna: usar inglés por defecto)"
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
@@ -9037,38 +8886,38 @@ msgstr ""
 "una cabecera Accept-Language y la solicitud no incluye un parámetro ?lang=. "
 "Los usuarios autenticados mantienen su propia configuración regional."
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Visibilidad predeterminada para nuevos usuarios"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 "Elige qué secciones de la barra lateral estarán visibles por defecto para "
 "los nuevos usuarios."
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Mostrar libros aleatorios en la vista detallada"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Añadir etiquetas Permitidas/Denegados"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Añadir valores personalizados Permitidos/Denegados"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr "Usar una URL"
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 msgid "Upload a file"
 msgstr "Subir un archivo"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
@@ -9079,11 +8928,11 @@ msgstr ""
 "peticiones. Las claves se guardan una vez para toda la instancia; solo "
 "administradores."
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr "Mostrar cómo se vería cada portada en tu eReader"
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
@@ -9091,59 +8940,54 @@ msgstr ""
 "Ajusta cómo se previsualizan las portadas aquí. Los valores predeterminados "
 "están en Administración → Configuración → Sincronización con Kobo."
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr "Candidatos"
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr "Cargando candidatos…"
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr "¿Sustituir la portada por este candidato?"
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr "Renderizando vistas previas de eReader:"
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run Archive"
 msgstr "Ejecutar Archivo"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 msgid "Download Log"
 msgstr "Descargar registro"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Iniciar"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr "Programar cada 5m"
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr "Programar cada 15m"
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr "Conversión de biblioteca programada correctamente"
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr "Error al programar la conversión de la biblioteca"
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -9158,7 +9002,7 @@ msgstr ""
 "aplicación automática de portada y metadatos de NextGen que se activa al "
 "editar, disponible en la Configuración de CWA."
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
@@ -9169,7 +9013,7 @@ msgstr ""
 "web o mediante la CLI, verás abajo el resultado de la ejecución anterior más "
 "reciente."
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -9181,11 +9025,11 @@ msgstr ""
 "sigue en curso, simplemente pulsa el botón Cancelar de arriba y la ejecución "
 "terminará lo antes posible."
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr "Procesamiento por lotes"
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
@@ -9193,76 +9037,75 @@ msgstr ""
 "No hay ninguna ejecución actual ni anterior que mostrar. Pulsa el botón "
 "Iniciar de arriba para comenzar una."
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr "Se perdió la conexión con el servidor, reintentando..."
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr "La solicitud ha fallado."
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr "Iniciando..."
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr "Cancelando..."
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr "Funciona con un solo libro"
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr "Búsqueda por título / autor"
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on selected book"
 msgstr "Ejecutar en el libro seleccionado"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer scheduled successfully"
 msgstr "Reparador de EPUB programado correctamente"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error scheduling EPUB Fixer"
 msgstr "Error al programar el reparador de EPUB"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 msgid "No matches found"
 msgstr "No se han encontrado resultados"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 msgid "Enter a search term"
 msgstr "Introduce un término de búsqueda"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 msgid "Failed to search library"
 msgstr "No se pudo buscar en la biblioteca"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 msgid "Select a book first"
 msgstr "Selecciona primero un libro"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer started for selected book"
 msgstr "Se inició el reparador de EPUB para el libro seleccionado"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error starting EPUB Fixer"
 msgstr "Error al iniciar el reparador de EPUB"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Activar/desactivar los servicios de Calibre-Web NextGen"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr "Activar la conversión automática de NextGen"
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -9274,13 +9117,13 @@ msgstr ""
 "por defecto), \\n        <em>EXCEPTO</em> aquellos que hayas indicado "
 "específicamente a NextGen que ignore abajo."
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 "Activar el servicio automático de aplicación de portada y metadatos de "
 "NextGen"
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -9298,11 +9141,11 @@ msgstr ""
 "ves en la interfaz web, no a los propios archivos del libro. Esta función "
 "actualmente solo admite archivos en formato EPUB \\n        o AZW3."
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr "Activar el corrector de EPUB para Kindle de NextGen"
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -9318,7 +9161,7 @@ msgstr ""
 "frecuencia archivos EPUB a sus dispositivos Kindle y han experimentado "
 "problemas de \\n        rechazo de archivos o de formato."
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
@@ -9328,11 +9171,11 @@ msgstr ""
 "\">kindle-epub-fix.netlify.app</a>, creada por <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr "Activar la sincronización con KOReader (complemento de NextGen)"
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
@@ -9342,7 +9185,7 @@ msgstr ""
 "verificación compatibles con KOReader en metadata.db para sincronizar el "
 "progreso. Requiere el complemento de KOReader en tu dispositivo."
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
@@ -9353,11 +9196,11 @@ msgstr ""
 "metadata.db. Para detener el relleno en ejecución, reinicie el contenedor "
 "después de deshabilitar esta opción."
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr "Habilitar modo agresivo del reparador de EPUB (más arriesgado)"
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
@@ -9366,11 +9209,11 @@ msgstr ""
 "de codificación con menor confianza. El modo seguro se recomienda para la "
 "mayoría de bibliotecas."
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 msgid "Enable Archived Book Cleanup"
 msgstr "Activar la limpieza de libros archivados"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
@@ -9379,116 +9222,116 @@ msgstr ""
 "ya no existe en la biblioteca de Calibre. Ayuda a mantener precisos los "
 "contadores de archivados."
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr "Programación de limpieza:"
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr "Intervalos frecuentes"
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr "Cada 15 minutos"
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr "Cada 30 minutos"
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr "Cada hora"
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr "Cada 2 horas"
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr "Cada 4 horas"
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr "Cada 6 horas"
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr "Cada 12 horas"
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr "Diario/Semanal/Mensual"
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr "Diariamente a una hora específica"
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr "Semanalmente en un día específico"
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr "Mensualmente en un día específico"
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr "Por defecto: diariamente a las 03:00"
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr "Día de la semana:"
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr "Lunes"
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr "Martes"
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr "Miércoles"
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr "Jueves"
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr "Viernes"
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr "Sábado"
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr "Domingo"
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr "Día del mes:"
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr "(1-28)"
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr "Hora del día:"
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr "(Zona horaria del servidor: %(tz)s)"
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr "Activar la obtención automática de metadatos para libros nuevos"
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9501,11 +9344,11 @@ msgstr ""
 "ayuda a mejorar la calidad de la información de los libros, especialmente en "
 "aquellos con metadatos escasos o ausentes."
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr "Habilitar aplicación inteligente de metadatos"
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9517,11 +9360,11 @@ msgstr ""
 "portadas con mayor resolución). Cuando está desactivado, los metadatos "
 "obtenidos reemplazarán los existentes tal cual desde el proveedor preferido."
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 msgid "Metadata Fields to Update"
 msgstr "Campos de metadatos a actualizar"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
@@ -9531,25 +9374,23 @@ msgstr ""
 "automática. Los campos no marcados no se modificarán nunca durante la "
 "obtención automática de metadatos, conservando tus datos actuales."
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr "Etiquetas/Géneros"
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identificadores (ISBN, etc.)"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 msgid "Cover Image"
 msgstr "Imagen de portada"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr "Tip"
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
@@ -9560,15 +9401,15 @@ msgstr ""
 "de calidad a los campos seleccionados, mientras que el modo directo "
 "reemplazará todos los campos seleccionados con los datos del proveedor."
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr "Tamaño máximo del archivo de portada (MB):"
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr "Rango: 1-200 MB (predeterminado: 15)"
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
@@ -9577,11 +9418,11 @@ msgstr ""
 "proveedores de metadatos o URL para evitar que el guardado sea lento o se "
 "bloquee."
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr "Tiempo de espera del procesamiento de importación"
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
@@ -9592,19 +9433,19 @@ msgstr ""
 "espera se mueven a la carpeta de copias de seguridad fallidas para su "
 "investigación."
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr "Tiempo de espera (minutos):"
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr "Rango: 5-120 minutos (predeterminado: 15)"
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr "Limpieza de temporales obsoletos"
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
@@ -9615,27 +9456,27 @@ msgstr ""
 "los valores en 0, se desactiva la limpieza. Los cambios se aplicarán en el "
 "siguiente ciclo de limpieza."
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr "Antigüedad de archivos temporales obsoletos (minutos):"
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr "Rango: 0-10080 minutos (predeterminado: 120)"
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr "Intervalo de limpieza de temporales obsoletos (segundos):"
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr "Rango: 0-86400 segundos (predeterminado: 600)"
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr "Retardo de envío automático para libros nuevos"
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9647,19 +9488,19 @@ msgstr ""
 "de metadatos y otros procesos antes del envío. Solo se aplica a los usuarios "
 "que hayan activado el envío automático en su perfil."
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr "Retardo (minutos):"
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr "Rango: 1-60 minutos (predeterminado: 5)"
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr "Jerarquía de proveedores para la obtención automática de metadatos"
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
@@ -9669,25 +9510,25 @@ msgstr ""
 "obtener metadatos automáticamente para libros nuevos. Arrastra y suelta para "
 "reordenar los proveedores. Solo se usarán los proveedores habilitados."
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 "Los proveedores se prueban en orden de arriba a abajo. Arrastra para "
 "reordenar."
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr "Proveedores de metadatos habilitados"
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr "Los proveedores no marcados se deshabilitan globalmente."
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Configuración de obtención automática de Hardcover"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
@@ -9697,11 +9538,11 @@ msgstr ""
 "biblioteca. Los IDs de Hardcover permiten sincronizar el progreso de lectura "
 "y las anotaciones con Hardcover.app al usar eReaders compatibles."
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr "Se requiere token de Hardcover"
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
@@ -9712,14 +9553,14 @@ msgstr ""
 "configurar un token global en Configuración básica. Sin un token válido, "
 "esta función permanecerá deshabilitada."
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 "La sincronización con Hardcover está activada. El calendario de abajo "
 "controla la obtención automática de ID."
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
@@ -9727,7 +9568,7 @@ msgstr ""
 "La sincronización con Hardcover está desactivada. Actívala una vez en la "
 "Configuración básica o define HARDCOVER_SYNC_ENABLED=true."
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
@@ -9737,25 +9578,25 @@ msgstr ""
 "coincidencias de alta confianza se aplican automáticamente; las de baja "
 "confianza se ponen en cola para revisión manual."
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr "Programación de ejecución:"
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 "Con qué frecuencia ejecutar automáticamente la tarea de obtención de IDs de "
 "Hardcover"
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr "Umbral mínimo de confianza:"
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr "Rango: 0.50-1.00 (predeterminado: 0.85)"
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
@@ -9766,15 +9607,15 @@ msgstr ""
 "para revisión manual. Valores más altos = menos coincidencias automáticas, "
 "pero mayor precisión."
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr "Tamaño del lote:"
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr "Rango: 10-200 libros por ejecución (predeterminado: 50)"
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
@@ -9783,15 +9624,15 @@ msgstr ""
 "pequeños reducen la carga de la API; los lotes más grandes procesan tu "
 "biblioteca más rápido."
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr "Retardo por límite de tasa (segundos):"
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr "Rango: 0-60 segundos (predeterminado: 5.0)"
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
@@ -9799,7 +9640,7 @@ msgstr ""
 "Retardo entre solicitudes a la API de Hardcover. Evita el rate limiting y "
 "protege tu clave de API. Usa backoff exponencial en caso de errores."
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
@@ -9810,15 +9651,15 @@ msgstr ""
 "estadísticas de NextGen para ver el progreso y revisar las coincidencias en "
 "cola que necesitan aprobación manual."
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 msgid "Web UI Settings"
 msgstr "Configuración de la Interfaz de Usuario Web"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr "Activar las notificaciones de actualización de NextGen"
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
@@ -9826,11 +9667,11 @@ msgstr ""
 "Cuando está activo, recibirás notificaciones en la interfaz web cuando se "
 "publique una nueva versión de NextGen"
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 msgid "Automatic updates"
 msgstr "Actualizaciones automáticas"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9844,7 +9685,7 @@ msgstr ""
 "imagen nueva y sustituye NextGen de forma segura, sin tocar tus otros "
 "contenedores."
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
@@ -9853,13 +9694,12 @@ msgstr ""
 "compose up -d». A partir de ahí te mantienes actualizado automáticamente; no "
 "hay que pulsar ningún botón."
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr "¡Copiado!"
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
@@ -9869,7 +9709,7 @@ msgstr ""
 "de 86400 comprueba una vez al día; «cleanup» elimina la imagen antigua tras "
 "cada actualización."
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
@@ -9878,11 +9718,11 @@ msgstr ""
 "publicaremos una guía de configuración en cuanto lo verifiquemos con esta "
 "imagen."
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr "Habilitar notificaciones de contribuciones a traducciones"
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -9892,11 +9732,11 @@ msgstr ""
 "usuario web cuando utilice un idioma distinto del inglés si las traducciones "
 "para el idioma elegido no están completas."
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Sincronizar estanterías mágicas con Kobo"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
@@ -9905,11 +9745,11 @@ msgstr ""
 "dispositivo Kobo como colecciones. Nota: también debes activar Kobo Sync en "
 "Configuración básica."
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Habilitar fondos difuminados en dispositivos móviles (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -9918,15 +9758,15 @@ msgstr ""
 "reproduce en pantallas pequeñas. Desactívalo si notas retrasos en el "
 "desplazamiento o la animación."
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 msgid "Automatic Backup Settings"
 msgstr "Configuración de Copias de Seguridad Automáticas"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr "Activar la copia de seguridad automática de importación de NextGen"
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -9934,11 +9774,11 @@ msgstr ""
 "Cuando esté activo, se almacenará una copia de todos los archivos importados "
 "en <i>/config/processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr "Activar la copia de seguridad automática de conversión de NextGen"
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -9946,12 +9786,12 @@ msgstr ""
 "Cuando esté activo, los originales de los archivos importados que se sometan "
 "a conversión se almacenarán en /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 "Activar la copia de seguridad automática del corrector de EPUB de NextGen"
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
@@ -9960,11 +9800,11 @@ msgstr ""
 "de EPUB para Kindle de NextGen se guardarán en /config/processed_books/"
 "fixed_originals"
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr "Activar las copias de seguridad automáticas en ZIP de NextGen"
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9977,11 +9817,11 @@ msgstr ""
 "mantener organizados los subdirectorios de /config/processed_books y "
 "minimizar el uso del espacio en disco."
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr "Formato de destino de la autoconversión de NextGen: EPUB por defecto"
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -9992,11 +9832,11 @@ msgstr ""
 "los formatos seleccionados en la lista de ignorados que aparece a "
 "continuación)."
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 msgid "Choose a target format:"
 msgstr "Elija un formato de destino:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
@@ -10006,11 +9846,11 @@ msgstr ""
 "admite archivos en formato EPUB o AZW3. Los archivos en otros formatos "
 "simplemente serán ignorados por el servicio"
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr "Autoconversión de NextGen: formatos ignorados"
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
@@ -10019,11 +9859,11 @@ msgstr ""
 "autoconversión de NextGen cuando esté activa, es decir, se importarán tal "
 "cual."
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr "Autoconversión de NextGen: formatos conservados"
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -10035,21 +9875,21 @@ msgstr ""
 "formato está en la lista «Auto-ingesta de NextGen: formatos ignorados», no "
 "se importará. Ten en cuenta que el formato de destino siempre se conserva."
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr "Autofusión de la auto-ingesta de NextGen"
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "Calibre puede detectar títulos de libros duplicados durante la importación y "
 "dependiendo de la configuración de la"
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr "fusión automatica"
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -10057,23 +9897,23 @@ msgstr ""
 ". Se puede configurar para borrar cualquiera de las instancias de un libro "
 "duplicado o conservar ambas (por defecto)."
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Descarta importación duplicada, conserva la copia de la biblioteca"
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr "Sobrescribe la copia de la biblioteca con el archivo recién importado"
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Crea un registro duplicado, conservando ambas copias"
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr "Auto-ingesta de NextGen: formatos ignorados"
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
@@ -10083,11 +9923,11 @@ msgstr ""
 "ingesta de NextGen, es decir, los archivos en estos formatos no se añadirán "
 "a la biblioteca por parte de NextGen durante el proceso de ingesta"
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr "Sistema de detección de duplicados de NextGen"
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
@@ -10095,33 +9935,33 @@ msgstr ""
 "Activa o desactiva el sistema de detección de duplicados. Si se desactiva, "
 "no se ejecutará el escaneo de duplicados y no se mostrarán notificaciones."
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Detection"
 msgstr "Activar la detección de duplicados"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 "Cuando está activado, NextGen buscará libros duplicados después de cada "
 "importación"
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr "Método de detección de duplicados"
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr "Híbrido (prefiltro SQL + validación en Python)"
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr "Solo Python (más lento, más robusto)"
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr "Solo SQL heredado (experimental)"
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
@@ -10129,11 +9969,11 @@ msgstr ""
 "El modo híbrido usa un prefiltro SQL rápido para reducir candidatos y luego "
 "aplica la lógica robusta en Python para obtener el resultado final."
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 msgid "Automatic Duplicate Scanning"
 msgstr "Escaneo automático de duplicados"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
@@ -10141,27 +9981,27 @@ msgstr ""
 "Configura los escaneos de duplicados en segundo plano. Se ejecutan "
 "automáticamente sin bloquear la interfaz."
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr "Habilitar escaneos automáticos de duplicados"
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr "Escaneos tras la importación"
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr "Ejecutar tras cada importación (con retardo)"
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr "Solo manual"
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr "Retardo tras la importación (segundos)"
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
@@ -10169,15 +10009,15 @@ msgstr ""
 "Espera estos segundos después de la última importación antes de iniciar un "
 "escaneo en segundo plano."
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr "Escaneos programados (expresión cron)"
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr "Déjalo en blanco para desactivar los escaneos programados. Ejemplo:"
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
@@ -10186,15 +10026,15 @@ msgstr ""
 "como los escaneos por cron. Usa “Solo manual” para desactivar los escaneos "
 "tras la importación y mantener la programación por cron."
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr "Próximo escaneo programado:"
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr "Criterios de detección de duplicados de NextGen"
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
@@ -10204,31 +10044,31 @@ msgstr ""
 "duplicados. Para considerarse duplicados, deben coincidir TODOS los "
 "criterios seleccionados."
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr "Considerar títulos al detectar duplicados"
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr "Considerar autores al detectar duplicados"
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr "Considerar idioma al detectar duplicados"
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr "Considerar series al detectar duplicados"
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr "Considerar editorial al detectar duplicados"
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr "Considerar el formato de archivo al detectar duplicados"
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
@@ -10236,11 +10076,11 @@ msgstr ""
 "Debe seleccionarse al menos un criterio. Se recomiendan Título y Autor como "
 "criterios principales."
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr "Orden de prioridad de formatos para duplicados"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
@@ -10250,11 +10090,11 @@ msgstr ""
 "resolución automática \"Formato de mayor calidad\". Arrastra y suelta para "
 "reordenar los formatos por prioridad (más alto = mejor)."
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr "Consejo:"
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
@@ -10264,11 +10104,11 @@ msgstr ""
 "conservarán los libros con formatos mejor clasificados. Los formatos con "
 "menor prioridad se borrarán."
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr "Notificaciones de duplicados y resolución automática"
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
@@ -10276,11 +10116,11 @@ msgstr ""
 "Configura cómo se te notifican los libros duplicados y, opcionalmente, "
 "activa la resolución automática."
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Notifications"
 msgstr "Activar notificaciones de duplicados"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
@@ -10291,15 +10131,15 @@ msgstr ""
 "un indicador en el botón \"Duplicados\" de la barra lateral y una "
 "notificación emergente al iniciar sesión."
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Activar la resolución automática de duplicados"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr "Advertencia:"
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
@@ -10307,74 +10147,74 @@ msgstr ""
 "Esto borrará automáticamente libros según la estrategia indicada abajo. Los "
 "archivos originales se guardarán como copia de seguridad en"
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr "Estrategia de resolución automática"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr "Conservar el más reciente"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 "Borrar copias más antiguas y conservar el libro añadido más recientemente"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr "Conservar el más antiguo"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr "Borrar copias más recientes y conservar el primero que se añadió"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge Formats"
 msgstr "Fusionar formatos"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr "Fusionar los formatos en el libro más reciente y borrar el resto"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr "Conservar el formato de mayor calidad"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 "Preferir formatos según tu orden de prioridad de formatos para duplicados"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep Most Metadata"
 msgstr "Conservar la mayoría de los metadatos"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr "Conservar el libro con la información más completa"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr "Conservar el tamaño de archivo más grande"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr "Conservar el libro con el mayor tamaño total de archivos"
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 "Elige qué libro conservar cuando los duplicados se resuelven automáticamente."
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 msgid "Rate Limiting"
 msgstr "Limitación de tasa"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr "Periodo de enfriamiento (minutos)"
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
@@ -10382,7 +10222,7 @@ msgstr ""
 "Tiempo mínimo entre resoluciones automáticas (0 para desactivar). Evita "
 "borrados en ráfaga durante importaciones por lotes."
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -10391,91 +10231,83 @@ msgstr ""
 "detectan nuevos duplicados. Los grupos de duplicados descartados nunca se "
 "resuelven automáticamente."
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr "Revisar %(count)s coincidencia(s) pendiente(s)"
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr "Haz clic para ver más"
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr "Antes de irte: ¿qué te hizo volver a la vista anterior?"
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr "Opcional y totalmente anónimo. Nos ayuda a mejorar la nueva interfaz."
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr "Algo estaba roto o fallaba"
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr "Prefiero el aspecto clásico"
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr "Faltaba una función que uso"
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr "Es demasiado distinta / cuesta encontrar las cosas"
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr "Se sentía lenta"
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr "No, gracias"
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Siguiente"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr "¿Quieres añadir algo más?"
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr "Opcional; con una o dos frases es suficiente."
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr "¿Qué te habría hecho quedarte en la nueva interfaz?"
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr "Enviar comentarios"
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr "Gracias"
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr "Tus comentarios se enviaron de forma anónima. Leemos todas las notas."
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr "No se pudo enviar en este momento"
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
@@ -10483,21 +10315,21 @@ msgstr ""
 "No hay problema: tus comentarios no se guardaron en ningún sitio. Puedes "
 "cerrar esto o intentarlo de nuevo."
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr "Intentar de nuevo"
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr "Anonimizar mis comentarios"
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 "No se envía ni almacena ninguna cuenta, nombre, dirección IP, versión ni "
 "información del dispositivo."
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
@@ -10508,7 +10340,7 @@ msgstr ""
 "brevemente tu IP para evitar spam; solo usamos un hash unidireccional de "
 "ella durante alrededor de un minuto y nunca la almacenamos."
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
@@ -10516,156 +10348,152 @@ msgstr ""
 "Como has desactivado la anonimización, se incluirá la versión de tu "
 "aplicación para ayudarnos a reproducir problemas."
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Marcar como no leído"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Marcar como leído"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 msgid "Marked as read"
 msgstr "Marcado como leído"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 msgid "Marked as unread"
 msgstr "Marcado como no leído"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 msgid "Added to favorites"
 msgstr "Añadido a favoritos"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 msgid "Removed from favorites"
 msgstr "Quitado de favoritos"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Restarurar desde el archivo"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Añadir al archivo"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 msgid "Restored from archive"
 msgstr "Restaurado desde el archivo"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr "Metadatos recargados desde el disco"
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr "Los metadatos en disco coinciden: nada que actualizar"
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr "Mostrar de nuevo en tu biblioteca"
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Hide from your library"
 msgstr "Ocultar de tu biblioteca"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr "Vuelto a mostrar"
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 msgid "Rating updated"
 msgstr "Valoración actualizada"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 msgid "Rating cleared"
 msgstr "Valoración eliminada"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "Libro %(index)s de %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr "ID"
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr "UUID"
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr "UUID copiado al portapapeles"
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr "No se pudo copiar el UUID"
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr "Copiar UUID"
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr "Tamaños de archivo"
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Descripción:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 msgid "Select eReader Email Addresses"
 msgstr "Seleccionar direcciones de correo electrónico del eReader"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 msgid "Choose email addresses:"
 msgstr "Seleccionar direcciones de correo electrónico:"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 msgid "Select All"
 msgstr "Seleccionar Todo"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr "eReaders de otros usuarios:"
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr "Direcciones de correo adicionales:"
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr "Introduce direcciones de correo adicionales (separadas por comas):"
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr "example@domain.com, another@domain.com"
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr "Introduce una o más direcciones de correo separadas por comas"
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 msgid "Select format:"
 msgstr "Seleccionar formato:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 msgid "Failed to update tags"
 msgstr "No se pudieron actualizar las etiquetas"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 msgid "Failed to update shelves"
 msgstr "No se pudieron actualizar las estanterías"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr "Gestor de duplicados de NextGen"
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
@@ -10673,31 +10501,31 @@ msgstr ""
 "Libros con títulos, autores e idiomas coincidentes. Los libros en idiomas "
 "distintos no se consideran duplicados."
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 msgid "Run Full Duplicate Scan"
 msgstr "Ejecutar escaneo completo de duplicados"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 msgid "Scan for Duplicates Now"
 msgstr "Buscar duplicados ahora"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr "Seleccionar duplicados"
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 msgid "Select None"
 msgstr "Seleccionar Ninguno"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 msgid "Delete Selected"
 msgstr "Borrar seleccionados"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr "La detección de duplicados necesita un escaneo completo único."
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
@@ -10708,7 +10536,7 @@ msgstr ""
 "metadatos. Antes de poder ejecutar escaneos incrementales, el índice "
 "necesita una línea base inicial."
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
@@ -10717,23 +10545,23 @@ msgstr ""
 "puede tardar varios minutos en bibliotecas grandes, y puedes seguir usando "
 "CWA mientras se ejecuta."
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 msgid "Duplicate scan is running."
 msgstr "El escaneo de duplicados está en curso."
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr "Puedes seguir usando CWA mientras se ejecuta."
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr "Ver tareas en segundo plano"
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr "Resolver duplicados automáticamente"
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
@@ -10741,29 +10569,29 @@ msgstr ""
 "Resuelve automáticamente todos los grupos de duplicados conservando un libro "
 "y borrando los demás según una estrategia."
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr "Estrategia:"
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 "Conservar el más reciente - Borra copias más antiguas y conserva el añadido "
 "más recientemente"
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 "Conservar el más antiguo - Borra copias más recientes y conserva el primero "
 "que se añadió"
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 "Fusionar formatos - Fusiona los formatos en el libro más reciente y borra el "
 "resto"
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
@@ -10771,61 +10599,61 @@ msgstr ""
 "Conservar el formato de mayor calidad - Prioriza formatos según tu orden de "
 "prioridad de formatos para duplicados"
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 "Conservar más metadatos - Conserva el libro con la información más completa"
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 "Conservar el mayor tamaño de archivo - Conserva el libro con el mayor tamaño "
 "total de archivos"
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 msgid "Preview"
 msgstr "Vista previa"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr "Ejecutar resolución"
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 "Esto borrará libros de forma permanente. Los archivos originales se "
 "guardarán como copia de seguridad en"
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 msgid "Merge Selected"
 msgstr "Fusionar seleccionados"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr "Descartar este grupo de duplicados"
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 msgid "View book details"
 msgstr "Ver detalles del libro"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 msgid "Edit book metadata"
 msgstr "Editar metadatos del libro"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 msgid "Archive/delete book"
 msgstr "Archivar/borrar libro"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 msgid "No Duplicate Books Found"
 msgstr "No se han encontrado libros duplicados."
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 "Tu biblioteca no tiene libros con combinaciones duplicadas de título y autor."
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
@@ -10833,11 +10661,11 @@ msgstr ""
 "Esta búsqueda busca libros con títulos y autores idénticos para evitar "
 "falsos positivos."
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr "Ejecutar resolución automática"
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
@@ -10845,77 +10673,77 @@ msgstr ""
 "CWA resolverá los grupos de duplicados usando la estrategia seleccionada y "
 "borrará permanentemente los libros duplicados."
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 msgid "Selected strategy:"
 msgstr "Estrategia seleccionada:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr "¡Esta acción no se puede deshacer!"
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 msgid "The following books will be permanently deleted:"
 msgstr "Los siguientes libros se borrarán de forma permanente:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Merge Books"
 msgstr "Fusionar libros"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 msgid "The following book will be kept:"
 msgstr "Se conservará el siguiente libro:"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "Los siguientes libros se fusionarán con él (y luego se borrarán):"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 "Nota: Los formatos de archivo de los libros de origen se añadirán al libro "
 "de destino."
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr "Vista previa de resolución"
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr "Éxito"
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr "¡Los libros duplicados seleccionados se han borrado correctamente!"
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr "Se ha producido un error al procesar su solicitud."
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "Tipo de cuenta de correo electrónico"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr "Cuenta de correo electrónico estándar"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr "Cuenta de Gmail"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr "Configurar cuenta de Gmail"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Revocar acceso a Gmail"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "Contraseña SMTP"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
@@ -10924,35 +10752,35 @@ msgstr ""
 "prueba. Se envía como texto plano, en cualquier idioma. Déjalo en blanco "
 "para usar el predeterminado."
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Tamaño límite del archivo adjunto"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 msgid "Save and Send Test Email"
 msgstr "Guardar y enviar un correo electrónico de prueba"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Dominios Permitidos (Lista Blanca)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Añadir Dominio"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Introducir nombre de dominio"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Dominios Prohibidos (Lista Negra)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr "(Mágica)"
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10960,23 +10788,23 @@ msgstr ""
 "Abre el archivo .kobo/Kobo/Kobo eReader.conf en un editor de texto y añade "
 "(o edita):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Token de Kobo:"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "Lista"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr "Revisión de coincidencias de Hardcover 🔖"
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr "¡Todo al día!"
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
@@ -10985,15 +10813,15 @@ msgstr ""
 "nuevas coincidencias aparecerán aquí cuando se ejecute la tarea de obtención "
 "automática."
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr "Volver al panel de administración"
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr "Revisión requerida"
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
@@ -11003,11 +10831,11 @@ msgstr ""
 "coincidencia y selecciona el resultado correcto, o sáltala/recházala si no "
 "hay una coincidencia adecuada."
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr "Coincidencias pendientes"
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
@@ -11017,66 +10845,60 @@ msgstr ""
 "Las coincidencias de alta confianza se aplican automáticamente; estas "
 "requieren verificación manual."
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 msgid "Reject All Pending"
 msgstr "Rechazar todas las pendientes"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 msgid "Search Query"
 msgstr "Consulta de búsqueda"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr "Coincidencias candidatas"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr "Top %(count)s"
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr "Confianza"
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr "Motivo de la coincidencia"
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 msgid "View on Hardcover"
 msgstr "Ver en Hardcover"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr "Seleccionar esta coincidencia"
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 msgid "Reject All"
 msgstr "Rechazar todas"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr "Saltar por ahora"
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 msgid "Processing..."
 msgstr "Procesando..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr "✓ Seleccionar esta coincidencia"
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr "No se pudo aplicar la coincidencia"
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
@@ -11084,41 +10906,38 @@ msgstr ""
 "¿Seguro que quieres rechazar todas las coincidencias de este libro? Esto no "
 "se puede deshacer."
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr "✗ Rechazar todas las coincidencias"
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject match"
 msgstr "No se pudo rechazar la coincidencia"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr ""
 "¿Seguro que quieres rechazar todas las coincidencias pendientes? Esto no se "
 "puede deshacer."
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Pending"
 msgstr "✗ Rechazar todas las pendientes"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject all pending matches"
 msgstr "No se pudieron rechazar todas las coincidencias pendientes"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr "→ Saltar por ahora"
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr "No se pudo omitir la coincidencia"
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
@@ -11126,61 +10945,61 @@ msgstr ""
 "La instancia de Calibre-Web NextGen no está configurada; contacta con tu "
 "administrador"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Crear incidencia"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Volver al inicio"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "Cerrar sesión"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr "Aviso para móviles"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 "La edición de estanterías mágicas funciona mejor en equipos de escritorio o "
 "tablet."
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr "Actualiza la estantería para reflejar los últimos cambios"
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 msgid "Edit shelf rules"
 msgstr "Editar reglas de la estantería"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr "Ocultar esta estantería de la barra lateral"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Show this shelf in your sidebar"
 msgstr "Mostrar esta estantería en la barra lateral"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 msgid "Show Shelf"
 msgstr "Ver estantería"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 msgid "Hide Shelf"
 msgstr "Ocultar estantería"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 msgid "Add Series to Shelf"
 msgstr "Añadir serie a la estantería"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr "La sincronización con KOReader está desactivada."
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
@@ -11188,201 +11007,200 @@ msgstr ""
 "Actívalo en la Configuración de NextGen para activar los endpoints /kosync y "
 "la generación de sumas de verificación."
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr "Abrir la Configuración de NextGen"
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 "La descarga está disponible después de activar la sincronización con "
 "KOReader en la Configuración de NextGen."
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Inicio"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Alternar navegación"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Buscar en la Biblioteca"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Cambiar a la nueva interfaz de Calibre-Web NextGen"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr "Cambiar a la nueva interfaz"
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Cerrar sesión"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr "Apoya a Calibre-Web NextGen"
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 msgid "Settings"
 msgstr "Ajustes"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 msgid "Refresh Library"
 msgstr "Actualizar Biblioteca"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr "Apoyo"
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 msgid "New interface available"
 msgstr "Nueva interfaz disponible"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr ""
 "Una interfaz de Calibre-Web NextGen más rápida y rediseñada ya está lista."
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr "Tu vista clásica sigue siendo la predeterminada hasta que cambies."
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr "Prueba la nueva interfaz"
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr "Ver registro de cambios"
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 msgid "Open Duplicates"
 msgstr "Abrir duplicados"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr "¡Colabora aquí!"
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Por favor, no actualice la página"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 msgid "Create Shelf"
 msgstr "Crear estantería"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr "Estanterías mágicas ✨"
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Anterior"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Detalles del libro"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 msgid "This cannot be undone."
 msgstr "Esta acción no se puede deshacer."
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 msgid "Will be deleted"
 msgstr "Se borrará"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 msgid "Formats:"
 msgstr "Formatos:"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr "Se conservará"
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr "Conflictos de formato: elige qué hacer:"
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 msgid "Result will have formats:"
 msgstr "El resultado tendrá los formatos:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr "Combinar y borrar el origen"
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 msgid "Duplicate Books Detected"
 msgstr "Libros duplicados detectados"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr "Tienes libros duplicados sin resolver en tu biblioteca"
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 msgid "Duplicate Groups Found"
 msgstr "Grupos de duplicados encontrados"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr "Recordármelo más tarde"
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr "Ver y resolver duplicados"
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 msgid "Scroll to top"
 msgstr "Desplazarse arriba"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 msgid "Top"
 msgstr "Arriba"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Se añadieron {n} libros a {shelf}"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr "Se añadieron {ok} de {n} libros a {shelf} (el resto ya estaba allí)"
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr "Los {n} libro(s) ya estaban en {shelf}."
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Se marcaron {n} libros como leídos"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Se marcaron {n} libros como no leídos"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Se borraron {n} libros"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 msgid "Delete books?"
 msgstr "¿Borrar libros?"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -11391,91 +11209,91 @@ msgstr ""
 "Esto borrará permanentemente {n} libro(s) de tu biblioteca. Esta acción no "
 "se puede deshacer."
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 msgid "Select at least one book first."
 msgstr "Selecciona primero al menos un libro."
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Error en la solicitud: {err}"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr "Filtrar por inicial"
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "Cuadrícula"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 msgid "Show Password"
 msgstr "Mostrar contraseña"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Recordarme"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "¿Olvidó la contraseña?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Iniciar sesión con Magic Link"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 msgid "Log in with SSO"
 msgstr "Iniciar sesión con SSO"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 "El inicio de sesión estándar está deshabilitado. Usa uno de los métodos de "
 "inicio de sesión alternativos."
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Mostrar registro web de Calibre-Web: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Calibre-Web Log: "
 msgstr "Log de Calibre-Web: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Salida en tiempo real, no se puede mostrar"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Mostrar el registro de acceso: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Descargar el registro de Calibre-Web"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "Descargar el registro de acceso"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr "Plantilla del sistema"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 "Esta es una estantería de plantilla preconfigurada. Puedes editarla "
 "libremente."
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 msgid "Share with Everyone (Public)"
 msgstr "Compartir con todos (público)"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
@@ -11483,52 +11301,52 @@ msgstr ""
 "Otros usuarios pueden ver esta estantería. Los usuarios con el permiso "
 "\"Edit Public Shelves\" pueden editarla/borrarla."
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Seleccionar etiquetas Permitidas/Denegadas"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Seleccionar valores de columna personalizados Permitidos/Denegados"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Seleccionar etiquetas de usuario Permitidas/Denegadas"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr ""
 "Seleccionar valores de columna personalizados del usuario Permitidos/"
 "Denegados"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Introduce la etiqueta"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Añadir restricción de vista"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "Este formato de libro se borrará permanentemente de la base de datos"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Este libro se borrará permanentemente de la base de datos"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "y del disco duro"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Nota importante de Kobo: los libros borrados permanecerán en cualquier "
 "dispositivo Kobo emparejado."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11536,280 +11354,280 @@ msgstr ""
 "Los libros deben archivarse primero y sincronizarse con el dispositivo antes "
 "de poder borrarlos de forma segura."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Seleccionar ubicación del archivo"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "tipo"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "nombre"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "tamaño"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "Directorio padre"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "Ok"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Catálogo de eBooks de Calibre-Web NextGen"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "lector de epub"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 msgid "Annotations"
 msgstr "Anotaciones"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr "Abrir la página de anotaciones"
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "Negro"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "Tamaños de letra"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 msgid "Text margin"
 msgstr "Margen de texto"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr "Fuente"
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 msgid "Default"
 msgstr "Por defecto"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr "Yahei"
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr "SimSun"
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 msgid "KaiTi"
 msgstr "KaiTi"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 msgid "Arial"
 msgstr "Arial"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 msgid "Spread"
 msgstr "Extender"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr "Dos columnas"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr "Una columna"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Reajustar el texto cuando las barras laterales están abiertas."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr "Nota"
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr "Añadir una nota (opcional)"
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr "Selecciona dentro de un párrafo para subrayar."
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Lector de Comic"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Atajos de teclado"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Página Anterior"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Página Siguiente"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 msgid "Single Page Display"
 msgstr "Visualización de una sola página"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr "Visualización en tira larga"
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Escala al máximo"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Escalar a la ancho"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Escalar a lo alto"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Escalado nativo"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Rotar hacia la derecha"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Rotar hacia la izquierda"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Voltear imagen"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "Visualización"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 msgid "Single Page"
 msgstr "Página Única"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr "Tira Larga"
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Escalar"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Máximo"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Ancho"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Alto"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Nativo"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Rotar"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Voltear"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Horizontal"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Vertical"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 msgid "Direction"
 msgstr "Dirección"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "De izquierda a derecha"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "De derecha a izquierda"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr "Volver al inicio"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 msgid "Remember Position"
 msgstr "Recordar posición"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "Barra de desplazamiento"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "Mostrar"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "Lector de DJVU"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "Lector de PDF"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "lector de txt"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Registrar nueva cuenta"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Elige un nombre de usuario"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Tu correo electrónico"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Magic Link - Autorizar un nuevo dispositivo"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "En otro dispositivo, inicie sesión y visite:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr ""
 "Una vez verificado, se iniciará sesión automáticamente en este dispositivo."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Este enlace de verificación caducará en 10 minutos."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
@@ -11818,255 +11636,251 @@ msgstr ""
 "programado. Las miniaturas se generan siempre bajo demanda, "
 "independientemente de este ajuste."
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "Generar miniaturas de portadas de series"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "No se han encontrado resultados"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Buscar término:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Resultados para:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Fecha de publicación desde"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Fecha de publicación hasta"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr "Vacío"
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Excluir etiquetas"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Excluir Series"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "Excluir Estanterías"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Excluir Idiomas"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Extensiones"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Extensiones Excluidas"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Valoración mayor que"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Valoración menor que"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "De:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "Para:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Borrar esta Estantería"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "Editar Propiedades de la Estantería"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 msgid "Add Books"
 msgstr "Añadir libros"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "Ordenar libros manualmente"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "Deshabilitar cambio de orden"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "Habilitar cambio de orden"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, python-format
 msgid "%(count)s selected"
 msgstr "%(count)s seleccionado(s)"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, python-format
 msgid "Add %(count)s"
 msgstr "Añadir %(count)s"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 msgid "No books found."
 msgstr "No se han encontrado libros."
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 msgid "Already on this shelf"
 msgstr "Ya está en esta estantería"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr "No se pudieron añadir los libros. Inténtalo de nuevo."
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 msgid "Add books to"
 msgstr "Añadir libros a"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 msgid "Search your library…"
 msgstr "Buscar en tu biblioteca…"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 msgid "Search your library"
 msgstr "Buscar en tu biblioteca"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Compartir con Todos"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "Sincronizar esta estantería con el dispositivo Kobo"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr "Exponer esta estantería en mi feed OPDS"
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 "Arrastra una portada a su nueva posición; el orden se guarda automáticamente."
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 "Teclado: enfoca una portada con Tab y muévela con las teclas de flecha."
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr "Orden guardado"
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr "No se pudo guardar el orden; haz clic aquí para reintentarlo"
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr "Movido a la posición %(num)s de %(total)s"
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 msgid "Shelf order"
 msgstr "Orden de la estantería"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Libro Oculto"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr "Ordenar por"
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr "Aún no tienes estanterías que reordenar."
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 "Arrastra para reorganizar el orden de tus estanterías en la barra lateral."
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 "Orden guardado. La barra lateral reflejará el nuevo orden al cargar la "
 "página de nuevo."
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Estadísticas de la Biblioteca"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Libros en esta Biblioteca"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Autores en esta Biblioteca"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Categorías en esta Biblioteca"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Series en esta Biblioteca"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Estadísticas del Sistema"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "Programa"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Versión Instalada"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr "Resumen de tareas en segundo plano"
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Tiempo de ejecución"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr "Acciones"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr "Próximos envíos programados"
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr "Hora programada"
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 msgid "State"
 msgstr "Estado"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
@@ -12074,15 +11888,15 @@ msgstr ""
 "Los próximos envíos se guardan y se pondrán en cola como tareas a la hora "
 "programada. Puedes cancelar un envío pendiente antes de que se ejecute."
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr "Próximas operaciones programadas"
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr "Tipo"
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
@@ -12090,14 +11904,14 @@ msgstr ""
 "Las ejecuciones de Convert Library y del reparador de EPUB programadas aquí "
 "se mantendrán tras reinicios. Cancélalas para evitar que se lancen."
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 "Esta tarea se cancelará. Se guardará cualquier progreso realizado en esta "
 "tarea."
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
@@ -12105,19 +11919,19 @@ msgstr ""
 "Si se trata de una tarea programada, se volverá a ejecutar en la próxima "
 "hora programada."
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 msgid "Scheduled item cancelled successfully"
 msgstr "Elemento programado cancelado correctamente"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr "Error cancelling scheduled item"
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 msgid "Update Calibre-Web NextGen"
 msgstr "Actualizar Calibre-Web NextGen"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
@@ -12127,40 +11941,40 @@ msgstr ""
 "biblioteca, configuración y progreso de lectura están a salvo: viven en tus "
 "volúmenes montados, no en el contenedor."
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr "¿Cómo ejecutas Calibre-Web NextGen?"
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr "Tipo de instalación"
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr "Docker Compose"
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr "docker run"
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr "Unraid"
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr "Portainer / Synology"
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr "Ejecuta esto desde la carpeta que contiene tu archivo compose:"
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 "Sustituye calibre-web-nextgen por el nombre de tu servicio si es distinto."
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
@@ -12168,7 +11982,7 @@ msgstr ""
 "Descarga la nueva imagen y luego recrea tu contenedor con las mismas "
 "opciones con las que lo iniciaste:"
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
@@ -12177,11 +11991,11 @@ msgstr ""
 "comando docker run habitual. Tus volúmenes montados conservan todos los "
 "datos."
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr "Abre la pestaña Docker en la interfaz web de Unraid."
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
@@ -12189,7 +12003,7 @@ msgstr ""
 "Haz clic en el icono del contenedor Calibre-Web NextGen y elige Force update "
 "(comprueba antes si hay actualizaciones si quieres ver qué ha cambiado)."
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
@@ -12197,11 +12011,11 @@ msgstr ""
 "Para actualizaciones automáticas, instala el complemento «CA Auto Update "
 "Applications» desde Community Applications."
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr "Portainer:"
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
@@ -12209,11 +12023,11 @@ msgstr ""
 "Images → descarga la imagen de abajo, luego Containers → selecciona Calibre-"
 "Web NextGen → Recreate con «Re-pull image» activado."
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr "Synology Container Manager:"
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
@@ -12221,46 +12035,46 @@ msgstr ""
 "Registry → descarga la imagen de abajo (etiqueta: latest), luego detén el "
 "contenedor → Action → Reset para recrearlo."
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr "Configurar actualizaciones automáticas"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "Your Profile"
 msgstr "Tu perfil"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "User Settings"
 msgstr "Configuración de usuario"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr "Información de la cuenta"
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 "Si necesitas cambiar tu dirección de correo o contraseña, puedes hacerlo "
 "aquí."
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Restablecer contraseña del usuario"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 msgid "eReader Configuration"
 msgstr "Configuración del eReader"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 msgid "Send to eReader Email Address"
 msgstr "Dirección de correo para enviar al eReader"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr "Usa comas para separar varias direcciones"
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
@@ -12268,11 +12082,11 @@ msgstr ""
 "Dirección(es) de correo de tus dispositivos eReader. Separa varias "
 "direcciones con comas."
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr "Habilitar la ventana emergente \"Enviar a lector electrónico\""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
@@ -12283,7 +12097,7 @@ msgstr ""
 "electrónico adicionales y enviar el mensaje únicamente a una selección de "
 "direcciones guardadas al enviarlo al lector electrónico."
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
@@ -12291,11 +12105,11 @@ msgstr ""
 "Cuando está desactivado, los correos se enviarán a todas las direcciones de "
 "eReader configuradas sin preguntar."
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr "Enviar automáticamente libros nuevos a mi(s) eReader(s)"
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
@@ -12304,72 +12118,72 @@ msgstr ""
 "automáticamente a todas las direcciones de correo de eReader configuradas "
 "arriba."
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr "Preferencias de idioma y tema"
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 msgid "Interface Language"
 msgstr "Idioma de la interfaz"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Idioma de los libros"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr "Filtra la biblioteca para mostrar solo libros en un idioma específico."
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 msgid "Book Language Filter"
 msgstr "Filtro de idioma de los libros"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr "Integraciones OAuth y API"
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "Ajustes de OAuth"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Vincular"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Desvincular"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr "Token de API de Hardcover"
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 "Token de API para la integración con el proveedor de metadatos Hardcover."
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Token de sincronización de Kobo"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Crear/Ver"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "Forzar sincronización completa con Kobo"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr "Reenviar un libro a este Kobo"
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr "Reenviar"
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
@@ -12378,35 +12192,35 @@ msgstr ""
 "vuelva a descargar en la próxima sincronización. Busca el ID del libro en la "
 "URL de la página de detalles del libro."
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "Sincronizar con Kobo solo los libros de las estanterías seleccionadas"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr "Exposición de estanterías en OPDS"
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "Exponer en OPDS solo los libros de las estanterías seleccionadas"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 msgid "Sidebar Display Settings"
 msgstr "Configuración de visualización de la barra lateral"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr "Elige qué secciones mostrar en la navegación de la barra lateral."
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Añadir valores permitidos/denegados de columnas personalizadas"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr "Orden del catálogo OPDS"
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
@@ -12415,7 +12229,7 @@ msgstr ""
 "orden que quieras. Los IDs desconocidos se ignoran y las entradas que falten "
 "se añaden automáticamente."
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
@@ -12423,74 +12237,74 @@ msgstr ""
 "Arrastra para reordenar las entradas raíz de OPDS. Las entradas que falten "
 "se añaden automáticamente."
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr "Permisos de usuario"
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr "Configura qué acciones puede realizar este usuario."
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Order"
 msgstr "Orden de las estanterías mágicas"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 "En la barra lateral, elige cómo quieres que se ordenen tus estantes mágicos."
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr "Modo de pedido"
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr "Manual (arrastra para reordenar)"
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr "Nombre (A-Z)"
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr "Nombre (Z-A)"
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr "Cantidad de libros (de mayor a menor)"
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr "Cantidad de libros (de menor a mayor)"
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr "Creado (más reciente primero)"
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr "Creado (el más antiguo primero)"
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 msgid "Recently modified"
 msgstr "Modificado recientemente"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr "Modificado hace más tiempo"
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 "El pedido manual solo se utiliza cuando el modo de pedido está configurado "
 "en Manual."
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr "Visibilidad de estanterías mágicas"
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
@@ -12499,33 +12313,33 @@ msgstr ""
 "estanterías del sistema no se pueden borrar, solo ocultar. Las estanterías "
 "públicas de otros usuarios también se pueden ocultar."
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr "Estanterías del sistema por defecto:"
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 msgid "Public Shelves:"
 msgstr "Estanterías públicas:"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr "%(visible)s de %(total)s estanterías por defecto visibles"
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr "%(visible)s de %(total)s estanterías públicas visibles"
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Borrar usuario"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr "Contraseñas de aplicación para OPDS / sincronización con KOReader"
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12538,11 +12352,11 @@ msgstr ""
 "se muestra tras crearla. Puedes revocar cualquier contraseña de aplicación "
 "en cualquier momento sin afectar a tu sesión web activa."
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 msgid "New app password"
 msgstr "Contraseña de aplicación nueva"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
@@ -12550,139 +12364,139 @@ msgstr ""
 "Contraseña de aplicación creada para «%(label)s». Cópiala ahora; no volverás "
 "a verla."
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr "Contraseña de aplicación nueva (en texto plano)"
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr "p. ej. Kobo Forma, KOReader iPad"
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 msgid "Create app password"
 msgstr "Crear contraseña de aplicación"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr "Etiqueta"
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 msgid "Created"
 msgstr "Creado"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr "Usado por última vez"
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr "Nunca"
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr "¿Revocar esta contraseña de aplicación?"
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Generar URL de autenticación de Kobo"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr "Visible"
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Seleccionar..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Eliminar selecciones"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "Editar usuario"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "Introduce el nombre de usuario"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 msgid "Enter Email"
 msgstr "Introduce el correo electrónico"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "Enter eReader Email"
 msgstr "Introduce el correo electrónico del eReader"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "eReader Email"
 msgstr "Correo electrónico del eReader"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 msgid "Enter eReader Email Subject"
 msgstr "Introduce el asunto del correo electrónico del eReader"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 msgid "eReader Email Subject"
 msgstr "Asunto del correo electrónico del eReader"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Idioma"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "Idiomas de libros visibles"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "Editar etiquetas permitidas"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Etiquetas Permitidas"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Editar etiquetas denegadas"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Etiquetas Denegadas"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "Editar valores permitidos en columnas"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "Valores permitidos en columna"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "Editar valores no permitido en columna"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "Valores no permitidos en columna"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "Cambiar contraseña"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "Editar Estanterías Públicas"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "Sincronizar estanterías seleccionadas con Kobo"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 msgid "Expose selected Shelves to OPDS"
 msgstr "Exponer las estanterías seleccionadas en OPDS"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 msgid "Show Read/Unread Section"
 msgstr "Mostrar Selección Leidos/No Leidos"
 

--- a/cps/translations/fi/LC_MESSAGES/messages.po
+++ b/cps/translations/fi/LC_MESSAGES/messages.po
@@ -19,1492 +19,1465 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Tilastot"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 #, fuzzy
 msgid "Server restarted, please reload page."
 msgstr "Palvelin uudelleenkäynnistetty, ole hyvä ja päivitä sivu"
 
-#: cps/admin.py:210
+#: cps/admin.py
 #, fuzzy
 msgid "Performing Server shutdown, please close window."
 msgstr "Palvelinta sammutetaan, ole hyvä ja sulje sivu"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr ""
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr ""
 
-#: cps/admin.py:232
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 "Kirja lisätty onnistuneeksi lähetettäväksi osoitteeseen %(eReadermail)s"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr ""
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 
-#: cps/admin.py:414
+#: cps/admin.py
 msgid "Hardcover ID applied successfully"
 msgstr ""
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr ""
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr ""
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr ""
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr ""
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr ""
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Ylläpitosivu"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "OAuth asetukset"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Perusasetukset"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Käyttöliittymän asetukset"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Edit Users"
 msgstr "Pääkäyttäjä"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Kaikki"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr ""
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr ""
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Näytä kaikki"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr ""
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr ""
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr ""
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr ""
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr ""
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr ""
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr ""
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr ""
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr ""
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr ""
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr ""
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr ""
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr ""
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr ""
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr ""
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr ""
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr ""
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Oletko varma, että haluat poistaa hyllyn?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 #, fuzzy
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr "Oletko varma, että haluat poistaa hyllyn?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1095
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
 msgstr "Oletko varma, että haluat poistaa hyllyn?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1100
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr "Oletko varma, että haluat poistaa hyllyn?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
 msgstr "Oletko varma, että haluat poistaa hyllyn?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 #, fuzzy
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Haluatko varmasti pysäyttää Calibre-Webin?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr ""
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr ""
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr ""
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Valtuutusta ei löytynyt"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr ""
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr ""
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr ""
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr ""
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr ""
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
 msgstr ""
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr ""
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Muuta SMTP asetuksia"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr ""
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr ""
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
 msgstr ""
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Testisähköpostin lähetyksessä tapahtui virhe: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr ""
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Sähköpostipalvelimen tiedot päivitetty"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "Pääkäyttäjä"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Ole hyvä ja aseta SMTP postiasetukset ensin..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 msgid "Please set an email address on your own account first..."
 msgstr ""
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "luo hylly"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
 msgstr ""
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
 "delivery."
 msgstr ""
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr ""
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr ""
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr ""
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr ""
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Tapahtui tuntematon virhe. Yritä myöhemmin uudelleen."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "Otsikko"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Muokkaa käyttäjää %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Käyttäjän %(user)s salasana palautettu"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Ole hyvä ja aseta SMTP postiasetukset ensin..."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Lokitiedoston katselin"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Haetaan päivitystiedostoa"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Ladataan päivitystiedostoa"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Puretaan päivitystiedostoa"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Korvataan tiedostoja"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Tietokantayhteydet on katkaistu"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Sammutetaan palvelin"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Päivitys valmistui, ole hyvä ja paina OK ja lataa sivu uudelleen"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Päivitys epäonnistui:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "HTTP virhe"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Yhteysvirhe"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Aikakatkaisu yhteyttä luotaessa"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Yleinen virhe"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr ""
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr ""
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr ""
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr ""
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr ""
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr ""
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr ""
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr ""
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr ""
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr ""
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr ""
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 #, fuzzy
 msgid "Database Settings updated"
 msgstr "Sähköpostipalvelimen tiedot päivitetty"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 #, fuzzy
 msgid "Database Configuration"
 msgstr "Ominaisuuksien asetukset"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Ole hyvä ja täytä kaikki kentät!"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "Sähköpostiosoite ei ole toimivasta domainista"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Lisää uusi käyttäjä"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Käyttäjä '%(user)s' lisätty"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "Tälle sähköpostiosoitteelle tai tunnukselle löytyi jo tili."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Käyttäjä '%(nick)s' poistettu"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr ""
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "Pääkäyttäjiä ei jää jäljelle, käyttäjää ei voi poistaa"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr ""
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Käyttäjä '%(nick)s' päivitetty"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr ""
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr ""
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Yhteysvirhe"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr ""
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "Ei päivitystietoa saatavilla"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr ""
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr ""
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr ""
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "Tapahtui tuntematon virhe. Yritä myöhemmin uudelleen."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "Yhteysvirhe"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Yhteysvirhe"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "Tiedosto %(file)s tallennettu"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr ""
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr ""
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr ""
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr ""
 
-#: cps/constants.py:265
+#: cps/constants.py
 #, fuzzy
 msgid "Finnish"
 msgstr "Valmistui"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr ""
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr ""
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr ""
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr ""
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr ""
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr ""
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr ""
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr ""
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr ""
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr ""
 
-#: cps/constants.py:276
+#: cps/constants.py
 #, fuzzy
 msgid "Polish"
 msgstr "Julkaisija"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr ""
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr ""
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr ""
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr ""
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr ""
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr ""
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr ""
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr ""
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr ""
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr ""
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "ei asennettu"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr ""
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, python-format
 msgid "Change cover — %(title)s"
 msgstr ""
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Yhteysvirhe"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr ""
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Book ID"
 msgstr "Kirjat"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Kirjan otsikko"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "Kirjailija"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr ""
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "Tiedotomuodot"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filename"
 msgstr "Lempinimi"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr ""
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr ""
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "Lataa tiedostomuoto"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "Tuntematon"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr ""
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "Virheellinen hylly valittu"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "Merkitse lukemattomaksi"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "%(format)s tiedostomuotoa ei löytynyt levyltä"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 msgid "EPUB Fixer started for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr ""
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr ""
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 msgid "Invalid image data format."
 msgstr ""
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr ""
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Ei mitään"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "Poista kirja"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "Poista kirja"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "Poista kirja"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "Tulosket haulle:"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 msgid "Invalid resolution strategy"
 msgstr ""
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Lataus tehty, prosessoidaan, ole hyvä ja odota..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 msgid "Failed to queue upload for processing"
 msgstr ""
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Lähteen tai kohteen tiedostomuoto puuttuu"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "Kirja lisätty muutosjonoon muotoon %(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Kirjan muunnoksessa tapahtui virhe: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 #, fuzzy
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr ""
 "Tiedostopääte '%(ext)s' ei ole sallittujen palvelimelle ladattavien listalla"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr ""
 "Tiedostopääte '%(ext)s' ei ole sallittujen palvelimelle ladattavien listalla"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "Ladattavalla tiedostolla on oltava tiedostopääte"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr "Virhe eKirjan avaamisessa. Tiedostoa ei ole tai se ei ole saatavilla:"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr ""
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "%(langname)s ei ole kelvollinen kieli"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Metadata päivitetty onnistuneesti"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr ""
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Tuntematon"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
 msgstr ""
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr ""
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr ""
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr ""
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr ""
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "muokkaa metadataa"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr ""
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr ""
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Polun %(path)s luonti epäonnistui (Ei oikeutta)."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Tiedoston %(file)s tallennus epäonnistui."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Tiedostoformaatti %(ext)s lisätty %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Valtuutusta ei löytynyt"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "%(format)s tiedostomuotoa ei löytynyt levyltä"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1512,7 +1485,7 @@ msgstr ""
 "Google Drive asetukset ei ole valmiit. Koita poistaa Google Drive käytöstä "
 "ja ottaa se uudelleen käyttöön"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1520,107 +1493,106 @@ msgstr ""
 "Paluuosoitteen domain ei ole varmistettu, seuraa ohjeita vamistaaksesi sen "
 "googlen kehittäjäkonsolissa"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "%(format)s tiedostomuotoa ei löytynyt kirjalle: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(format)s ei löytynyt Google Drivesta: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s ei löydy: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 #, fuzzy
 msgid "Send to eReader"
 msgstr "Lähetä Kindleen"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "%(format)s tiedostomuotoa ei löytynyt kirjalle: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "%(format)s tiedostomuotoa ei löytynyt kirjalle: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 #, fuzzy
 msgid "Test Email"
 msgstr "Testi sähköposti"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Rekiströintisähköposti käyttäjälle: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Muunna %(orig)s muotoon %(format)s ja lähetä Kindleen"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Lähetä %(format)s Kindleen"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "%(book)s send to eReader"
 msgstr "Lähetä Kindleen"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "Haettua tiedostoa ei pystytty lukemaan. Ehkä vaäärät oikeudet?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr ""
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
 msgstr ""
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr ""
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
 "%(path)s"
 msgstr ""
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, fuzzy, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
@@ -1628,192 +1600,192 @@ msgstr ""
 "Tiedon muuttaminen arvosta: '%(src)s' arvoon '%(dest)s' epäonnistui "
 "virheeseen: %(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Tiedostoa %(file)s ei löytynyt Google Drivesta"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Tiedon muuttaminen arvosta: '%(src)s' arvoon '%(dest)s' epäonnistui "
 "virheeseen: %(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Kirjan polkua %(path)s ei löytynyt Google Drivesta"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr ""
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr ""
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr ""
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr ""
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr ""
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr ""
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr ""
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
 msgstr ""
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr ""
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr ""
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr ""
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr ""
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr ""
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr ""
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr ""
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr ""
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr ""
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr ""
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr ""
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr ""
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr ""
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Rekisteröi tuottajalle %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "Calibre-Web asetukset päivitetty"
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1821,35 +1793,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "olet nyt kirjautunut tunnuksella: \"%(nickname)s\""
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr ""
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1857,4154 +1829,4086 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 msgid "OAuth system error. Please contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr ""
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr ""
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr ""
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "GitHubiin kirjautuminen epäonnistui."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Käyttäjätietojen haku GitHubista epäonnistui"
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Googleen kirjautuminen epäonnistui."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Käyttäjätietojen haku Googlesta epäonnistui."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "Failed to log in with Generic OAuth."
 msgstr "GitHubiin kirjautuminen epäonnistui."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "GitHub Oauth virhe, yritä myöhemmin uudelleen."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr ""
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Google Oauth virhe, yritä myöhemmin uudelleen."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr ""
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr ""
 
-#: cps/opds.py:164
+#: cps/opds.py
 #, fuzzy
 msgid "Alphabetical Books"
 msgstr "Poista kirja"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr ""
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Kuumat kirjat"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "Suositut julkaisut tästä kokoelmasta perustuen latauksiin."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Parhaiten arvioidut kirjat"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Suositut julkaisut tästä kokoelmasta perustuen arvioihin."
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "Luetut kirjat"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Viimeisimmät kirjat"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Satunnaisia kirjoja"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Näytä satunnausia kirjoja"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Luetut kirjat"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Nykyinen versio"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Lukemattomat kirjat"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Kirjailijat"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Kirjat kirjailijoittain"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Julkaisijat"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Kirjat julkaisijoittain"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Kategoriat"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Kirjat kategorioittain"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Sarjat"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Kirjat sarjoittain"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Kielet"
 
-#: cps/opds.py:237
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by Languages"
 msgstr "Kirjat sarjoittain"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Arvostelut"
 
-#: cps/opds.py:243
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by Rating"
 msgstr "Kirjat kategorioittain"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Tiedotomuodot"
 
-#: cps/opds.py:249
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by file formats"
 msgstr "Kirjat sarjoittain"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr ""
 
-#: cps/opds.py:255
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in shelves"
 msgstr "Kirjat sarjoittain"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Muokkaa hyllyä"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Kirjat sarjoittain"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "Kuvaus"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr ""
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Hae"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Kirjaudu sisään"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Valtuutusta ei löytynyt"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Valtuutus vanhentunut"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Onnistui! Ole hyvä ja palaa laitteellesi"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Kirjat"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Näytä viimeisimmät kirjat"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Näytä kuumat kirjat"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr ""
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr ""
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Näytä parhaiten arvioidut kirjat"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Read and Unread"
 msgstr "Näytä luetut ja lukemattomat"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Näyt lukemattomat"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Löydä"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Category Section"
 msgstr "Näytä kategoriavalinta"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Series Section"
 msgstr "Näytä sarjavalinta"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Author Section"
 msgstr "Näytä kirjailijavalinta"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Publisher Section"
 msgstr "Näytä julkaisijavalinta"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Language Section"
 msgstr "Näytä keilivalinta"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Ratings Section"
 msgstr "Näytä arvosteluvalinta"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show File Formats Section"
 msgstr "Näytä tiedostomuotovalinta"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr ""
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Archived Books"
 msgstr "Näytä viimeisimmät kirjat"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr ""
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr ""
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr ""
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Näytä parhaiten arvioidut kirjat"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Julkaistu alkaen "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Julkaisut ennen "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Arvostelu <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Arvostelu >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr ""
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Edistynyt haku"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Virheellinen hylly valittu"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 #, fuzzy
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr ""
 "Valitettavasti sinulla ei ole oikeutta lisätä kirjaa hyllyyn: %(shelfname)s"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "Kirja on jo hyllyssä: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "Kirja on lisätty hyllyyn: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr ""
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Kirjat on jo osa hyllyssä: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "Kirjat on lisätty hyllyyn: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Kirjojen lisäys hyllyyn: %(sname)s epäonnistui"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "Virheellinen hylly valittu"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Kirjojen lisäys hyllyyn: %(sname)s epäonnistui"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Kirjat on jo osa hyllyssä: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "Kirjat on lisätty hyllyyn: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "Kirja on poistettu hyllystä: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr ""
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "luo hylly"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 #, fuzzy
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr ""
 "Valitettavsti sinulla ei ole oikeutta poistaa kirjaa hyllystä: %(sname)s"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Muokkaa hyllyä"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr ""
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 #, fuzzy
 msgid "Shelf successfully deleted"
 msgstr "Metadata päivitetty onnistuneesti"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Muuta hyllyn: '%(name)s' järjestystä"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr ""
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Hylly %(title)s luotu"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Hylly %(title)s muutettu"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Tapahtui virhe"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr ""
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr ""
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Hylly: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Virhe hyllyn avauksessa. Hyllyä ei ole tai se ei ole saatavilla"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Poissulje sarja"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr ""
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr ""
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr ""
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr ""
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Kyllä"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Ei"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr ""
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Teema"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Vaalea"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Tumma"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr ""
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Lisää hyllyyn"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Kirjailija"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Selaa"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Sulje"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Poista"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr ""
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Julkaisija"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Luettu"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Otsikko"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Lähetä"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Tili"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Ylläpito"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr ""
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Lähde"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "Tietoja"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Kuvaus"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Lataa"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Muokkaa"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "Sähköposti"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr ""
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Kieli"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Salasana"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Portti"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Edistyminen"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Arvostelu"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr ""
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Tila"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Tunnisteet"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Tehtävä"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Tehtävät"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Käyttäjä"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Lempinimi"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr ""
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Odottaa"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Epäonnistui"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Aloitettu"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Valmistui"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr ""
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr ""
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Tuntematon tila"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Odottamatonta tietoa luettaessa päivitystietoa"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr "Ei päivitystä saatavilla. Sinulla on jo uusin versio"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6012,15 +5916,15 @@ msgstr ""
 "Uusi päivitys saatavilla. Paina alla olevaa nappia päivittääksesi uusimpaan "
 "versioon."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Päivitystiedon hakeminen epäonnistui"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr "Paina alla olevaa nappia päivittääksesi uusimpaan vakaaseen versioon."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6029,1033 +5933,1001 @@ msgstr ""
 "Uusi päivitys saatavilla. Paina alla olevaa nappia päivittääksesi versioon: "
 "%(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Ei päivitystietoa saatavilla"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Löydä (satunnaiset kirjat)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Kuumat kirjat (ladatuimmat)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr ""
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Kirjailija: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Julkaisija: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Sarja: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr ""
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Arvostelu: %(rating)s tähteä"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Tiedostomuoto: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Kategoria: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Kieli: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Kuumat kirjat"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Näytä ekirjat"
 
-#: cps/web.py:1193
+#: cps/web.py
 msgid "Error loading magic shelf"
 msgstr ""
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "Tiedotomuodot"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 msgid "Invalid request"
 msgstr ""
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr ""
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 msgid "Error creating shelf"
 msgstr ""
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "luo hylly"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 msgid "Shelf name is required"
 msgstr ""
 
-#: cps/web.py:1647
+#: cps/web.py
 msgid "Error updating shelf"
 msgstr ""
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "Muokkaa hyllyä"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "Valtuutusta ei löytynyt"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "Metadata päivitetty onnistuneesti"
 
-#: cps/web.py:1710
+#: cps/web.py
 msgid "Error duplicating shelf"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 msgid "Error deleting shelf"
 msgstr ""
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "Muokkaa hyllyä"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 msgid "Error unhiding shelf"
 msgstr ""
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "DLS"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Tiedostomuotolistaus"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 #, fuzzy
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Ole hyvä ja aseta SMTP postiasetukset ensin..."
 
-#: cps/web.py:2400
+#: cps/web.py
 #, fuzzy
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr "Ole hyvä ja aseta Kindle sähköpostiosoite ensin..."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr ""
 "Kirja lisätty onnistuneeksi lähetettäväksi osoitteeseen %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Kirjan: %(res)s lähettämisessa tapahtui virhe"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr ""
 "Kirja lisätty onnistuneeksi lähetettäväksi osoitteeseen %(eReadermail)s"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Rekisteröi"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr ""
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr ""
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "Sähköpostiosoitteellasi ei ole sallittua rekisteröityä"
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "Vahvistusviesti on lähetetty sähköpostiosoitteeseesi."
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
 msgstr "Calibre-Web asetukset päivitetty"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "Calibre-Web asetukset päivitetty"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 #, fuzzy
 msgid "Cannot activate LDAP authentication"
 msgstr "LDAP autnetikoinnin aktivointi ei onnistu"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr ""
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, fuzzy, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "olet nyt kirjautunut tunnuksella: \"%(nickname)s\""
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "olet nyt kirjautunut tunnuksella: \"%(nickname)s\""
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
 msgstr "Calibre-Web asetukset päivitetty"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
 "known"
 msgstr ""
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr ""
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 #, fuzzy
 msgid "Wrong Username or Password"
 msgstr "Väärä käyttäjätunnus tai salasana"
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr ""
 
-#: cps/web.py:2836
+#: cps/web.py
 #, fuzzy
 msgid "An unknown error occurred. Please try again later."
 msgstr "Tapahtui tuntematon virhe. Yritä myöhemmin uudelleen."
 
-#: cps/web.py:2838
+#: cps/web.py
 #, fuzzy
 msgid "Please enter valid username to reset password"
 msgstr "Väärä käyttäjätunnus tai salasana"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, fuzzy, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "olet nyt kirjautunut tunnuksella: \"%(nickname)s\""
 
-#: cps/web.py:3158
+#: cps/web.py
 #, fuzzy
 msgid "Success! Profile Updated"
 msgstr "Profiili päivitetty"
 
-#: cps/web.py:3164
+#: cps/web.py
 #, fuzzy
 msgid "Oops! An account already exists for this Email."
 msgstr "Tälle sähköpostiosoitteelle läytyi jo käyttäjätunnus."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr ""
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr ""
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "Lähetä Kindleen"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "Lähetä Kindleen"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 msgid "Auto-send completed successfully"
 msgstr ""
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr ""
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr ""
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, fuzzy, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "Lähetä Kindleen"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr ""
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "%(format)s tiedostomuotoa ei löytynyt levyltä"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 #, fuzzy
 msgid "Ebook converter failed with unknown error"
 msgstr "E-kirjan muunnos epäonnistui: %(error)s"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, fuzzy, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "E-kirjan muunnos epäonnistui: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre epäonnistui virheeseen: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "E-kirjan muunnos epäonnistui: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 #, fuzzy
 msgid "Reconnecting Calibre database"
 msgstr "Calibre -tietokannan paikka"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "Poista kirja"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Poista kirja"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Puretaan päivitystiedostoa"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Tulosket haulle:"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 msgid "Hardcover Sync"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 #, fuzzy
 msgid "E-mail"
 msgstr "Sähköposti"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 #, fuzzy
 msgid "Backing up Metadata"
 msgstr "muokkaa metadataa"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "Kirjastossa"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "Kirjat sarjoittain"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Salli sananan vaihto"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "luo hylly"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "OAuth asetukset"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Asetukset"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "valitse vaihtoehto"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "Lisää hyllyyn"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "DLS"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "DLS"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 msgid "Date added, newest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 msgid "Date added, oldest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Kirjailija"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Kirjailija"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Julkaisut ennen "
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Julkaisut ennen "
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Lisää hyllyyn"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "Lisää hyllyyn"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Send to eReader Email"
 msgstr "Kindle"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "Lähetä Kindleen"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Näytä ekirjat"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Public Shelf"
 msgstr "Muokkaa hyllyä"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr ""
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr ""
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "SMTP sähköpostipalvelimen asetukset"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "SMTP palvein"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "SMTP portti"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "SMTP tunnus"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Lähettäjän sähköposti"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Service"
 msgstr "SMTP sähköpostipalvelimen asetukset"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr ""
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Calibre DB hakemisto"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Lokitaso"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 #, fuzzy
 msgid "External Port"
 msgstr "Ulkoiset binäärit"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Kirjaa sivulla"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Lähetetään"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Nimetön selaus"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Julkinen rekisteröinti"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Etäkirjautuminen"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr ""
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr ""
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Edit Basic Configuration"
 msgstr "Perusasetukset"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Edit UI Configuration"
 msgstr "Käyttöliittymän asetukset"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Edit Calibre Database Configuration"
 msgstr "Calibre DB hakemisto"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr ""
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Start Time"
 msgstr "Aloitettu"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr ""
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr ""
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 #, fuzzy
 msgid "Reconnect Calibre Database"
 msgstr "Calibre -tietokannan paikka"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr ""
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr ""
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Setup KOReader Sync"
 msgstr "PDF lukija"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr ""
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Ylläpito"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Download Debug Package"
 msgstr "Ladataan päivitystiedostoa"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Katsele lokitiedostoja"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Uudellenkäynnistä Calibre-Web"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Sammuta Calibre-Web"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr ""
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Versio"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Yksityiskohdat"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "Päivitys epäonnistui:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Päivityskanava"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Nykyinen versio"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Tarkista päivitykset"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Päivitä"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Haluatko varmasti uudelleenkäynnistää Calibre-Webin?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Haluatko varmasti pysäyttää Calibre-Webin?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Päivitetään, älä päivitä sivua"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7063,626 +6935,603 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Kirjat tässä kirjastossa"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Ladataan..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "Päivitys epäonnistui:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Yhteysvirhe"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Sarja: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr ""
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "Kirjastossa"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "vähennä"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Enemmän"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Poista kirja"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Poista tiedostomuodot:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Muunna kirjan tiedostomuoto:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Muunna muodosta:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "select an option"
 msgstr "valitse vaihtoehto"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Muunna muotoon:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Muunna kirja"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Virhe"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Lataa tiedostomuoto"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 #, fuzzy
 msgid "Series ID"
 msgstr "Sarjat"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Julkaisupäivä"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr ""
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr ""
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr ""
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr ""
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Kannen osoite (jpg, kuva ladataan ja tallennetaan tietokantaan, kenttä jää "
 "uudelleen tyhjäksi)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Lataa kuva paikalliselta levyltä"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 msgid "Hardcover Sync Blacklist"
 msgstr ""
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "katso kirjaa muokkauksen jälkeen"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Hae metadata"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Avainsana"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Search keyword"
 msgstr " Hae avainsanaa "
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Ladataan..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Hakuvirhe!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "Ei osumia! Kokeile jotain tosita hakusanaa."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr ""
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr ""
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "luo hylly"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr ""
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 msgid "Update Title Sort automatically  "
 msgstr ""
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr ""
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Title"
 msgstr "Testi sähköposti"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr ""
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Title Sort"
 msgstr "Otsikko"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr ""
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Author Sort"
 msgstr "Kirjailija"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Authors"
 msgstr "Kirjailijat"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Categories"
 msgstr "Kategoriat"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Series"
 msgstr "Poissulje sarja"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Languages"
 msgstr "Poissulje kieli"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Julkaisupäivä"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Publishers"
 msgstr "Julkaisijat"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter comments"
 msgstr "Syötä domainnimi"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Comments"
 msgstr "Syötä domainnimi"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Archived?"
 msgstr "Hae"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Read?"
 msgstr "Luettu"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter "
 msgstr "Rekisteröi"
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Oletko aivan varma?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr ""
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Into Book with Title:"
 msgstr "Kirjan otsikko"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr ""
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr ""
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr ""
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr ""
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr ""
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Muokkaa metadataa"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "luo hylly"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr ""
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Lisää"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Kindle"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Lähetä Kindleen"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Palaa"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Calibre -tietokannan paikka"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7698,13 +7547,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7715,7 +7564,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7726,43 +7575,43 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr ""
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
 "can be wherever you desire"
 msgstr ""
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Käytä Google Drivea?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Autentikoi Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Google Drive Calibre -kansio"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "Metadata Katso kanava ID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Kumoa"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Calibre -tietokannan paikka"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7772,131 +7621,131 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "Haluatko varmasti pysäyttää Calibre-Webin?"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Calibre -tietokannan paikka"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr ""
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Käytä oletuskirjautumista"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Käytä LDAP kirjautumista"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Käytä OAuth kirjautumista"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Palvelinasetukset"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Palvelimen portti"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL sertifikaatin paikka (jätä tyhjäksi ei-SSL -palvelimella)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL avaintiedoston paikka (jätä tyhjäksi ei-SSL -palvelimella)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Päivityskanava"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Vakaa"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Öinen"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr ""
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Lokitiedoston asetukset"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "Pääsylokitiedoston nimi ja paikka (access.log jos ei asetettu)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Ota pääsyloki käyttöön"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "Pääsylokitiedoston nimi ja paikka (access.log jos ei asetettu)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "Palvelinasetukset"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Salli lähetys"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr ""
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Allowed Upload Fileformats"
 msgstr "Lataa tiedostomuoto"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Salli nimetön selailu"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Salli julkinen rekisteröinti"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Use Email as Username"
 msgstr "Valitse käyttäjänimi"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Salli etäkirjautuminen (\"magic link\")"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7904,153 +7753,153 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr ""
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr ""
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Käytä Goodreads -palvelua"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Goodreads API-avain"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 msgid "Enable Hardcover Sync"
 msgstr ""
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "Valtuutus vanhentunut"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Goodreads API-avain"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8058,419 +7907,419 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Käytä LDAP kirjautumista"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Kirjautumisen tyyppi"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "LDAP palvelimen nimi tai IP osoite"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "LDAP Palveimen portti"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Encryption"
 msgstr "SSL"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Authentication"
 msgstr "Käytä LDAP kirjautumista"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr ""
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "LDAP pääkäyttäjän käyttäjänimi"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "LDAP pääkäyttäjän salasana"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "LDAP DN"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "LDAP käyttäjä suodin (object filter)"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "LDAP palvelin on OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr ""
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Group Object Filter"
 msgstr "LDAP käyttäjä suodin (object filter)"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr ""
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr ""
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr ""
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr ""
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Member User Filter"
 msgstr "LDAP käyttäjä suodin (object filter)"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "Hae metadata"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
 msgstr ""
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "Käyttöliittymän asetukset"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "Valtuutusta ei löytynyt"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "Yhteysvirhe"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "OAuth asetukset"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Id"
 msgstr "%(provider)s OAuth asiakas Id"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Secret"
 msgstr "%(provider)s OAuth asiakas salaisuus"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "Näytä konfiguraatio"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "Lempinimi"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr ""
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "SMTP sähköpostipalvelimen asetukset"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr ""
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 msgid "OAuth Group Claim"
 msgstr ""
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr ""
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Uuden käyttäjän oletusasetukset"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Salli kirjojen lataukset"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Salli kirjojen luku"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Salli lisäykset"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Salli muutokset"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Allow Delete Books"
 msgstr "Poista kirja"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Salli sananan vaihto"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Salli julkisten hyllyjen editointi"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr ""
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Hanki %(provider)s OAuth valtuutus"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "%(provider)s OAuth asiakas Id"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "%(provider)s OAuth asiakas salaisuus"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Ulkoiset binäärit"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr ""
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 msgid "Calibre E-Book Converter Settings"
 msgstr ""
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr ""
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "UnRar binäärin paikka"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Security Settings"
 msgstr "OAuth asetukset"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8478,340 +8327,335 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr ""
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr ""
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr ""
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Session protection"
 msgstr "valitse vaihtoehto"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr ""
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr ""
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "User Password policy"
 msgstr "Nollaa käyttäjän salasana"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr ""
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr ""
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Näytä konfiguraatio"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Satunnaisten kirjojen näytön lukumäärä"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr "Kirjailijoiden lukumäärä ennen piilotusta (0=poista piilotus)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "Poista"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "caliBlur! Tumma teema"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Regular expression sarakkeiden poisjättämiseen"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Linkitä luettu/ei luettu -tieto Calibren sarakkeeseen"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "Linkitä luettu/ei luettu -tieto Calibren sarakkeeseen"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Regular expression nimikkeiden järjestämiseen"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Näytä konfiguraatio"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 msgid "Custom CSS"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Uuden käyttäjän oletusasetukset"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "Versio"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Pääkäyttäjä"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "Ylläpitosivu"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Language"
 msgstr "Poissulje kieli"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "Uuden käyttäjän oletusasetukset"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Visible Language of Books"
 msgstr "Näytä kirjat kielellä"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "Oletusnäkymä uusille käyttäjille"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Oletusnäkymä uusille käyttäjille"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Näytä satunnaisia kirjoja näkymässä"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr ""
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Lähetä"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "Hae"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "Lataa"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Aloita"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8820,14 +8664,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8835,91 +8679,90 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on selected book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error scheduling EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "Tulosket haulle:"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "Valitse käyttäjänimi"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "Kirjastossa"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "luo hylly"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer started for selected book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error starting EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Calibre-Web asetukset päivitetty"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8927,11 +8770,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -8942,11 +8785,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -8956,161 +8799,161 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 msgid "Enable Archived Book Cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9118,11 +8961,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9130,109 +8973,107 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "Metadata päivitetty onnistuneesti"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 msgid "Identifiers (ISBN, etc.)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "Löydä"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
 "investigation."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9240,157 +9081,157 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "OAuth asetukset"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "Asetukset"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "OAuth asetukset"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9398,102 +9239,101 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "OAuth asetukset"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9501,44 +9341,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Muunna kirjan tiedostomuoto:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9546,2440 +9386,2414 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Salli julkinen rekisteröinti"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "OAuth asetukset"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Salli julkinen rekisteröinti"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Salli julkinen rekisteröinti"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Poista tiedostomuodot:"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Hae metadata"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Arvostelu"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Seuraava"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Merkitse lukemattomaksi"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Merkitse luetuksi"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "Merkitse lukemattomaksi"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "Merkitse lukemattomaksi"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Lisää hyllyyn"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Lisää hyllyyn"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr ""
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, fuzzy
 msgid "Add to archive"
 msgstr "Lisää hyllyyn"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "Lisää hyllyyn"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "Kirjastossa"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "Sähköpostipalvelimen tiedot päivitetty"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "Arvio enemmän kun"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr ""
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr ""
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Kuvaus:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "Kindle"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "Kindle"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "luo hylly"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "Poista tiedostomuodot:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 msgid "Failed to update tags"
 msgstr ""
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "Tiedoston %(file)s tallennus epäonnistui."
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr ""
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Poista kirja"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "Näytä parhaiten arvioidut kirjat"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "luo hylly"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "Poista kirja"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Poista kirja"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "Edellinen"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "Poista kirja"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "Kirjan tiedot"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "muokkaa metadataa"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "Näytä viimeisimmät kirjat"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "Tulosket haulle:"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr ""
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Poista tiedostomuodot:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be permanently deleted:"
 msgstr "Kirja poistetaan Calibren tietokannasta"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "Lukemattomat kirjat"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "Kirja poistetaan Calibren tietokannasta"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "Kirja poistetaan Calibren tietokannasta"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr ""
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr ""
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr ""
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Email Account Type"
 msgstr "Tili"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Standard Email Account"
 msgstr "Tili"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Gmail Account"
 msgstr "Tili"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Setup Gmail Account"
 msgstr "Tili"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr ""
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "SMTP salasana"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr ""
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Save and Send Test Email"
 msgstr "Tallenna asetukset ja testaa sähköpostia"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Rekisteröinnissä sallitut domainit"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Lisää domain"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Syötä domainnimi"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Denied Domains (Blacklist)"
 msgstr "Rekisteröinnissä sallitut domainit"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr ""
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "luo hylly"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "Hakuvirhe!"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "katso kirjaa muokkauksen jälkeen"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "luo hylly"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "Ladataan..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr "Oletko varma, että haluat poistaa hyllyn?"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "luo hylly"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject all pending matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "Calibre-Web asetukset päivitetty"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Luo virheilmoitus"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Palaa kotiin"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 #, fuzzy
 msgid "Logout User"
 msgstr "Kirjaudu ulos"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "Muokkaa hyllyä"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Show this shelf in your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "Näytä kaikki"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "Muokkaa hyllyä"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Lisää hyllyyn"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Koti"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Vaihda navigointi"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Search Library"
 msgstr "Kirjastossa"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Calibre-Web e-kirjaluettelo"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Kirjaudu ulos"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "Asetukset"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "Sarjat kirjastossa"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Ei päivitystietoa saatavilla"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Calibre-Web e-kirjaluettelo"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Poista kirja"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Please do not refresh the page"
 msgstr "Päivitetään, älä päivitä sivua"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "luo hylly"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Edellinen"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Kirjan tiedot"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Haluatko varmasti pysäyttää Calibre-Webin?"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Poista kirja"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Lataa tiedostomuoto"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Poista tiedostomuodot:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Poista kirja"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Tulosket haulle:"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Skaalaa parhaaseen"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "Asetukset"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Lisää hyllyyn"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Merkitse lukemattomaksi"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Merkitse lukemattomaksi"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Poista kirja"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Poista kirja"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "luo hylly"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Yhteysvirhe"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr ""
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr ""
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "SMTP salasana"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Muista minut"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 #, fuzzy
 msgid "Forgot Password?"
 msgstr "Salasana"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Kirjadu käyttäen magic link"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 #, fuzzy
 msgid "Log in with SSO"
 msgstr "Kirjadu käyttäen magic link"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr ""
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Calibre-Web Log: "
 msgstr "Calibre-Web testisähköposti"
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr ""
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Show Access Log: "
 msgstr "Ota pääsyloki käyttöön"
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr ""
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Download Access Log"
 msgstr "Ota pääsyloki käyttöön"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "pitäisikö hyllyn olla julkinen?"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Enter Tag"
 msgstr "Rekisteröi"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "This book format will be permanently erased from database"
 msgstr "Kirja poistetaan Calibren tietokannasta"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Kirja poistetaan Calibren tietokannasta"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "ja kiintolevyltä"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Choose File Location"
 msgstr "Näytä tiedostomuotovalinta"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "name"
 msgstr "Lempinimi"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Parent Directory"
 msgstr "Calibre DB hakemisto"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 #, fuzzy
 msgid "Ok"
 msgstr "Kirja"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Calibre-Web e-kirjaluettelo"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 #, fuzzy
 msgid "epub Reader"
 msgstr "PDF lukija"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 msgid "Annotations"
 msgstr ""
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 #, fuzzy
 msgid "Black"
 msgstr "Palaa"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr ""
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Seuraava sivu"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr ""
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 #, fuzzy
 msgid "Default"
 msgstr "Poista"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr ""
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr ""
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 #, fuzzy
 msgid "KaiTi"
 msgstr "Odottaa"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 #, fuzzy
 msgid "Arial"
 msgstr "Pystysuunta"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 #, fuzzy
 msgid "Spread"
 msgstr "Luettu"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr ""
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr ""
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Uudelleenjärjestä teksti kun sivut on auki."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Comic Reader"
 msgstr "PDF lukija"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Näppäimistöpikakomennot"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Edellinen sivu"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Seuraava sivu"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page Display"
 msgstr "Ylläpitosivu"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Skaalaa parhaaseen"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Skaalaa leveyteen"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Skaalaa korkeuteen"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Skaalaa alkuperäiseen"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Käännä oikealle"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Käännä vasemmalle"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Käännä kuva"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page"
 msgstr "Ylläpitosivu"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr ""
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Skaalaa"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Paras"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Leveys"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Korkeus"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Alkuperäinen"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Pyöritä"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Käännä"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Vaakasuunta"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Pystysuunta"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Direction"
 msgstr "Kuvaus"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Vasemmalta oikealle"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Oikealta vasemmalle"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Reset to Top"
 msgstr "Palaa kotiin"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Remember Position"
 msgstr "Muista minut"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr ""
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Show"
 msgstr "Näytä kaikki"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 #, fuzzy
 msgid "DJVU Reader"
 msgstr "PDF lukija"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 #, fuzzy
 msgid "PDF Reader"
 msgstr "PDF lukija"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 #, fuzzy
 msgid "txt Reader"
 msgstr "PDF lukija"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Rekisteröi uusi tili"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Valitse käyttäjänimi"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Sähköpostiosoitteesi"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr ""
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "Käytä toista laitetta, kirjaudu ja käy osoitteessa "
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr ""
 "Kun teet näin, sinut kirjataan automaattisesti sisään tälle laitteelle."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Linkki vanhenee 10 minuutissa."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr ""
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 #, fuzzy
 msgid "No Results Found"
 msgstr "Tulosket haulle:"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 #, fuzzy
 msgid "Search Term:"
 msgstr "Hakuvirhe!"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Tulosket haulle:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Julkaisupäivästä"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Julkaisupäivään"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr ""
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Poissulje merkintä"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Poissulje sarja"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Exclude Shelves"
 msgstr "Poissulje sarja"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Poissulje kieli"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr ""
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Exclude Extensions"
 msgstr "Poissulje sarja"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Arvio enemmän kun"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Arvio vähemmän kun"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr ""
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr ""
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Poista tämä hylly"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr ""
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Näytä ekirjat"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr ""
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr ""
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr ""
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Poista kirja"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Tili"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Valtuutusta ei löytynyt"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Poista tämä hylly"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Lisää hyllyyn"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Kirjastossa"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Kirjastossa"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "pitäisikö hyllyn olla julkinen?"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr ""
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Valtuutusta ei löytynyt"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Hidden Book"
 msgstr "Näytä ekirjat"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Calibre -kirjaston tilastot"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Kirjat tässä kirjastossa"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Kirjailijat tässä kirjastossa"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Kategoriat tässä kirjastossa"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Sarjat kirjastossa"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 #, fuzzy
 msgid "System Statistics"
 msgstr "Tilastot"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 #, fuzzy
 msgid "Program"
 msgstr "Edistyminen"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Asennettu versio"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Ajoaika"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr ""
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "Pyöritä"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
 msgstr ""
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 msgid "Scheduled item cancelled successfully"
 msgstr ""
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Calibre-Web e-kirjaluettelo"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "Sähköpostiosoitteesi"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "Asetukset"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Nollaa käyttäjän salasana"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "Palvelinasetukset"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "Kindle"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "Poissulje kieli"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Näytä kirjat kielellä"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "Näytä kirjat kielellä"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "OAuth asetukset"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Linkitä"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Poista linkitys"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create/View"
 msgstr "Luo virheilmoitus"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 msgid "Expose only books in selected shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "OAuth asetukset"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr ""
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "Luetut kirjat"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "Muokkaa hyllyä"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Poista tämä käyttäjä"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -11987,164 +11801,164 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Salli sananan vaihto"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Salli sananan vaihto"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Luo virheilmoitus"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr ""
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr ""
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr ""
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit User"
 msgstr "Pääkäyttäjä"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Username"
 msgstr "Valitse käyttäjänimi"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Email"
 msgstr "Testi sähköposti"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email"
 msgstr "Kindle"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email"
 msgstr "Testi sähköposti"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "Kindle"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "Testi sähköposti"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Locale"
 msgstr "Skaalaa"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Visible Book Languages"
 msgstr "Näytä kirjat kielellä"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr ""
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Allowed Tags"
 msgstr "Salli lisäykset"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr ""
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr ""
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Change Password"
 msgstr "Salli sananan vaihto"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Public Shelves"
 msgstr "Muokkaa hyllyä"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 msgid "Expose selected Shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Read/Unread Section"
 msgstr "Näytä sarjavalinta"

--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -37,46 +37,46 @@ msgstr ""
 "Generated-By: Babel 2.13.1\n"
 "X-Generator: Poedit 3.8\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Statistiques"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 "Base de données de Calibre indisponible. Veuillez reconfigurer le chemin de "
 "la bibliothèque."
 
-#: cps/admin.py:208
+#: cps/admin.py
 msgid "Server restarted, please reload page."
 msgstr "Serveur redémarré, merci de rafraîchir la page."
 
-#: cps/admin.py:210
+#: cps/admin.py
 msgid "Performing Server shutdown, please close window."
 msgstr "Arrêt du serveur en cours, merci de fermer la fenêtre."
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "Bravo ! Base de données reconnectée"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Commande inconnue"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 "Bravo ! Livres placés en file d'attente pour une sauvegarde des métadonnées, "
 "veuillez vérifier les Tâches pour voir le résultat"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
@@ -85,49 +85,49 @@ msgstr ""
 "d'environnement HARDCOVER_TOKEN ou configurez-la dans la configuration de "
 "base."
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 "Réussi ! La tâche de récupération automatique Hardcover a démarré. Vérifiez "
 "la progression dans le panneau Tâches."
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 "Erreur lors du démarrage de la tâche de récupération automatique Hardcover : "
 "%(error)s"
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr "Vérifier les correspondances Hardcover"
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 "Erreur lors du chargement de la file d'attente des vérifications : %(error)s"
 
-#: cps/admin.py:414
+#: cps/admin.py
 msgid "Hardcover ID applied successfully"
 msgstr "Identifiant de couverture rigide appliqué avec succès"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr "Correspond à %(action)s"
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr "Aucune correspondance en attente à rejeter"
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr "%(count)s correspondance(s) rejetée(s)"
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
@@ -135,172 +135,170 @@ msgstr ""
 "Actualisation du cache des vignettes lancée pour {} livre(s). Cela peut "
 "prendre quelques minutes."
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr "Aucun livre avec couverture trouvé à traiter."
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr "Échec du démarrage de l'actualisation des miniatures : {}"
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Page admin"
 
-#: cps/admin.py:653
+#: cps/admin.py
 msgid "Hardcover token expires"
 msgstr "Le jeton Hardcover expire"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Configuration principale"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Configuration de l’interface utilisateur"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 "La colonne personnalisée No.%(column)d n'existe pas dans la base de données "
 "calibre"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Éditer les utilisateurs"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Tout"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "L'utilisateur n'a pas été trouvé"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} utilisateurs supprimés avec succès"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Montrer tout"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Demande malformée"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "Le nom de l’invité ne peut pas être modifié"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "L’invité ne peut pas avoir ce rôle"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr "Aucun utilisateur admin restant, impossible de supprimer le rôle admin"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "La valeur doit être vraie ou fausse"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Rôle invalide"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "L’invité ne peut pas avoir cette vue"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "Vue invalide"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 "Les paramètres régionaux de l’invité sont déterminés automatiquement et ne "
 "peuvent pas être définis"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Aucun paramètre régional valide n’est donné"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Aucune langue de livre valide donnée"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Paramètre non trouvé"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "La base de données des paramètres n'est pas accessible en écriture"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Colonne de lecture non valide"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Colonne restreinte non valide"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Voulez-vous vraiment supprimer le jeton Kobo ?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "Voulez-vous vraiment supprimer ce domaine ?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "Voulez-vous vraiment supprimer cet utilisateur ?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Voulez-vous vraiment supprimer l’étagère ?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr ""
 "Voulez vous vraiment changer la langue pour le ou les utilisateurs "
 "sélectionnés ?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "Voulez-vous vraiment modifier les langues de livre visibles pour le ou les "
 "utilisateurs sélectionnés ?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 "Voulez-vous vraiment modifier le rôle sélectionné pour le ou les "
 "utilisateurs sélectionnés ?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
@@ -308,7 +306,7 @@ msgstr ""
 "Voulez-vous vraiment modifier les restrictions sélectionnées pour le ou les "
 "utilisateurs sélectionnés ?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -316,14 +314,14 @@ msgstr ""
 "Voulez-vous vraiment modifier les restrictions de visibilité sélectionnées "
 "pour le ou les utilisateurs sélectionnés ?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "Voulez-vous vraiment changer le comportement de synchronisation pour le ou "
 "les utilisateurs sélectionnés ?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
@@ -331,131 +329,126 @@ msgstr ""
 "Voulez-vous vraiment changer le comportement de synchronisation pour le ou "
 "les utilisateurs sélectionnés ?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr ""
 "Voulez-vous vraiment changer l’emplacement de la bibliothèque de Calibre ?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Refuser"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Autoriser"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "{} entrées de synchronisation supprimées"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Livre introuvable."
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Étiquette introuvable"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Action invalide"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json n'est pas configuré pour l'application Web"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "L'emplacement du fichier logfile est incorrect, veuillez saisir un chemin "
 "valide"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "L'emplacement du fichier Access Logfile est incorrect, veuillez saisir un "
 "chemin valide"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 "Veuillez saisir un fournisseur LDAP, Port, DN et l'identifiant objet de "
 "l'utilisateur"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Veuillez saisir un identifiant et mot de passe de service LDAP"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "Veuillez entrer un compte de service LDAP"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Le filtre objet du groupe LDAP a besoin d'un identifiant de format \"%s\""
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "Le filtre objet du groupe LDAP a une parenthèse non gérée"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Le filtre objet de l'utilisateur LDAP a besoin d'un identifiant de format "
 "\"%s\""
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "Le filtre objet de l'utilisateur LDAP a une parenthèse non gérée"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Le filtre utilisateur des membres LDAP doit avoir un identificateur de "
 "format \"%s\\ »"
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "Le filtre utilisateur de membre LDAP a des parenthèses non appariées"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -463,29 +456,24 @@ msgstr ""
 "LDAP CACertificat, certificat ou emplacement de clé non valide, veuillez "
 "entrer le chemin correct"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Ajouter un nouvel utilisateur"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Modifier les paramètres du serveur de courriels"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "Bravo ! Compte Gmail vérifié."
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Erreur de la base de données : %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -493,53 +481,53 @@ msgstr ""
 "Le courriel de test a été mis en file d'attente pour être envoyé à "
 "%(email)s, veuillez vérifier les Tâches pour voir le résultat"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Il y a eu une erreur pendant l’envoi du courriel de test : %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Veuillez d'abord configurer votre adresse de courriel…"
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Les paramètres du serveur de courriels ont été mis à jour"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "Éditer les utilisateurs"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Veuillez configurer les paramètres SMTP au préalable…"
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "Veuillez d'abord configurer votre adresse de courriel…"
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "Le nouveau mot de passe a été envoyé vers votre adresse de courriel"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -547,7 +535,7 @@ msgstr ""
 "Le courriel de test a été mis en file d'attente pour être envoyé à "
 "%(email)s, veuillez vérifier les Tâches pour voir le résultat"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -556,169 +544,167 @@ msgstr ""
 "Le courriel de test a été mis en file d'attente pour être envoyé à "
 "%(email)s, veuillez vérifier les Tâches pour voir le résultat"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "Modifier les paramètres des tâches planifiées"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "Heure de début non valide pour la tâche spécifiée"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "Durée non valide pour la tâche spécifiée"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "Paramètres des tâches planifiées mis à jour"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Une erreur inconnue est survenue. Veuillez réessayer plus tard."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 msgid "title"
 msgstr "Titre"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Éditer l'utilisateur %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr ""
 "Le mot de passe de l’utilisateur %(user)s a été réinitialisé avec succès"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Oups ! Veuillez configurer les paramètres de messagerie SMTP."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Visualiseur de fichier journal"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Demande de mise à jour"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Téléchargement de la mise à jour"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Décompression de la mise à jour"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Remplacement des fichiers"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Les connexions à la base de données ont été fermées"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Arrêt du serveur"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr ""
 "Mise à jour terminée, merci d’appuyer sur okay et de rafraîchir la page"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "La mise à jour a échoué :"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "Erreur HTTP"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Erreur de connexion"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Délai d'attente dépassé lors de l'établissement de connexion"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Erreur générale"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr ""
 "Le fichier de mise à jour n'a pas pu être sauvegardé dans le répertoire "
 "temporaire"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "Les fichiers n’ont pas pu être remplacés pendant la mise à jour"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "Impossible d'extraire au moins un utilisateur LDAP"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Impossible de créer au moins un utilisateur LDAP"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Erreur : %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Erreur : Aucun utilisateur renvoyé dans la réponse LDAP du serveur"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr ""
 "Au moins un utilisateur LDAP n'a pas été trouvé dans la base de données"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} utilisateur importé avec succès"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr "Chemin d'accès aux livres non valide"
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "L'emplacement de la base de données est incorrect, veuillez saisir un chemin "
 "valide"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "La base de données n'est pas accessible en écriture"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "L'emplacement du fichier Keyfile est incorrect, veuillez saisir un chemin "
 "valide"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "L'emplacement du fichier Certfile est incorrect, veuillez saisir un chemin "
 "valide"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
@@ -726,13 +712,13 @@ msgstr ""
 "La création automatique d'utilisateurs ne peut pas être activée sans activer "
 "l'authentification par reverse proxy"
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 "La création automatique d'utilisateurs nécessite un nom d'en-tête de reverse "
 "proxy valide"
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
@@ -740,7 +726,7 @@ msgstr ""
 "Format d'hôte de redirection OAuth non valide. Veuillez inclure l'URL "
 "complète avec le protocole (par exemple, https://your-domain.com)."
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
@@ -748,69 +734,69 @@ msgstr ""
 "L'hôte de redirection OAuth ne doit pas inclure de chemin d'accès. Utilisez "
 "uniquement l'URL de base (par exemple, https://your-domain.com)."
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr ""
 "La longueur du mot de passe doit être comprise entre 1 et 40 caractères"
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "La configuration de la base de données a été mise à jour"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "Configuration de la base de données"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Veuillez compléter tous les champs."
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "Cette adresse de courriel n’appartient pas à un domaine valide"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Ajouter un nouvel utilisateur"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Utilisateur '%(user)s' créé"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "Oups ! Un compte existe déjà pour cette adresse e-mail ou ce nom."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Utilisateur '%(nick)s' supprimé"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "Impossible de supprimer l’utilisateur Invité"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "Aucun utilisateur admin restant, impossible de supprimer l’utilisateur"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "L'adresse e-mail ne peut pas être vide et doit être valide"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Utilisateur '%(nick)s' mis à jour"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
@@ -818,7 +804,7 @@ msgstr ""
 "Connexion réussie ! Le point de terminaison de découverte OIDC est "
 "accessible.%(endpoints)s"
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
@@ -826,13 +812,13 @@ msgstr ""
 "Échec de la connexion : point de terminaison OIDC introuvable (404). "
 "Vérifiez que l'URL de base est correcte."
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 "Échec de la connexion : Le serveur a retourné le code de statut %(code)s"
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
@@ -840,14 +826,14 @@ msgstr ""
 "Échec de la connexion : impossible de se connecter au serveur. Vérifiez "
 "l'URL et la connexion réseau."
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 "Échec de la connexion : délai d'attente expiré. Le serveur est peut-être "
 "lent ou inaccessible."
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
@@ -855,12 +841,12 @@ msgstr ""
 "Échec de la connexion : le serveur a renvoyé un JSON non valide. Il ne "
 "s'agit peut-être pas d'un point de terminaison OIDC."
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Échec de la connexion : %(error)s"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
@@ -870,31 +856,31 @@ msgstr ""
 "se peut que ce ne soit pas un point de terminaison de métadonnées OIDC "
 "valide."
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 "L'URL des métadonnées est valide ! %(count)s points de terminaison OAuth "
 "trouvés."
 
-#: cps/admin.py:3322
+#: cps/admin.py
 msgid " User info endpoint is available."
 msgstr " Le point de terminaison des informations utilisateur est disponible."
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 " Remarque : point de terminaison des informations utilisateur introuvable - "
 "cela peut entraîner des problèmes d'authentification."
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 "URL des métadonnées introuvable (404). Veuillez vérifier que l'URL est "
 "correcte."
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
@@ -902,49 +888,49 @@ msgstr ""
 "Échec de la connexion : impossible de se connecter à l'URL des métadonnées. "
 "Vérifiez l'URL et la connectivité réseau."
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr "Échec de la connexion : Délai d'attente dépassé."
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr "Échec de la connexion : Réponse JSON invalide."
 
-#: cps/admin.py:3340
+#: cps/admin.py
 msgid "An unknown error occurred."
 msgstr "Une erreur inconnue est survenue."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 msgid "Restore already in progress."
 msgstr "Restauration déjà en cours."
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 "Restauration échouée : chemin de la bibliothèque Calibre non configuré."
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr "Restauration échouée : metadata.db introuvable à %(path)s"
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr "Restauration échouée : app.db introuvable à %(path)s"
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Échec de la restauration : %(err)s"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 "La restauration est terminée mais le nettoyage de app.db a échoué. Voir les "
 "journaux pour plus de détails."
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
@@ -953,203 +939,202 @@ msgstr ""
 "Restauration terminée. Sauvegardes et journal de restauration enregistrés "
 "dans %(dir)s. Toutes les données liées aux livres ont été réinitialisées."
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "Le fichier %(file)s a été téléchargé"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr "Tchèque"
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr "Allemand"
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr "Grec"
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr "Espagnol"
 
-#: cps/constants.py:265
+#: cps/constants.py
 msgid "Finnish"
 msgstr "Finlandais"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr "Français"
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr "Galicien"
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr "Hongrois"
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr "Indonésien"
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr "Italien"
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr "Japonais"
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr "Khmer"
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr "Coréen"
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr "Néerlandais"
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr "Norvégien"
 
-#: cps/constants.py:276
+#: cps/constants.py
 msgid "Polish"
 msgstr "Polonais"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr "Portugais"
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr "Portugais (Brésil)"
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr "Russe"
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr "Slovaque"
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr "Slovène"
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr "Suédois"
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr "Turque"
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr "Ukrainien"
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr "Vietnamien"
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr "Chinois (Simplifié, Chine)"
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr "Chinois (Traditionnel, Taïwan)"
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "non installé"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Les permissions d'exécutions manquantes"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr "Retour à l’édition des métadonnées"
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr "Retour au livre"
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, fuzzy, python-format
 msgid "Change cover — %(title)s"
 msgstr " Échanger l’auteur et le titre"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Erreur de connexion"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Could not render the e-reader preview."
 msgstr "Impossible de trouver le répertoire spécifié"
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr "L’enregistrement de la couverture a échoué."
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 "Le changement de thème est temporairement désactivé jusqu'à la version 5.0.0"
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
@@ -1157,271 +1142,262 @@ msgstr ""
 "Actualisation de la bibliothèque 🔄 Recherche des livres qui auraient pu "
 "être oubliés, veuillez patienter..."
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 "Expression cron non valide pour les analyses en double. Les modifications "
 "n'ont pas été enregistrées."
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr "Horodatage"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Book ID"
 msgstr "Identifiant du livre"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Titre du livre"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Book Author"
 msgstr "Auteur du livre"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr "Type de déclencheur"
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Filepath"
 msgstr "Chemin du fichier"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Filename"
 msgstr "Nom du fichier"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr "Manuel ?"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr "Nb Corrections"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr "Original sauvegardé ?"
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr "Corrections appliquées"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr "Format original"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "End Format"
 msgstr "Format de fin"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 msgid "Unknown User"
 msgstr "Utilisateur inconnu"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr "✅ Tous les services de surveillance fonctionnent comme prévu ! 👍"
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 "🔴 Le service d’ingestion est en cours d’exécution, mais le détecteur de "
 "modification des métadonnées ne l’est pas"
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 "🔴 Le détecteur de modification des métadonnées est en cours d’exécution, "
 "mais le service d’ingestion ne l’est pas"
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 "⛔ Ni le service d'ingestion, ni le détecteur de changement de métadonnées "
 "ne sont en cours d'exécution"
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr "Une erreur s'est produite"
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 "Le correcteur EPUB pour un seul livre n'est pas pris en charge avec les "
 "bibliothèques Google Drive."
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 msgid "Invalid book selection."
 msgstr "Sélection de livre invalide."
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr "Livre introuvable."
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 msgid "Selected book has no EPUB format."
 msgstr "Le livre sélectionné n'a pas de format EPUB."
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 msgid "EPUB file not found on disk."
 msgstr "Fichier EPUB introuvable sur le disque."
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 msgid "EPUB Fixer started for selected book."
 msgstr "Correction EPUB démarrée pour le livre sélectionné."
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr "Échec du démarrage de la correction EPUB pour le livre sélectionné."
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr "Vous devez être un administrateur pour accéder à cette page."
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr "Le nom d’utilisateur et les données d’images sont requis."
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr "Format de données d'image non valide. Doit être une image valide."
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 "Type d'image non pris en charge. Seuls les formats PNG et JPEG sont "
 "autorisés."
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 "L'image est trop volumineuse. Veuillez utiliser une image inférieure à 500 "
 "Ko."
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr "Données d'image Base64 non valides."
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 msgid "Invalid image data format."
 msgstr "Format de données d'image non valide."
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr "Erreur lors de la validation des données d'image."
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr "Image de profil mise à jour."
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Aucun"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 msgid "Duplicate Books"
 msgstr "Livres en double"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr "Groupe en double déjà supprimé"
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 msgid "Duplicate group dismissed"
 msgstr "Groupe en double supprimé"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 msgid "Duplicate group restored"
 msgstr "Groupe dupliqué restauré"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr "Le groupe en double n'a pas été supprimé"
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 msgid "Duplicate scan queued"
 msgstr "Scan en double mis en file d'attente"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr "Scan en double terminé (plan de secours)"
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 msgid "Invalid resolution strategy"
 msgstr "Stratégie de résolution non valide"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
@@ -1429,100 +1405,97 @@ msgstr ""
 "Le dossier d'ingestion n'est pas accessible en écriture. Vérifiez les "
 "permissions de votre volume /cwa-book-ingest."
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 "Identifiant du livre manquant ou invalide pour le téléchargement du format"
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 "Impossible de télécharger le format : le livre n'existe plus dans la "
 "bibliothèque"
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Téléversement terminé, traitement en cours, veuillez patienter…."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 msgid "Failed to queue upload for processing"
 msgstr "Échec de mise en file d'attente du téléversement pour traitement"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Le format de conversion de la source ou de la destination est manquant"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr ""
 "Le livre a été mis avec succès en file de traitement pour conversion vers "
 "%(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Une erreur est survenue au cours de la conversion du livre : %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "Ce type de fichier n’est pas autorisé à être déposé sur ce serveur"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr ""
 "L’extension de fichier '%(ext)s' n’est pas autorisée pour être déposée sur "
 "ce serveur"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "Pour être déposé le fichier doit avoir une extension"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 "Erreur d'ouverture du livre numérique. Le fichier n'existe pas ou n'est pas "
 "accessible"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "L’utilisateur n’a pas les droits pour envoyer une couverture de livre"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 "Les identificateurs ne sont pas sensibles à la casse, écrasant l’ancien "
 "identificateur"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "%(langname)s n'est pas une langue valide"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Les métadonnées ont bien été mises à jour"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "Erreur d'édition du livre : {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1530,100 +1503,100 @@ msgstr ""
 "Le fichier téléchargé existe probablement dans la bibliothèque, veuillez le "
 "modifier avant de le télécharger de nouveau : "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 "Le fichier %(filename)s ne peut pas être sauvegardé dans le répertoire "
 "temporaire"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Impossible de déplacer le fichier de couverture %(file)s : %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Le format du livre a été supprimé avec succès"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Le livre a été supprimé avec succès"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "Vous n’avez par les permissions pour supprimer les livres"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "modifier les métadonnées"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "Index de série : %(seriesindex)s n'est pas un nombre valide, ignoré"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr ""
 "L’utilisateur n’a pas le droit de télécharger des formats de fichiers "
 "supplémentaires"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Impossible de créer le chemin %(path)s (Permission refusée)."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Échec de la sauvegarde du fichier %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Le format de fichier %(ext)s a été ajouté à %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Livre introuvable."
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "Fichier EPUB introuvable sur le disque."
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1631,7 +1604,7 @@ msgstr ""
 "La configuration de Google Drive n’est pas terminée, essayez de désactiver "
 "et d’activer à nouveau Google Drive"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1640,87 +1613,86 @@ msgstr ""
 "suivre les étapes nécessaires pour vérifier le domaine dans la console de "
 "développement de Google"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr "Ce message a été envoyé via Calibre-Web NextGen."
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "le format %(format)s est introuvable pour le livre : %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "le %(format)s est introuvable sur Google Drive : %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s introuvable : %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "Envoyer à l'eReader"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "le format %(format)s est introuvable pour le livre : %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "le format %(format)s est introuvable pour le livre : %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 msgid "Test Email"
 msgstr "Courriel de test"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Courriel d’inscription pour l’utilisateur : %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Convertir %(orig)s en %(format)s et envoyer à l'eReader"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Envoyer %(format)s à l'eReader"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s envoyer à l'eReader"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "Le fichier demandé n’a pu être lu. Problème de permission d’accès ?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "Impossible de définir le statut de lecture : {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
@@ -1728,12 +1700,12 @@ msgstr ""
 "Échec de la suppression du dossier de livre pour le livre %(id)s, le chemin "
 "d’accès comporte des sous-dossiers : %(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "La suppression du livre %(id)s a échoué : %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1742,7 +1714,7 @@ msgstr ""
 "Suppression du livre %(id)s de la base de données uniquement, le chemin du "
 "livre en base de données est invalide : %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
@@ -1750,68 +1722,68 @@ msgstr ""
 "Renommer l'auteur de : '%(src)s' à '%(dest)s' a échoué avec l’erreur : "
 "%(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Le fichier %(file)s n'a pas été trouvé dans Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Renommer le titre de : '%(src)s' à '%(dest)s' a échoué avec l’erreur : "
 "%(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Le chemin du livre %(path)s n'a pas été trouvé dans Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr "Un compte existant a été trouvé pour cette adresse mail"
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Cet utilisateur est déjà pris"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr "Format de l’adresse courriel invalide"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr ""
 "Le mot de passe saisi ne respecte pas les règles de validation du mot de "
 "passe"
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 "Le module Python 'advocate' n'est pas installé mais celui-ci est requis pour "
 "téléverser les couvertures"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Erreur lors du téléchargement de la couverture"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr "La couverture dépasse la taille maximale de %(size)s Mo"
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr ""
 "Le fichier couverture n'est pas un fichier image valide, ou ne peut pas être "
 "stocké"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Erreur de format de couverture"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
@@ -1819,110 +1791,110 @@ msgstr ""
 "Vous n'êtes pas autorisé à accéder localement ou au réseau local pour "
 "téléverser des couvertures"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Impossible de créer le chemin pour la couverture"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr ""
 "Seuls les fichiers jpg/jpeg/png/webp/bmp sont supportés comme fichier de "
 "couverture"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "Contenu du fichier de couverture invalide"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Seuls les fichiers jpg/jpeg sont supportés comme fichier de couverture"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr "Couverture"
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "Fichier binaire UnRar non trouvé"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr "Erreur lors de l'exécution d'UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr "Impossible de trouver le répertoire spécifié"
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr "Merci de spécifier un répertoire, pas un fichier"
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr "Les exécutables Calibre ne sont pas viables"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr "Exécutables Calibre manquants : %(missing)s"
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Permissions d'exécution manquantes : %(missing)s"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr "Erreur lors de l'exécution de Calibre"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr ""
 "Mettre en file d’attente tous les livres pour la sauvegarde des métadonnées"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Configuration Kobo"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr "Ajoutés récemment"
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr "Les mieux notés"
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr "Lecture en cours"
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr "À lire"
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr "Publications récentes"
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Enregistrer avec %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
@@ -1933,13 +1905,13 @@ msgstr ""
 "Veuillez vérifier la configuration des champs d'application OAuth ou "
 "contacter votre administrateur."
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 "Échec de la connexion : le jeton OAuth a expiré. Veuillez réessayer de vous "
 "connecter."
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
@@ -1948,7 +1920,7 @@ msgstr ""
 "informations utilisateur du fournisseur OAuth. Veuillez réessayer ou "
 "contacter votre administrateur."
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
@@ -1956,7 +1928,7 @@ msgstr ""
 "Échec de la connexion : le fournisseur OAuth a renvoyé des données de profil "
 "utilisateur non valides. Veuillez contacter votre administrateur."
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1967,37 +1939,37 @@ msgstr ""
 "champs obligatoires : %(fields)s. Veuillez vérifier votre configuration "
 "OAuth ou contacter votre administrateur."
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr "Échec de la connexion au compte OAuth. Veuillez réessayer."
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 "Erreur OAuth : le fournisseur a renvoyé des informations utilisateur non "
 "valides. Veuillez réessayer."
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "Vous êtes maintenant connecté en tant que : '%(nickname)s'"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Lien vers %(oauth)s effectué avec succès"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -2008,59 +1980,59 @@ msgstr ""
 "%(provider)s. Veuillez contacter votre administrateur pour créer un compte "
 "ou associer votre compte existant."
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 "Échec de l'authentification OAuth. Veuillez réessayer ou contacter "
 "l'administrateur."
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 msgid "OAuth system error. Please contact administrator."
 msgstr "Erreur système OAuth. Veuillez contacter l'administrateur."
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "Suppression de la liaison vers %(oauth)s effectuée avec succès"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Suppression de la liaison vers %(oauth)s a échoué"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "Non lié à %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Échec de la connexion avec GitHub."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr ""
 "Impossible d’obtenir les informations d’utilisateur à partir de GitHub."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Échec de la connexion avec Google."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Impossible d’obtenir les informations d’utilisateur avec Google."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 msgid "Failed to log in with Generic OAuth."
 msgstr "Échec de la connexion l'OAuth générique."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 "Échec de l'authentification OAuth : erreur de validation du jeton. Veuillez "
 "réessayer."
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
@@ -2068,7 +2040,7 @@ msgstr ""
 "L'authentification OAuth a échoué en raison d'une erreur inattendue. "
 "Veuillez contacter l'administrateur."
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
@@ -2078,721 +2050,712 @@ msgstr ""
 "manière répétée, veuillez configurer le paramètre « Hôte de redirection "
 "OAuth » dans Admin > Configuration de base > OAuth."
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "Erreur Oauth GitHub, veuillez réessayer plus tard."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "Erreur Oauth Github : {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Erreur Oauth Google, veuillez réessayer plus tard."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Erreur Oauth Google : {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr "Erreur OAuth : {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "Livres alphabétiques"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "Livres triés dans l’ordre alphabétique"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Livres populaires"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr ""
 "Publications populaires depuis le catalogue basées sur les téléchargements."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Livres les mieux notés"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Publications populaires de ce catalogue sur la base des évaluations."
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "Livres téléchargés"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Les derniers livres"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Livres au hasard"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Montrer des livres au hasard"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Livres lus"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Version actuelle"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Livres non-lus"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Auteurs"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Livres classés par auteur"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Éditeurs"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Livres classés par éditeur"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Catégories"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Livres classés par catégorie"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Séries"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Livres classés par série"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Langues"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Livres classés par langue"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Évaluations"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Livres classés par évaluation"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Formats de fichier"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Livres classés par formats de fichiers"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Étagères"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "Livres organisés par étagères"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Étagères magiques ✨"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Livres organisés par étagères"
 
-#: cps/opds.py:317
+#: cps/opds.py
 msgid "description"
 msgstr "Description"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} Étoiles"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Chercher"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Connexion"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Jeton non trouvé"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Jeton expiré"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Réussite! Merci de vous tourner vers votre appareil"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Livres"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Afficher les livres récents"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Montrer les livres populaires"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Livres téléchargés"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Montrer les livres téléchargés"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Montrer les livres les mieux notés"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 msgid "Show Read and Unread"
 msgstr "Montrer lus et non-lus"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Afficher non-lus"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Découvrir"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Category Section"
 msgstr "Montrer la section Catégories"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Series Section"
 msgstr "Montrer la section Séries"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Author Section"
 msgstr "Montrer la section Auteurs"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Publisher Section"
 msgstr "Montrer la section Éditeurs"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Language Section"
 msgstr "Montrer la section Langues"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Ratings Section"
 msgstr "Afficher la section Évaluations"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show File Formats Section"
 msgstr "Afficher la section Formats de fichiers"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Livres archivés"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Archived Books"
 msgstr "Afficher les livres archivés"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr "Favoris"
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Liste des livres"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Montrer la liste des livres"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr "Doubles"
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 msgid "Show Duplicate Books"
 msgstr "Montrer les livres en double"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Publié après le "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Publié avant le "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Évaluation <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Évaluation >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Statut de lecture = « %(status)s »"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 "Erreur lors de la recherche de colonnes personnalisées, veuillez redémarrer "
 "Calibre-Web"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Recherche avancée"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "L’étagère indiquée est invalide"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "Désolé, vous n’êtes pas autorisé à ajouter un livre dans cette étagère"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "Ce livre est déjà sur l’étagère : %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 "%(book_id)s est un identifiant de livre invalide. Il ne peut être ajouté à "
 "l'étagère"
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "Le livre a bien été ajouté à l'étagère : %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "Vous n’êtes pas autorisé à ajouter un livre à l’étagère"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Ces livres sont déjà sur l’étagère : %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "Les livres ont été ajoutés à l’étagère : %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Impossible d’ajouter les livres à l’étagère : %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "L’étagère indiquée est invalide"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Impossible d’ajouter les livres à l’étagère : %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Ces livres sont déjà sur l’étagère : %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "Les livres ont été ajoutés à l’étagère : %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "Le livre a été supprimé de l'étagère %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "Désolé, vous n’êtes pas autorisé à supprimer un livre de cette étagère"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Créer une étagère"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Désolé, vous n’êtes pas autorisé à modifier cette étagère"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Modifier une étagère"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "Erreur lors de la suppression de l’étagère"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "Étagère supprimée avec succès"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Modifier l’arrangement de l’étagère : ‘%(name)s’"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "Désolé, vous n’êtes pas autorisé à créer une étagère publique"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Étagère %(title)s créée"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Étagère %(title)s modifiée"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Il y a eu une erreur"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "Une étagère publique avec le nom '%(title)s' existe déjà."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "Une étagère privée avec le nom '%(title)s' existe déjà."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Étagère : '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Erreur à l’ouverture de l’étagère. Elle n’existe plus ou n’est plus "
 "accessible"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Étagères exclues"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 #, fuzzy
 msgid "Name (A → Z)"
 msgstr "Nom (A-Z)"
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 #, fuzzy
 msgid "Name (Z → A)"
 msgstr "Nom (Z-A)"
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 #, fuzzy
 msgid "Book count (most → fewest)"
 msgstr "Nombre de livres (décroissant)"
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 #, fuzzy
 msgid "Book count (fewest → most)"
 msgstr "Nombre de livres (décroissant)"
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 #, fuzzy
 msgid "Created (newest → oldest)"
 msgstr "Création (plus récent en premier)"
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 #, fuzzy
 msgid "Created (oldest → newest)"
 msgstr "Création (plus ancien en premier)"
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 #, fuzzy
 msgid "Manual (drag below)"
 msgstr "Manuel (glisser pour réorganiser)"
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr "Lire"
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr "Ouvrir les détails de {title}"
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr "Lire {title}"
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr "Standard (nom d’utilisateur / mot de passe)"
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr "LDAP"
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr "OAuth / OpenID Connect"
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Anonyme"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Non authentifié"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr "Simple (compte de service)"
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr "Ordre de série"
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr "Ordre de série (inverse)"
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr "Ajouter un tag"
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr "Nouvelle étiquette"
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr "Supprimer le tag"
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr "Retirer l’étiquette {name}"
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr "Renommer l’étiquette {name}"
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr "Nom de l’étiquette"
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr "Le nom de l’étiquette ne peut pas être vide"
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr "Sauvegarder le nom de l’étiquette"
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr "Sélectionner le format"
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr "Impossible de renommer l’étiquette"
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr "Étiquette renommée en {name}"
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr "Vous devez être connecté"
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr "Vous n’êtes pas autorisé à modifier les métadonnées"
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr "Une étiquette portant ce nom existe déjà"
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr "Le nom de l’étiquette doit être du texte"
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr "Le nom de l’étiquette ne peut pas contenir de virgules"
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr "Saisissez un nom d’étiquette valide"
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr "Impossible de charger cette page"
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr "Page introuvable"
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr "Effacer l’évaluation"
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr "Non évalué"
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Oui"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Non"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr "Corps du message"
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr "Noté {rating} sur 5"
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr "Plus de {name}"
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
@@ -2801,143 +2764,141 @@ msgstr ""
 "Fusionner {n} livres dans le premier sélectionné ? Les autres seront "
 "supprimés une fois leurs formats copiés."
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr "Appliquer à {n} livres"
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr "Condition de correspondance"
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr "Champ de la règle"
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr "Opérateur de la règle"
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr "Impossible de charger les règles de l’étagère intelligente."
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr "Avec couverture"
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr "Numéro dans la série"
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Status de lecture"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr "Avec identifiant Hardcover"
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr "Au cours des N derniers jours"
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr "Pas au cours des N derniers jours"
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr "est antérieur à / inférieur à"
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr "est le ou avant le / au plus"
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr "est postérieur à / supérieur à"
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr "est le ou après le / au moins"
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr "est compris entre"
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr "n’est pas compris entre"
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr "ne commence pas par"
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr "ne se termine pas par"
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr "est vide"
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr "n’est pas vide"
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr "Apparence"
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Thème"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr "Système"
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Clair"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Sombre"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "Sépia"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr "Contraste élevé"
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr "Minuit (AMOLED)"
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr "Suivre le réglage clair ou sombre de votre appareil"
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr "Thème enregistré."
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr "Impossible d’enregistrer le thème."
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr "Thème par défaut des nouveaux comptes"
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
@@ -2945,169 +2906,159 @@ msgstr ""
 "S’applique aux comptes créés à partir de maintenant. Chacun choisit le sien "
 "dans Compte → Thème."
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr "Ajouter un format"
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr "Ajouter une règle"
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Ajouter à l'étagère"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr "Ajouter la vôtre"
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr "Nom du mot de passe d’application"
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr "Mots de passe d’application"
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Auteur"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr "Auteurs (séparés par &)"
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr "Retour à la connexion"
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr "Bleu"
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr "Contenu du livre"
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Explorer"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr "Changer le mot de passe"
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Fermer"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr "Fermer le menu"
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr "Sommaire"
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr "La conversion a échoué."
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr "Convertir vers"
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr "Convertir au format"
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr "Copier"
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr "Impossible de changer le mot de passe."
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr "Impossible de créer."
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr "Impossible de récupérer la couverture."
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr "Impossible de charger les métadonnées."
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr "Impossible de charger le fichier du livre ({status})"
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr "Impossible de charger votre compte."
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr "Impossible d’enregistrer."
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr "URL de l’image de couverture"
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr "La mise à jour de la couverture a échoué."
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr "Couverture mise à jour."
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr "Créer l’étagère intelligente"
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr "Créez votre compte"
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr "Thème sombre"
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Supprimer"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr "Supprimer le livre"
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
@@ -3116,490 +3067,483 @@ msgstr ""
 "Supprimer « {title} » ? Le livre et tous ses fichiers seront définitivement "
 "retirés de votre bibliothèque. Cette action est irréversible."
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr "Suppression…"
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr "Impossible de supprimer ce livre."
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 "Supprimer le fichier {fmt} ? Le livre est conservé, seul ce format est "
 "supprimé."
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr "Supprimer {fmt}"
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr "Supprimer {n} livre(s) ? Cette action est irréversible."
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr "La description contient"
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr "Désélectionner {title}"
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr "Éditer les métadonnées"
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr "Modifier {title}"
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr "Affichage de votre vue de bibliothèque par défaut."
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr "Afficher tous les livres"
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr "Modifier la vue par défaut"
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr "Impossible de charger les livres."
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr "L’ouverture du livre a échoué."
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr "Générer"
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr "Vert"
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr "Aide"
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr "Couleur de surlignage"
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr "Importer depuis Kobo"
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr "Langue de l’interface"
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr "Nom d’utilisateur ou mot de passe incorrect."
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr "Police du corps de texte de l’interface"
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr "Police d’affichage de l’interface"
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr "Par défaut (Optima / Sans-Serif)"
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr "Par défaut (Bookish Serif)"
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr "Police sans empattement du système"
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr "Bookish Serif"
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr "Chasse fixe"
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr "Nom (par ex. KOReader sur le téléphone)"
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr "Langues (séparées par des virgules)"
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr "Thème clair"
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr "La connexion a échoué."
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr "Marquer comme lu"
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr "Marquer comme non lu"
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Fusionner"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr "Métadonnées appliquées à {n} livre(s)."
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 "Nouveau mot de passe pour « {label} » — copiez-le maintenant, il ne sera "
 "plus affiché :"
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr "Les nouveaux mots de passe ne correspondent pas."
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr "Aucun livre ici."
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr "Aucun résultat pour « {q} »."
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr "Aucune suggestion"
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr "Aucun livre {filter} ici."
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr "Mot de passe modifié."
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr "Coller une URL"
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr "Étagère privée"
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr "Profil"
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr "Profil enregistré."
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr "Étagère publique"
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Éditeur"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr "Éditeurs (séparés par des virgules)"
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Lu"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr "Progression de lecture"
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr "Rouge"
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr "L’inscription a échoué."
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr "Retirer {name}"
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr "La requête a échoué."
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr "Réinitialiser votre mot de passe"
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr "Révoquer {label}"
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr "Enregistrer les modifications"
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr "L’enregistrement a échoué."
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr "Sauvegarder le profil"
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr "Sauvegardé."
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr "Enregistrement…"
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr "La recherche a échoué."
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr "Rechercher des métadonnées"
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr "Sources de métadonnées"
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr "Chargement des sources…"
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr "Impossible de charger les sources."
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr "Impossible de mettre à jour la source."
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr "{provider} : {state}"
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr "Activé"
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr "Désactivé"
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr "Résultats de recherche"
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr "Chercher dans la bibliothèque"
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr "Sélectionner {title}"
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr "Thème sépia"
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr "Position {n} dans la série"
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr "{series} nº {n}"
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr "Se connecter"
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr "La connexion a échoué. Veuillez réessayer."
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr "Aller au contenu"
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr "Certains champs n’ont pas pu être enregistrés."
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr "Table des matières"
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr "Étiquettes (séparées par des virgules)"
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Titre"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr "Non lu"
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr "Mettre à jour le mot de passe"
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Téléverser"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr "Choisir les livres à téléverser"
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr "Échec du téléversement."
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr "Téléverser une image"
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr "Téléversement…"
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr "Jaune"
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr "p. ex. MOBI"
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr "Lecteur {format}"
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr "Clé API {name}"
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr "{n} livre(s) ajouté(s) à l’étagère."
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr "{n} livre(s) supprimé(s)."
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr "{n} marqué(s) comme lu(s)."
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr "{n} marqué(s) comme non lu(s)."
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr "{n} sélectionné(s)"
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr "{pct} % lu"
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr "Quoi de neuf"
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr "Aide — nouvelles mises à jour disponibles"
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 "Les dernières nouveautés et corrections de Calibre-Web NextGen — les plus "
 "récentes d’abord."
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr "{n} mise à jour"
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr "{n} mises à jour"
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 "Aucune note de version pour l’instant — revenez après la prochaine mise à "
 "jour."
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
@@ -3607,252 +3551,249 @@ msgstr ""
 "L’interface est traduite dans votre langue ; ces notes de mise à jour sont "
 "rédigées en anglais."
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr "Lecture"
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr "Vue en grille"
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr "Bibliothèque"
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr "Vue en liste"
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr "Synchronisation"
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Compte"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Administration"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr "Sous le capot"
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr "Ouvrir votre bibliothèque"
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr "Parcourir les étiquettes"
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr "Ouvrir la vue tableau"
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr "Examiner les doublons"
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr "Ouvrir vos étagères"
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr "Gérer la synchronisation et les mots de passe d’application"
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr "Vérifier l’adresse de votre liseuse"
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr "Créer un mot de passe d’application"
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr "Parcourir les séries"
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr "Parcourir les auteurs"
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr "Parcourir les langues"
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr "Ouvrir la vue tableau"
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr "Ouvrir l’administration"
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr "Ouvrir les paramètres du compte"
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr "Parcourir Découvrir"
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr "Explorer votre bibliothèque"
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr "Aller au téléversement"
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr "Ouvrir la recherche"
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr "Éditions"
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr "Retour à la nouvelle interface"
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr "Retour aux résultats"
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr "Aucune édition trouvée pour ce livre."
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr "Voir tous les détails"
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr "Détails du résultat"
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Publié"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr "Format"
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Source"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr "Personnaliser"
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr "Personnaliser la barre latérale"
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr "Personnaliser la navigation"
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr "Terminé"
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr "Rétablir les valeurs par défaut"
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr "Toujours affiché"
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 "Modification de la barre latérale. Réorganisez ou masquez des sections, puis "
 "appuyez sur Terminé."
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr "Modification annulée."
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 "Faites glisser pour réorganiser. Appuyez sur ✕ pour masquer une section. Les "
 "touches fléchées déplacent la poignée active."
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr "Barre latérale enregistrée."
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr "Barre latérale réinitialisée."
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr "{label} déplacé en position {pos} sur {total}"
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 "Réorganiser {label} (position {pos} sur {total}). Utilisez les touches "
 "fléchées pour le déplacer."
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr "Supprimer {label}"
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr "Rétablir {label}"
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr "{label} masqué"
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr "{label} rétabli"
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr "Impossible d’enregistrer la barre latérale. Veuillez réessayer."
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr "Actualiser la bibliothèque"
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr "<"
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr "="
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ">"
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
@@ -3860,45 +3801,44 @@ msgstr ""
 "Une analyse complète des doublons est nécessaire, une seule fois. Lancez-la "
 "depuis les paramètres CWA, puis revenez ici."
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr "Date d’ajout"
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 "Supprimer « {name} » ? Elle sera retirée de {count} livre, qui sera conservé."
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 "Supprimer « {name} » ? Elle sera retirée de {count} livres, qui seront "
 "conservés."
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr "Masquer le message de soutien Ko-fi"
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr "Masquer l’annonce d’aide"
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr "Ouvrir Ko-fi →"
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr "Date de publication"
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr "Soutenez-nous sur Ko-fi !"
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
@@ -3906,94 +3846,94 @@ msgstr ""
 "Ces liens ouvrent les pages de configuration complètes. Les modifications "
 "qui y sont faites s’appliquent à tout le serveur."
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 "« {name} » existe déjà sur {count} livre. Fusionner cette étiquette avec "
 "celle-ci ?"
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 "« {name} » existe déjà sur {count} livres. Fusionner cette étiquette avec "
 "celle-ci ?"
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr "commence par"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr "contient"
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr "ne contient pas"
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr "se termine par"
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr "au cours des N derniers jours"
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr "n’est pas"
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr "est"
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr "pas au cours des N derniers jours"
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr "le ou après le"
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr "le ou avant le"
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr "≤"
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr "≥"
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr "(remplacer la couverture)"
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 "2:3 (couverture d’éditeur — aucune marge pour les couvertures courantes)"
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr "3:4 (générique)"
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 "Une recherche de doublons est déjà en cours. Cette liste se mettra à jour "
 "une fois terminée."
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr "Une sélection aléatoire de votre bibliothèque"
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
@@ -4001,173 +3941,169 @@ msgstr ""
 "Une analyse complète des doublons est nécessaire une première fois. Utilisez "
 "« Rechercher les doublons » ci-dessus pour la lancer."
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr "Clés API"
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "À propos"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr "Paramètres du compte"
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr "Compte : {name}"
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr "Ajouter un identifiant"
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr "Ajouter aux favoris"
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr "Groupe administrateur"
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr "Avancé"
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr "Recherche avancée"
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr "Toutes les étagères"
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr "Autoriser la connexion à distance (lien magique)"
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr "Groupes autorisés (séparés par des virgules)"
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr "Tous"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr "Tous les formats"
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr "Toutes les langues"
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr "Toutes les séries"
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr "Toutes les étiquettes"
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr "Appliquer la sélection"
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 "Appliquer à toute la sélection (seuls les champs remplis sont modifiés ; les "
 "valeurs existantes sont remplacées) :"
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr "Application…"
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr "Archiver"
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Archivé"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr "Poser une question sur Discord"
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr "Authentification"
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr "Authentification et sécurité"
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr "Auteur A–Z"
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr "Auteur Z–A"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr "Autorisé — connexion en cours…"
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr "URL d’autorisation"
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr "Créer les utilisateurs automatiquement"
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr "Créer les utilisateurs automatiquement à la première connexion"
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr "Retour à la bibliothèque"
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr "Revenir à l’affichage classique"
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr "DN de base"
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr "Configuration de base"
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr "Valeur par défaut du livre"
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr "Densité des livres"
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr "Livre {number}"
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr "Livres par page"
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
@@ -4176,491 +4112,477 @@ msgstr ""
 "alors retirés de l’appareil lors de sa prochaine synchronisation. Ils "
 "restent dans votre bibliothèque ici."
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr "Sources intégrées (laisser vide pour désactiver) :"
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr "Actions groupées"
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr "Chemin du certificat d’autorité"
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr "Paramètres CWA (import/conversion)"
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr "Peut téléverser des livres"
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Annuler"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr "Annuler le renommage"
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr "Annuler la modification du titre"
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr "Annuler {task}"
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr "Chemin du fichier de certificat"
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr "Chemin du certificat"
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr "Changer la couverture"
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr "Vérification…"
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr "Choisir une couverture"
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr "Choisir une image de couverture à téléverser"
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr "Choisir une image…"
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr "Choisir les champs"
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr "Choisir votre thème"
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr "Effacer la valeur par défaut"
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr "Effacer la sélection"
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr "Identifiant client"
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr "Secret client"
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr "Secret client (laisser vide pour conserver)"
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr "Fermer le lecteur"
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr "Colonnes"
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr "Confortable"
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr "Compact"
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr "Configuré"
 
 # #973 — consolidating tags from the Tag view (merge on rename collision, delete).
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr "Confirmer la suppression de l’étiquette {name}"
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr "Confirmer le nouveau mot de passe"
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "Convertir"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr "Convertir avant l’envoi"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr "Convertir depuis"
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr "Copié dans le presse-papiers"
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr "Copier le lien"
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr "Impossible de créer l’étagère."
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr "Impossible de créer l’étagère."
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr "Impossible de supprimer l’étagère."
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr "Impossible de supprimer l’étiquette"
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr "Impossible de charger les propositions."
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr "Impossible de charger les doublons."
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr "Impossible de charger les surlignages."
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr "Impossible de charger les statistiques."
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr "Impossible de charger les tâches."
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr "Impossible de charger ce fichier texte."
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr "Impossible de charger les utilisateurs."
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr "Impossible de lire cette archive de bande dessinée."
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr "Impossible de recharger les métadonnées"
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr "Impossible de renommer l’étagère."
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr "Impossible de réinitialiser le mot de passe."
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr "Impossible d’enregistrer l’ordre."
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr "Impossible d’enregistrer les paramètres de lecture."
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr "Impossible d’enregistrer le filtre de bibliothèque par défaut."
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr "Impossible d’enregistrer l’étagère."
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr "Impossible d’enregistrer le titre."
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr "Impossible d’enregistrer votre position de lecture."
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr "Impossible de lancer la recherche de doublons."
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr "Impossible de mettre à jour l’étagère."
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr "Impossible de mettre à jour ce paramètre de votre compte."
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr "Impossible de créer un lien magique. Veuillez réessayer."
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr "Couverture verrouillée"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr "Couverture inaccessible"
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr "Couverture mise à jour à partir du résultat sélectionné."
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr "Créer"
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr "Créer un compte"
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr "Créer un compte"
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr "Échec de la création."
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr "Créer l’étagère et y ajouter le livre"
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr "Créer un utilisateur"
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr "{name} a été créé."
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr "Création…"
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr "Rogner pour remplir — sans bordure, rogne les bords"
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr "Actuelle"
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr "Couverture actuelle"
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr "Mot de passe actuel"
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr "Lecture en cours"
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr "Couleur de bordure personnalisée"
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr "Colonnes personnalisées"
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr "Chemin de la base de données et de la bibliothèque"
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr "Date d'ajout"
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr "Par défaut (police sans empattement du système)"
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr "Langue par défaut des livres"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr "Langue par défaut de l’interface"
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr "Filtre de bibliothèque par défaut effacé."
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr "Filtre de bibliothèque par défaut enregistré."
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr "Rôles par défaut des nouveaux utilisateurs OAuth :"
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 "Les valeurs par défaut se trouvent dans Administration → Configuration → "
 "Synchronisation Kobo."
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr "Supprimer des livres"
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr "Échec de la suppression."
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr "Supprimer l’étagère « {name} » ? Cette action est irréversible."
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr "Supprimer l’étiquette {name}"
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 "Supprimer cette étagère intelligente ? Vos livres ne sont pas affectés."
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 "Supprimer l’utilisateur « {name} » ? Ses étagères et ses données de lecture "
 "seront également supprimées."
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr "Supprimer {name}"
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr "Étiquette {name} supprimée"
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr "{name} a été supprimé."
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr "Dense"
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Description"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr "Désactiver la connexion par mot de passe classique"
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr "Sélection Découvrir mise à jour."
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr "Découvrir — Sélection aléatoire"
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr "Rejeter"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr "Ignorer ce groupe"
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr "Documentation"
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr "Réorganisation terminée"
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Télécharger"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr "Déposez les fichiers ici, ou cliquez pour les choisir"
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr "Dupliquer"
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr "Livres en double"
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr "Paramètres de détection des doublons"
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
@@ -4668,290 +4590,286 @@ msgstr ""
 "Recherche de doublons lancée. Elle s’exécute en arrière-plan — cette liste "
 "se mettra à jour une fois terminée."
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr "Aperçu sur liseuse"
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 "Chaque type (isbn, amazon, google, doi…) ne peut apparaître qu’une fois."
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr "Flou de bord — bordure bokeh douce"
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr "Miroir de bord — prolonge l’illustration (recommandé)"
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Éditer"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr "Modifier les étagères publiques"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr "Modifier l’étagère intelligente"
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr "Modifier le titre de {title}"
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "Adresse mail"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr "Serveur de messagerie (SMTP)"
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr "Adresse mail (facultative)"
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr "Revendication d’adresse mail"
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr "M’envoyer un lien de réinitialisation"
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr "Paramètres de messagerie enregistrés."
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Activer la synchronisation Kobo"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Chiffrement"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr "Expire dans"
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr "N’exposer que les étagères sélectionnées via OPDS"
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr "Impossible de charger les étagères."
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr "Le chargement a échoué."
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr "Favori"
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr "Ajouté aux favoris"
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr "Récupérer"
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr "Récupérer les métadonnées sur le Web"
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr "Fichiers"
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 "Les fichiers sont mis en file d’attente pour l’import de la bibliothèque et "
 "apparaissent une fois importés."
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr "Style de remplissage"
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr "Filtrer : {items}"
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr "Filtrer : {items}…"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr "Police"
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr "Taille de police"
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr "Mot de passe oublié ?"
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr "Format mis en file d’attente — il apparaîtra une fois traité."
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr "Formats"
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr "Formats — exclure"
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr "Formats — inclure"
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr "Adresse de l’expéditeur"
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr "Tableau complet des utilisateurs et restrictions"
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr "Générer un nouveau lien"
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr "Donnez un nom à votre étagère intelligente."
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr "Aller à votre bibliothèque"
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr "Dégradé — fondu haut/bas assorti à la palette"
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr "Revendication de groupe"
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr "Champ des membres du groupe"
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr "Nom du groupe"
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr "Filtre d’objet de groupe"
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr "Le HTML est autorisé et nettoyé à l’affichage."
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr "Nom de l’en-tête"
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr "Aide et assistance"
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr "menu Aide"
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr "Masqué"
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "Cacher"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr "Masquer la section Découvrir"
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr "Masquer les champs"
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr "Masquer le mot de passe"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr "Surligner"
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr "Surlignages"
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr "Populaires"
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr "Populaires — Les plus téléchargés"
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr "Icône"
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr "Type d’identifiant"
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr "Valeur de l’identifiant"
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Identifiants"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr "Image provenant de {source}"
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr "Importé sous"
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr "Dans votre livre"
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
@@ -4959,342 +4877,341 @@ msgstr ""
 "La lecture dans le navigateur prend actuellement en charge l’EPUB. Utilisez "
 "le téléchargement ou le lecteur classique pour les autres formats."
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr "Émetteur / URL de base"
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 "Elle a peut-être été déplacée, ou se trouve encore dans l’interface "
 "classique."
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr "Avancement KOReader"
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr "Chemin du fichier de clé"
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr "Chemin de la clé"
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr "Kobo Libra Color / Libra 2 (1264×1680)"
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr "Synchronisation Kobo activée"
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Langue"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr "Langues — inclure"
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr "Dernière modification"
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr "Dernière synchronisation"
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr "Paramètres de la bibliothèque"
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr "Interligne"
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr "Charger plus"
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr "Chargement…"
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr "Chargement d’une nouvelle sélection Découvrir."
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr "Chargement…"
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr "Verrouiller la couverture"
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr "Texte du bouton de connexion"
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr "Méthode de connexion"
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr "Se connecter avec"
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr "Journaux"
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr "Tout est bon"
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr "Basse résolution"
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr "Lien magique"
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr "QR code du lien magique"
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr "Rendre privée"
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr "Rendre publique"
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr "Définir comme ma vue de bibliothèque par défaut"
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr "Gérer le rôle administrateur depuis le groupe OAuth"
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr "Gérer les étagères"
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr "Marquer comme lu"
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr "Marquer comme non lu"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr "Correspondance"
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr "Max."
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr "Nombre maximal d’auteurs affichés"
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr "Note maximale"
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr "Filtre des utilisateurs membres"
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr "Fusionner avec {name}"
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr "Fusionnée avec {name}"
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr "URL de métadonnées (découverte automatique OIDC)"
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr "Min."
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr "Note minimale"
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 "Plus d’options de couverture (recherche de sources, aperçu sur liseuse)"
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr "Plus de paramètres du serveur"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr "Descendre"
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr "Monter"
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr "Mon compte"
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr "Nom"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr "Besoin de signaler un problème ? Essayez le nouveau"
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr "Nouveau"
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr "Nouveau mot de passe"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr "Nom de la nouvelle étagère"
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr "Nom de la nouvelle étagère…"
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr "Nouvelle étagère…"
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr "Nouvelle étagère intelligente"
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr "Nouvel utilisateur"
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr "Plus récent"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr "Date de publication (décroissant)"
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr "Page suivante"
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr "Aucun livre ne correspond à cette étagère intelligente pour le moment."
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr "Aucun livre ne correspond à ces critères."
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 "Aucune proposition pour l’instant. Essayez une autre recherche ou actualisez."
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr "Aucun sommaire trouvé."
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr "Aucun groupe de doublons trouvé."
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr "Aucune étiquette exclue"
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 "Aucun surlignage pour l’instant. Surlignez pendant la lecture, ou importez "
 "depuis un appareil Kobo."
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr "Aucun résultat dans {items} pour « {query} »."
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr "Aucune page trouvée dans cette bande dessinée."
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr "Aucune étagère pour l’instant — créez-en une ci-dessous."
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 "Aucune étagère pour le moment. Créez-en une ci-dessus pour commencer à "
 "regrouper des livres."
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr "Aucune source ne nécessite de clé."
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr "Aucune tâche en cours."
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr "Aucun élément dans {items} pour le moment."
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr "Non configuré"
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr "Non défini"
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr "Plus ancien"
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr "Date de publication (croissant)"
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
@@ -5302,56 +5219,56 @@ msgstr ""
 "Sur un autre appareil où vous êtes déjà connecté, scannez ce code ou ouvrez "
 "le lien ci-dessous pour autoriser cet appareil."
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr "Ouvrir le compte"
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr "Ouvrir le lecteur classique"
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr "Ouvrir la navigation"
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr "Ouvrir le lecteur"
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr "Ouvrir l’interface classique"
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr "Ouvrez le lien ci-dessous sur votre appareil connecté."
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr "Serveur OpenLDAP"
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr "S’ouvre dans la vue classique"
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr "Lecteur PDF"
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr "Marges de page"
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr "Thème de la page"
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr "Page {number}"
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
@@ -5359,17 +5276,16 @@ msgstr ""
 "Les pages signalées ci-dessous s’ouvrent dans la vue classique. Les "
 "modifications qui y sont faites s’appliquent à tout le serveur."
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Mot de passe"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr "Mot de passe (laisser vide pour conserver)"
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
@@ -5378,159 +5294,154 @@ msgstr ""
 "collez une URL, téléversez un fichier, ou utilisez la couverture intégrée au "
 "livre."
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr "{label} saisi. Faites glisser pour réorganiser, relâchez pour déposer."
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr "Préparation de votre lien magique…"
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr "Page précédente"
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Avancement"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr "Publique"
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr "Publié après le"
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr "Publié avant le"
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr "Livres aléatoires affichés"
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Évaluation"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr "Note (étoiles)"
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr "Statut de lecture"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr "Filtre de statut de lecture"
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr "Paramètres de lecture enregistrés."
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr "Apparence de lecture"
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr "Destinataire(s)"
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr "Hôte de redirection (URL complète)"
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr "Actualiser"
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr "Inscription…"
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr "Recharger"
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr "Recharger les métadonnées depuis le disque"
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr "Rechargement…"
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr "Se souvenir de moi"
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr "Retirer des favoris"
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr "Retirer de l'étagère"
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr "Supprimer le surlignage"
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr "Supprimer l’identifiant"
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr "Supprimer la règle"
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr "Renommer"
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr "Réorganiser"
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr "Remplacer la couverture par celle-ci ?"
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr "Remplacer la couverture ?"
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr "Signaler un problème sur Discord"
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr "Signaler un problème sur GitHub"
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr "Exiger l’appartenance à un groupe"
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr "Réinitialiser le mot de passe de {name}"
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
@@ -5539,372 +5450,370 @@ msgstr ""
 "Réinitialiser le mot de passe de {name} ? Son mot de passe actuel cessera de "
 "fonctionner et un nouveau lui sera envoyé par courrier électronique."
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr "Connexion par en-tête de proxy inverse"
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr "Lignes par chargement"
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr "Durée d’exécution"
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr "Serveur SMTP"
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Sauvegarder"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr "Sauvegarder les paramètres de messagerie"
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr "Sauvegarder le nom"
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr "Sauvegarder les paramètres de sécurité"
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr "Sauvegarder les paramètres"
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 "Sauvegardé. Redémarrez le serveur pour que les modifications de connexion "
 "prennent effet."
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr "Rechercher les doublons"
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr "Tâches planifiées"
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr "Portées"
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr "Chercher un titre, un auteur…"
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr "Recherche dans toutes les sources…"
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr "Recherche…"
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr "Paramètres de sécurité enregistrés."
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr "Voir le rendu de chaque couverture avec marges sur votre appareil"
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "Sélectionner"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr "Sélection multiple"
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr "Envoyer"
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr "Échec de l’envoi."
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr "Envoyer vers la liseuse"
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr "Adresse mail d’envoi vers la liseuse"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr "Envoi…"
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr "Numéro dans la série"
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr "Vue par séries"
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr "Séries — inclure"
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr "Servir en HTTPS"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr "SSL / HTTPS du serveur"
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr "Annonce du serveur (visible par tous les utilisateurs)"
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr "Hôte du serveur"
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr "Compte de service (DN)"
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr "Mot de passe du service"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr "Mot de passe du service (laisser vide pour conserver)"
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 "Indiquez une URL de métadonnées pour remplir automatiquement les points "
 "d’accès ci-dessous, ou saisissez-les manuellement."
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr "Paramètres enregistrés."
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr "Nom de l’étagère"
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr "Étagère introuvable."
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr "Afficher la section Découvrir"
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr "Afficher les boutons Lire et Modifier"
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr "Afficher la vue en tableau"
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr "Afficher les {count} étiquettes"
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr "Tout afficher dans {items}"
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr "Afficher les livres dans la langue"
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr "Afficher un aperçu liseuse sur chaque proposition"
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr "Afficher moins d’étiquettes"
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr "Afficher les livres masqués"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr "Afficher le mot de passe"
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr "Mélanger la sélection"
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr "Se connecter avec un lien magique"
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr "Se déconnecter"
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr "Connexion…"
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr "Titre du site"
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr "Étagère intelligente introuvable."
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr "Étagères intelligentes"
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr "Uni : couleur moyenne de la couverture"
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr "Uni : couleur personnalisée"
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr "Uni : couleur dominante de la couverture"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr "Certaines sources nécessitent une clé pour de meilleures couvertures"
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr "Une erreur s’est produite"
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr "Une erreur s’est produite. Réessayez."
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr "Ordre de tri"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr "Détails de la source"
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr "Lecture commencée"
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr "Démarrage de l’analyse…"
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr "Tableau de bord des statistiques"
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Statut"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr "Étirer pour remplir — sans bordure, légère distorsion"
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr "Soutenir sur Ko-fi →"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr "Ne synchroniser que les étagères que j’ai sélectionnées"
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr "Ne synchroniser que les étagères sélectionnées vers Kobo"
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr "Vue en tableau"
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr "Étiquette"
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Étiquettes"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr "Étiquettes — exclure"
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr "Étiquettes — inclure"
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr "Format d’image cible"
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Tâche"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Tâches"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr "Détails techniques"
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr "Cette URL ne correspond pas à une image utilisable."
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr "Ce format s’ouvre dans le lecteur plein écran."
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr "Ce lien magique a expiré. Générez-en un nouveau pour réessayer."
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr "Cette page n’existe pas ici."
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
@@ -5912,77 +5821,76 @@ msgstr ""
 "Cette page a rencontré une erreur et n’a pas pu être affichée. Votre "
 "bibliothèque n’est pas affectée — recharger suffit généralement."
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr "Cette étagère est vide. Ajoutez des livres depuis la page d’un livre."
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr "Titre A–Z"
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr "Titre Z–A"
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr "Titre, auteur ou ISBN"
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr "URL du jeton"
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr "Les mieux notés"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr "Faire confiance à l’en-tête d’authentification"
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr "Configuration de l’interface et de l’affichage"
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr "Désarchiver"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr "Afficher"
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr "Déverrouillez la couverture ci-dessus pour en appliquer une nouvelle."
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr "Déverrouillez la couverture pour la changer"
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr "Sans titre"
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr "Échec de la mise à jour."
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr "Téléverser comme couverture"
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr "Téléverser des livres"
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 "Le téléversement n'est pas disponible pour votre compte sur ce serveur."
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
@@ -5990,70 +5898,67 @@ msgstr ""
 "Utilisez-les pour connecter des lecteurs OPDS ou la synchronisation KOReader "
 "sans votre mot de passe principal."
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr "Utiliser cette couverture"
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Utilisateur"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr "Administration des utilisateurs"
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr "Filtre d’objet utilisateur"
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr "URL userinfo"
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr "Revendication de nom d’utilisateur"
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr "Versions"
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Vue"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr "Paramètres d’affichage"
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr "Visionneuse"
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr "En attente de votre autorisation…"
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 "Lorsqu’elle est verrouillée, la récupération des métadonnées ne remplacera "
 "pas cette couverture."
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr "Date de la première synchronisation de la progression de lecture"
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
@@ -6063,191 +5968,190 @@ msgstr ""
 "marquer cette étagère n’a donc aucun effet en soi. Basculez votre compte en "
 "synchronisation par étagères uniquement pour que cela prenne effet."
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr "Votre bibliothèque"
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr "Votre navigateur ne peut pas lire ce format audio."
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr "Votre bibliothèque numérique personnelle"
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 "Votre adresse de liseuse enregistrée est affichée — modifiez-la pour cet "
 "envoi uniquement."
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr "toutes les règles"
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr "au moins une règle"
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr "livres"
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr "livres correspondent"
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr "exemplaires"
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr "liseuse"
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr "ex. Science-fiction non lue"
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr "Objet du message vers la liseuse"
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr "partagé"
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr "à"
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr "type (isbn, amazon, doi…)"
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr "valeur"
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr "vous"
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr "{count} livre"
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr "{count} livres"
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr "{count} fichier mis en file d’attente pour l’importation"
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr "{count} fichier rejeté"
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr "{count} fichiers mis en file d’attente pour l’importation"
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr "{count} fichiers rejetés"
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr "{count} résultat"
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr "{count} résultats"
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr "{count} résultats pour « {query} »"
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr "{field} (séparés par des virgules)"
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr "{n} trouvé(s)"
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr "{ok} sources sur {total} ont répondu"
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr "…ou collez l’URL d’une image"
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr "← Retour au livre"
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr "← Retour à la connexion"
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr "← Bibliothèque"
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "En attente"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Echoué"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Débuté"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Terminé"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "Terminé"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "Annulée"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Statut inconnu"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Données inattendues lors de la lecture des informations de mise à jour"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr ""
 "Aucune mise à jour disponible. Vous avez déjà la dernière version installée"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6255,15 +6159,15 @@ msgstr ""
 "Une nouvelle mise à jour est disponible. Cliquez sur le bouton ci-dessous "
 "pour charger la dernière version."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Impossible d'extraire les informations de mise à jour"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr "Téléchargez la dernière version en cliquant sur le bouton ci-dessous."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6272,152 +6176,152 @@ msgstr ""
 "Une nouvelle mise à jour est disponible. Cliquez sur le bouton ci-dessous "
 "pour charger la version : %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Aucune information concernant cette version n’est disponible"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Découvrir (Livres au hasard)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Livres populaires (les plus téléchargés)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "Livres téléchargés par %(user)s"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Auteur : %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Éditeur : '%(name)s'"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Séries : %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "Évaluation : Aucune"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Évaluation : %(rating)s étoiles"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Format de fichier : %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Catégorie : %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Langue : %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Livres populaires"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Livre caché"
 
-#: cps/web.py:1193
+#: cps/web.py
 msgid "Error loading magic shelf"
 msgstr "Erreur lors du chargement de l'étagère magique"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr "Étagère magique&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr "Aucune règle fournie"
 
-#: cps/web.py:1400
+#: cps/web.py
 msgid "Invalid rules format"
 msgstr "Format de règles non valide"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr "Erreur lors du traitement des règles"
 
-#: cps/web.py:1426
+#: cps/web.py
 msgid "Invalid request"
 msgstr "Requête invalide"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr "Le nom et les règles sont obligatoires"
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr "Nom de l'étagère trop long (100 caractères maximum)"
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 msgid "Error creating shelf"
 msgstr "Erreur lors de la création de l'étagère"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 msgid "Create Magic Shelf"
 msgstr "Créer une étagère magique"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr "Autorisation refusée pour modifier le statut public"
 
-#: cps/web.py:1587
+#: cps/web.py
 msgid "Shelf name is required"
 msgstr "Le nom de l'étagère est obligatoire"
 
-#: cps/web.py:1647
+#: cps/web.py
 msgid "Error updating shelf"
 msgstr "Erreur lors de la mise à jour de l'étagère"
 
-#: cps/web.py:1652
+#: cps/web.py
 msgid "Edit Magic Shelf"
 msgstr "Modifier l'étagère magique"
 
-#: cps/web.py:1668
+#: cps/web.py
 msgid "Shelf not found"
 msgstr "Étagère introuvable"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr "Permission refusée"
 
-#: cps/web.py:1704
+#: cps/web.py
 msgid "Shelf duplicated successfully"
 msgstr "Étagère dupliquée avec succès"
 
-#: cps/web.py:1710
+#: cps/web.py
 msgid "Error duplicating shelf"
 msgstr "Erreur lors de la duplication de l'étagère"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
@@ -6425,111 +6329,109 @@ msgstr ""
 "Les étagères système ne peuvent pas être supprimées. Vous pouvez les masquer "
 "dans les paramètres de votre profil utilisateur."
 
-#: cps/web.py:1755
+#: cps/web.py
 msgid "Error deleting shelf"
 msgstr "Erreur lors de la suppression de l'étagère"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 "Vous ne pouvez pas masquer vos propres étagères. Supprimez-les plutôt si "
 "vous ne les voulez pas."
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr "Étagère déjà masquée"
 
-#: cps/web.py:1795
+#: cps/web.py
 msgid "Error hiding shelf"
 msgstr "Erreur lors du masquage de l'étagère"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr "L'étagère n'était pas masquée"
 
-#: cps/web.py:1818
+#: cps/web.py
 msgid "Error unhiding shelf"
 msgstr "Erreur lors de l'affichage de l'étagère"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Téléchargements"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Liste de formats de fichiers"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Veuillez configurer les paramètres SMTP au préalable…"
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 "Oups ! Veuillez mettre à jour votre profil avec une adresse e-mail valide "
 "pour votre liseuse."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr ""
 "Le livre a été mis en file de traitement avec succès pour un envoi vers "
 "%(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Il y a eu une erreur en envoyant ce livre : %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr "Aucune adresse e-mail sélectionnée"
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 "Les adresses e-mail supplémentaires sont désactivées pour votre compte."
 
-#: cps/web.py:2500
+#: cps/web.py
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr ""
 "Réussite ! Livre mis en attente pour être envoyé à l'adresse ou aux adresses "
 "sélectionnées !"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr "Merci de patienter une minute pour enregistrer un nouvel utilisateur"
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Créer un compte"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr ""
 "Erreur de connexion au backend du limiteur, veuillez contacter votre "
 "administrateur"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr ""
 "Le serveur de courriel n'est pas configuré, veuillez contacter votre "
 "administrateur."
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "Votre adresse de courriel n’est pas autorisée pour une inscription."
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "Le courriel de confirmation a été envoyé à votre adresse."
 
-#: cps/web.py:2624
+#: cps/web.py
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
@@ -6537,7 +6439,7 @@ msgstr ""
 "Boucle d'authentification détectée. Si vous rencontrez des problèmes de "
 "connexion, veuillez contacter votre administrateur."
 
-#: cps/web.py:2704
+#: cps/web.py
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
@@ -6545,28 +6447,28 @@ msgstr ""
 "L'authentification OAuth n'est pas correctement configurée. Veuillez "
 "contacter l'administrateur."
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr "Impossible d’activer l’authentification LDAP"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr "La connexion standard est désactivée."
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr "Veuillez patienter une minute avant de vous reconnecter"
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr "Le nom d'utilisateur ne peut pas être vide"
 
-#: cps/web.py:2756
+#: cps/web.py
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "vous êtes maintenant connecté en tant que : '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
@@ -6575,7 +6477,7 @@ msgstr ""
 "Bienvenue ! Votre compte a été créé automatiquement. Vous êtes désormais "
 "connecté sous le nom : « %(nickname)s »."
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
@@ -6583,7 +6485,7 @@ msgstr ""
 "Authentification réussie, mais création du compte échouée. Veuillez "
 "contacter votre administrateur."
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
@@ -6591,7 +6493,7 @@ msgstr ""
 "Authentification réussie, mais aucun compte local trouvé. Veuillez contacter "
 "votre administrateur pour créer votre compte."
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6600,698 +6502,668 @@ msgstr ""
 "Connexion de secours en tant que : '%(nickname)s', le serveur LDAP est "
 "indisponible, ou l'utilisateur est inconnu"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr "Impossible de se connecter : %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 msgid "Wrong Username or Password"
 msgstr "Mauvais nom d'utilisateur ou mot de passe"
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr "Le nouveau mot de passe a été envoyé vers votre adresse de courriel"
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr "Une erreur inconnue est survenue. Veuillez réessayer plus tard."
 
-#: cps/web.py:2838
+#: cps/web.py
 msgid "Please enter valid username to reset password"
 msgstr ""
 "Veuillez entrer un nom d'utilisateur valide pour réinitialiser le mot de "
 "passe"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "Vous êtes maintenant connecté en tant que : '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 msgid "Success! Profile Updated"
 msgstr "Profil mis à jour avec succès"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "Un compte existant a été trouvé pour cette adresse de courriel."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr "Identifiant du livre invalide."
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr "Plugin KOReader Sync"
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "Aucun fichier gmail.json avec information OAuth valide trouvé"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr "Récupération automatique des IDs Hardcover"
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 msgid "Preparing to send to eReader..."
 msgstr "Préparation de l'envoi vers l'eReader…"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr "Vérification des formats disponibles…"
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 msgid "Sending to eReader..."
 msgstr "Envoi vers eReader…"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 msgid "Auto-send completed successfully"
 msgstr "Envoi automatique réussi"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr "Envoi automatique"
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr "Suppression du contenu du dossier temporaire"
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s envoyer à E-Reader"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Calibre ebook-convert %(tool)s introuvable"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "Format %(format)s non trouvé sur le disque"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "Le convertisseur Ebook a échoué avec une erreur inconnue"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "La commande Kepubify-converter a échouée : %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "Fichier converti non trouvé ou plus d'un fichier dans le chemin %(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre a échoué avec l’erreur : %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "La commande ebook-convert a échouée : %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Reconnexion de la base de données de Calibre"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr "Nettoyer les références bibliographiques archivées"
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan"
 msgstr "Scan en double"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan skipped: import in progress"
 msgstr "Scan des doublons terminé : %(count)s nouveaux groupes"
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Supprimer ce groupe en double"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Décompression de la mise à jour"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Scan en double mis en file d'attente"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr "Scan des doublons terminé : %(count)s groupes"
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr "Scan des doublons terminé : %(count)s nouveaux groupes"
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr "Scan des doublons terminé : %(count)s groupes résolus automatiquement"
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Activer la synchronisation Hardcover"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "Adresse de courriel"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr "Sauvegarde des métadonnées"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr "Convertir la bibliothèque – exécution complète"
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 msgid "Convert Library"
 msgstr "Convertir la bibliothèque"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr "EPUB Fixer – exécution complète"
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr "EPUB Fixer"
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "%(count)s vignettes de couverture générées"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "Vignettes de couvertures"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "{0} vignettes de couverture des séries générées"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "Effacement du cache des vignettes de couverture"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "Livres organisés par étagères"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Changer le mot de passe"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Sélectionner d'abord un livre"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "Paramètres d'affichage de la barre latérale"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Paramètres de l'utilisateur"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "choisir une option"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 msgid "Add to Shelf"
 msgstr "Ajouter à l'étagère"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Public)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "Téléchargements par utilisateur"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Téléchargements par utilisateur"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "Création (plus récent en premier)"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "Création (plus ancien en premier)"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Auteur"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Auteur"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Création (plus récent en premier)"
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Création (plus ancien en premier)"
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr ""
 "Trier en fonction du livre ajouté à l'étagère, le plus récent en premier"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr ""
 "Trier en fonction du livre ajouté à l'étagère, le plus ancien en premier"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr "Utilisateurs&nbsp;&nbsp;👤"
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "Envoyer à l'eReader E-mail"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 msgid "Send to eReader Subject"
 msgstr "Objet de l'e-mail eReader"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Afficher les livres"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Étagère publique"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr "Gérer les photos de profil"
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "Importer des utilisateurs LDAP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Paramètres du serveur mail&nbsp;&nbsp;📬"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "Nom d'hôte du serveur SMTP"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "Port du serveur SMTP"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "Compte utilisateur SMTP"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Expéditeur des courriels"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr "Service de messagerie"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail via Oauth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr "Configuration"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Répertoire de la base de données Calibre"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Niveau de journalisation"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Port externe"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Livres par page"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Téléversements"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Navigation anonyme"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Inscription publique"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Connexion à distance Magic Link"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Compte du Reverse Proxy"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Nom de l'en-tête du Reverse Proxy"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Éditer la configuration principale"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Éditer la configuration de l’interface utilisateur"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Éditer la configuration de la base de données Calibre"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "Tâches planifiées"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "Heure de début"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "Durée maximale"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr "Actualisation programmée des vignettes"
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "Génération des vignettes de couvertures des séries"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Reconnecter la base de données Calibre"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr "Générer un fichier de sauvegarde des métadonnées"
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "Actualiser le cache des vignettes"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 msgid "Setup KOReader Sync"
 msgstr "Paramétrer la synchronisation KOReader"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr "Exécuter la récupération automatique des IDs Hardcover"
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Administration&nbsp;&nbsp;🚀"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Télécharger le package de débogage"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Afficher les fichiers journaux"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Redémarrer Calibre-Web"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Arrêter Calibre-Web"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "A propos"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Version"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Détails"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "La mise à jour a échoué :"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Canal de mise à jour"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Version actuelle"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Rechercher les mises à jour"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Effectuer la mise à jour"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Voulez-vous vraiment redémarrer Calibre-Web?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Voulez-vous vraiment arrêter Calibre-Web?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Mise à jour en cours, ne pas rafraîchir la page"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7299,427 +7171,405 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import"
 msgstr "Important :"
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Livres dans la bibiothèque"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Téléversement en cours…"
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "La mise à jour a échoué :"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Erreur de connexion"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr "Note :"
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Séries : %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "via"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "Dans la librairie"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "réduire"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Plus de"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Supprimer le livre"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Supprimer les formats :"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Convertir le format du livre :"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Convertir depuis :"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr "choisir une option"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Convertir vers :"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Convertir le livre"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Erreur"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Format du fichier téléversé"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "ID de séries"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Date de publication"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Type d'identifiant"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Valeur d'identifiant"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Supprimer"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Ajouter un identifiant"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Obtenir la couverture à partir d'une URL (JPEG - l'image sera téléchargée et "
 "sauvegardée dans la base de données)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Téléverser la couverture depuis un fichier en local"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 msgid "Hardcover Sync Blacklist"
 msgstr "Liste noire de synchronisation avec Hardcover"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 "Annotations de la liste noire issues de la synchronisation avec Hardcover"
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 "Liste noire : progression de la lecture depuis la synchronisation vers "
 "Hardcover"
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Voir le livre lors de la sauvegarde"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Obtenir les métadonnées"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Mot-clé"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "Rechercher le mot-clé"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 "Les champs de métadonnées sélectionnés ont été appliqués au formulaire."
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Chargement…"
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Erreur lors de la recherche!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "Aucun résultat. Veuillez essayer avec un nouveau mot clé."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "Ce champ est requis"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr " Échanger l’auteur et le titre"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 msgid "Select all"
 msgstr "Sélectionner tout"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr "Nettoyer tout"
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 msgid "Update Title Sort automatically  "
 msgstr "Mettre à jour le titre Trier automatiquement "
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Mettre à jour automatiquement le tri des auteurs"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Insérer le titre"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Insérer le tri des titres"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Tri des titres"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Insérer le tri des auteurs"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Tri des auteurs"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Insérer les auteurs"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Insérer les catégories"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Insérer les séries"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Insérer les langues"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Date de publication"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Insérer l’éditeur"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Saisir les commentaires"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Comments"
 msgstr "Commentaires"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 msgid "Archived?"
 msgstr "Archivé ?"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 msgid "Read?"
 msgstr "Lu ?"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "Entrez "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Êtes-vous vraiment sûr ?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "Les livres avec titre vont être fusionnés depuis :"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "Dans le livre avec le titre :"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr "Les livres suivants vont être effacés :"
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr "Les livres suivants vont être archivés :"
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr "Les livres suivants vont être désarchivés :"
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr "Les livres suivants vont être marqués comme lus :"
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr "Les livres suivants vont être marqués comme non-lus :"
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Éditer les métadonnées"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 "Éditer les champs que vous voulez changer. Les champs vides seront ignorés :"
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
@@ -7728,27 +7578,26 @@ msgstr ""
 "catégories, les langues et les éditeurs. Utilisez des valeurs séparées par "
 "des virgules (par exemple, « Nom1, Nom2 »)."
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 msgid "Select a Shelf"
 msgstr "Sélectionner une étagère"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 "Veuillez sélectionner une étagère à laquelle ajouter les livres "
 "sélectionnés :"
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr "--Sélectionner une étagère--"
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Ajouter"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
@@ -7756,162 +7605,162 @@ msgstr ""
 "Le serveur de courriel n'est pas configuré, veuillez contacter votre "
 "administrateur."
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr "Message"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Le nouveau mot de passe a été envoyé vers votre adresse de courriel"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Envoyer à l'eReader"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Retour"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Emplacement de la base de données Calibre (fichier metadata.db)"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7927,13 +7776,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7944,7 +7793,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7962,11 +7811,11 @@ msgstr ""
 "        qui s'affiche ci-dessous une fois que vous avez coché l'option "
 "<b>Séparer les fichiers de livres de la bibliothèque</b>."
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr "Fonctionnalité de bibliothèque fractionnée"
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
@@ -7977,32 +7826,32 @@ msgstr ""
 "cependant vos fichiers de bibliothèques peuvent se situer là où vous le "
 "désirez"
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Utiliser Google Drive ?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Authentification Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Répertoire Google Drive pour Calibre"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "Metadata Watch Channel ID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Révoquer"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr ""
 "En dernier recours : restaurer la base de données Calibre (expérimental)"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -8020,96 +7869,96 @@ msgstr ""
 "sauvegardées dans /config/backup avant toute action destructive.</b> Un "
 "journal de restauration sera enregistré aux côtés des sauvegardes."
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 msgid "Are you sure? This cannot be undone."
 msgstr "Êtes-vous sûr(e) ? Cette action ne peut pas être annulée."
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Restaurer la base de données Calibre (en dernier recours)"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr ""
 "Le nouvel emplacement pour la DB est incorrect, veuillez saisir un chemin "
 "valide"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Utiliser l’authentification standard"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Utiliser l’authentification LDAP"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Utiliser OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Configuration du serveur"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Numéro de port du serveur"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Emplacement du fichier certificat SSL (laisser vide pour les serveurs non "
 "SSL)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Emplacement du fichier Keyfile de chiffrement SSL (laisser vide pour les "
 "serveurs non SSL)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Canal de mise à jour"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Stable"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Nightly"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "Hôtes de confiance (séparés par des virgules)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Configuration du fichier journal"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "Emplacement et nom du fichier journal (/dev/stdout pour désactiver)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Activer le journal des accès"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr ""
 "Emplacement et nom du fichier journal d’accès (access.log pour aucune entrée)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 msgid "Feature Configuration"
 msgstr "Configuration de la fonctionnalité"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 "Convertir les caractères non-anglais des titre et auteur lors de "
 "l’enregistrement sur le disque"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
@@ -8118,41 +7967,41 @@ msgstr ""
 "conversion ou de l’envoi par e-mail (nécessite les exécutables Calibre/"
 "Kepubify)"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Autoriser le téléversement de fichier"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr ""
 "(Svp, vérifiez que les utilisateurs ont aussi les droits de téléchargement "
 "vers le serveur)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Formats de fichiers à télécharger autorisés"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Autoriser la navigation anonyme"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Autoriser l’inscription publique"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "Utiliser l'e-mail comme nom d'utilisateur"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Activer la connexion à distance Magic Link"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -8160,155 +8009,155 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Requêtes du Proxy inconnues vers le magasin Kobo"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Port externe du serveur (pour les appels d’API transférés par port)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 "Synchroniser les annotations Kobo avec Hardcover (nécessite une clé API par "
 "utilisateur)"
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Utiliser Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Clé de l’API Goodreads"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 msgid "Enable Hardcover Sync"
 msgstr "Activer la synchronisation Hardcover"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr "Clef API Harcover"
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr "État du jeton : non configuré."
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr "État du jeton : valide."
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 msgid "Token status: rejected or expired."
 msgstr "État du jeton : refusé ou expiré."
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 "État du jeton : présent ; la validation est temporairement indisponible."
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr "Expiration : non indiquée par ce jeton."
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Clé de l’API Goodreads"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8316,11 +8165,11 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Autoriser l'authentification Reverse Proxy"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
@@ -8330,11 +8179,11 @@ msgstr ""
 "l'authentification. Il s'agit d'une méthode d'authentification distincte du "
 "paramètre de sécurité HTTPS ci-dessous."
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr "Utilisation via HTTPS"
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
@@ -8343,11 +8192,11 @@ msgstr ""
 "Activez cette option UNIQUEMENT si vous accédez au serveur via HTTPS, sinon "
 "vous serez bloqué."
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr "Création automatique d'utilisateurs à partir d'un proxy inverse"
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
@@ -8357,79 +8206,79 @@ msgstr ""
 "inverse valides sont reçus. N'activez cette option que si l'authentification "
 "de votre proxy inverse est correctement sécurisée."
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Type de connexion"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr "Utiliser OAuth (nécessite HTTPS)"
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "Nom d'hôte ou Adresse IP du serveur LDAP"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "Port du serveur LDAP"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "Chiffrement LDAP"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Chemin d’accès LDAP CACertificat (uniquement requis pour l’authentification "
 "par certificat client)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Chemin d’accès LDAP CACertificat (requis uniquement pour l’authentification "
 "par certificat client)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Chemin d’accès au fichier de clés LDAP (requis uniquement pour "
 "l’authentification par certificat client)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "Authentification LDAP"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Simple"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "Nom d'utilisateur de l'administrateur LDAP"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "Mot de passe de l'administrateur LDAP"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "LDAP Distinguished Name (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "Filtre objet de l'utilisateur LDAP"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "Est-ce que le serveur LDAP est OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr "Création automatique d'utilisateurs à partir de LDAP"
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
@@ -8438,43 +8287,43 @@ msgstr ""
 "LDAP réussit pour les nouveaux utilisateurs. Recommandé pour les "
 "environnements d'entreprise."
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr "Les paramètres suivant sont nécessaires pour importer un utilisateur"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "Filtre objet de groupe LDAP"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "Nom de groupe LDAP"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "Champ des membres de groupe LDAP"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "Filtre de détection des utilisateurs membres LDAP"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "Détecter automatiquement"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "Filtre personnalisé"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "Filtre utilisateur des membres LDAP"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr "Important :"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
@@ -8482,29 +8331,29 @@ msgstr ""
 "L'authentification OAuth nécessite que ce serveur soit accessible via HTTPS. "
 "Si vous utilisez HTTP, la connexion échouera."
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr "Fournisseur OAuth générique"
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr "URL de métadonnées OAuth (pour auto-découverte)"
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 msgid "Test Metadata"
 msgstr "Tester les métadonnées"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr "Laisser vide pour utiliser la configuration manuelle ci-dessous"
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 "Utiliser les URL manuelles des points de terminaison (remplacer la détection "
 "automatique)"
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
@@ -8512,43 +8361,43 @@ msgstr ""
 "Cochez cette case pour configurer manuellement les points de terminaison "
 "OAuth individuels au lieu d'utiliser la détection automatique"
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 msgid "Manual Endpoint Configuration"
 msgstr "Configuration manuelle des terminaux"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr "URL de base OAuth"
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr "Point final d'autorisation"
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 msgid "Token Endpoint"
 msgstr "Point de terminaison du jeton"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr "Point de terminaison UserInfo"
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 msgid "Test Connection"
 msgstr "Test de connexion"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 msgid "OAuth Scopes"
 msgstr "Portées OAuth"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr "Liste d’autorisations OAuth séparées par des espaces"
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr "Hôte de redirection OAuth"
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
@@ -8558,7 +8407,7 @@ msgstr ""
 "les erreurs « URI de redirection non valide ». Incluez le protocole "
 "(https://). Laissez ce champ vide pour utiliser la détection automatique."
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
@@ -8566,70 +8415,70 @@ msgstr ""
 "Requis si : accès via plusieurs noms d'hôte, derrière un proxy inverse ou "
 "obtention d'erreurs « URI de redirection non valide »."
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 msgid "OAuth Client Id"
 msgstr "Client Id OAuth"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 msgid "OAuth Client Secret"
 msgstr "Client secret OAuth"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 msgid "Field Mapping Configuration"
 msgstr "Configuration du mappage de champs"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 msgid "Username Field"
 msgstr "Champs nom d'utilisateur"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr "Champs JWT d'où extraire le num d'utilisateur"
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 msgid "Email Field"
 msgstr "Champs courriel"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr "Champs JWT d'où extraire le courriel"
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "Groupe OAuth pour les administrateurs"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr "Groupe OAuth pour les administrateurs"
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
@@ -8640,101 +8489,101 @@ msgstr ""
 "groupes, ou utilisez le paramètre global dans les paramètres de sécurité "
 "pour plus de contrôle."
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Réglages par défaut pour les nouveaux utilisateurs"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Permettre les téléchargements"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Autoriser le visionneur de livres"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Permettre le téléversement de fichiers"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Permettre l'édition"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Permettre la suppression de livres"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Permettre le changement de mot de passe"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Autoriser la modification d’étagères publiques"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr "Texte du bouton d'authentification"
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Obtenir les identifiants OAuth %(provider)s"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "Client Id OAuth %(provider)s"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "Client secret OAuth %(provider)s"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Exécutables externes"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr "Chemin vers les exécutables de Calibre"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 msgid "Calibre E-Book Converter Settings"
 msgstr "Paramètres du convertisseur E-Book de Calibre"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Chemin vers le convertisseur de livres Kepubify"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 msgid "Location of Unrar binary"
 msgstr "Chemin d’accès du binaire UnRar"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 msgid "Security Settings"
 msgstr "Réglages de sécurité"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr "Désactiver la connexion standard (nom d'utilisateur/mot de passe)"
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
@@ -8743,12 +8592,12 @@ msgstr ""
 "connecter via OAuth ou LDAP. Assurez-vous de disposer d'une autre méthode de "
 "connexion fonctionnelle avant d'activer cette option."
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 "Activer la gestion des rôles administratifs basée sur les groupes OAuth"
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8762,92 +8611,92 @@ msgstr ""
 "d'empêcher les connexions OAuth de remplacer les attributions de rôles "
 "locales."
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr "Limiter le nombre de tentatives de connexion"
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr "Configurer le backend pour le limiteur"
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr "Options pour le backend du limiteur"
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 "Vérifiez si les extensions de fichier correspondent au contenu du fichier "
 "lors du téléversement"
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 msgid "Session protection"
 msgstr "Protection de la session"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr "Basique"
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr "Fort"
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 msgid "User Password policy"
 msgstr "Politique de mot de passe utilisateur"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr "Longueur minimum du mot de passe"
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr "Imposer des chiffres"
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr "Imposer lettre en minuscule"
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr "Imposer lettre en majuscule"
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 "Imposer des caractères (requis pour les caractères Chinois/Japonnais/Coréens)"
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr "Imposer des caractères spéciaux"
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Configuration du mode d’affichage"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 "Le titre affiché dans l'onglet du navigateur et la barre de navigation."
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr "Nombre de livres à afficher par page dans les vues en liste (1-200)."
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Nombre de livres choisis au hasard à afficher"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr "Nombre de livres aléatoires affichés sur la page d'accueil (1-30)."
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr ""
 "Nombre d’auteurs à afficher avant de masquer (0=désactiver le masquage)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
@@ -8855,15 +8704,15 @@ msgstr ""
 "Nombre maximal d'auteurs à afficher dans les détails du livre avant "
 "tronquage. Définissez cette valeur sur 0 pour désactiver cette fonction."
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 msgid "Default Theme"
 msgstr "Thème par défaut"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "caliBlur ! Thème sombre"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
@@ -8871,42 +8720,42 @@ msgstr ""
 "Thème par défaut pour les nouveaux utilisateurs et la navigation anonyme. "
 "Les utilisateurs peuvent sélectionner leur thème préféré dans leur profil."
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Expression régulière à utiliser pour filtrer les colonnes"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 "Modèle Regex permettant de masquer les colonnes personnalisées dans "
 "l'interface utilisateur."
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Lier le statut lu/non lu à la colonne équivalente dans Calibre"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr ""
 "Synchronisez le statut lu/non lu avec une colonne personnalisée booléenne "
 "Calibre."
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Visualiser les restrictions basées sur la colonne Calibre"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 "Limiter la visibilité des livres en fonction des valeurs d'une colonne "
 "personnalisée de texte Calibre."
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Expression régulière à utiliser pour trier les titres"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
@@ -8914,199 +8763,194 @@ msgstr ""
 "Expression régulière permettant de supprimer les préfixes des titres afin de "
 "les trier correctement (par exemple, « The », « A », « An »)."
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Configuration du mode d’affichage"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Custom CSS"
 msgstr "Filtre personnalisé"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Réglages par défaut pour les nouveaux utilisateurs"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 "Ces paramètres seront appliqués à tous les nouveaux comptes utilisateurs "
 "créés."
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 msgid "Permissions"
 msgstr "Permissions"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Utilisateur admin"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 msgid "Language & Display"
 msgstr "Langue et affichage"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "Langue par défaut"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 msgid "Default interface language for new users."
 msgstr "Langue par défaut de l'interface pour les nouveaux utilisateurs."
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "Langue des livres visible par défaut"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 msgid "Default book language filter for new users."
 msgstr "Filtre de langue par défaut pour les nouveaux utilisateurs."
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Mode de visualisation par défaut pour les nouveaux utilisateurs"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 "Choisissez les sections de la barre latérale qui seront visibles par défaut "
 "pour les nouveaux utilisateurs."
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Montrer aléatoirement des livres dans la vue détaillée"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Ajouter les étiquettes autorisées/refusées"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Ajouter les valeurs de colonnes autorisées/refusées"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Téléverser"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Candidates"
 msgstr "Correspondances potentielles"
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run Archive"
 msgstr "Exécuter archivage"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 msgid "Download Log"
 msgstr "Télécharger les journaux utilisateurs"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Démarrer"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr "Calendrier 5m"
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr "Calendrier 15 m"
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr "Conversion de la bibliothèque réussie"
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr "Erreur de planification Convertir la bibliothèque"
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -9115,14 +8959,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -9130,87 +8974,86 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr "Exécuter sur un seul livre"
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr "Rechercher par titre/auteur"
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on selected book"
 msgstr "Exécuter sur le livre sélectionné"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer scheduled successfully"
 msgstr "EPUB Fixer planifié avec succès"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error scheduling EPUB Fixer"
 msgstr "Erreur de planification EPUB Fixer"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 msgid "No matches found"
 msgstr "Aucun résultat trouvé"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 msgid "Enter a search term"
 msgstr "Saisir un terme de recherche"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 msgid "Failed to search library"
 msgstr "Échec de la recherche dans la bibliothèque"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 msgid "Select a book first"
 msgstr "Sélectionner d'abord un livre"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer started for selected book"
 msgstr "Correction EPUB démarrée pour le livre sélectionné"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error starting EPUB Fixer"
 msgstr "Erreur lors du démarrage du correcteur EPUB"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Activer/Désactiver les services Calibre-Web Automated"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -9218,11 +9061,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -9233,11 +9076,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -9247,28 +9090,28 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
-"Cet outil a été adapté à partir de l'outil <a href=\"https://kindle-epub-fix."
-"netlify.app/\">kindle-epub-fix.netlify.app</a> créé par <a href=\"https://"
-"github.com/innocenat\">innocenat</a>."
+"Cet outil a été adapté à partir de l'outil <a href=\"https://kindle-epub-"
+"fix.netlify.app/\">kindle-epub-fix.netlify.app</a> créé par <a "
+"href=\"https://github.com/innocenat\">innocenat</a>."
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
@@ -9279,11 +9122,11 @@ msgstr ""
 "metadata.db. Pour arrêter un remplissage en cours, redémarrez le conteneur "
 "après l'avoir désactivé."
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr "Activer le mode agressif EPUB Fixer (plus risqué)"
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
@@ -9292,11 +9135,11 @@ msgstr ""
 "conversions d'encodage moins fiables. Le mode sécurisé est recommandé pour "
 "la plupart des bibliothèques."
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 msgid "Enable Archived Book Cleanup"
 msgstr "Activer le nettoyage des livres archivés"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
@@ -9305,117 +9148,117 @@ msgstr ""
 "livre n'existe plus dans la bibliothèque Calibre. Permet de maintenir "
 "l'exactitude du nombre d'ouvrages archivés."
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr "Calendrier de nettoyage :"
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr "Intervalles fréquents"
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr "Toutes les 15 minutes"
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr "Toutes les 30 minutes"
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr "Toutes les heures"
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr "Toutes les 2 heures"
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr "Toutes les 4 heures"
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr "Toutes les 6 Heures"
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr "Toutes les 12 heures"
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr "Quotidien/Hebdomadaire/Mensuel"
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr "Tous les jours à une heure précise"
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr "Chaque semaine, un jour précis"
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr "Chaque mois, à une date précise"
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr "Par défaut : tous les jours à 3 h"
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr "Jour de la semaine :"
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr "Lundi"
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr "Mardi"
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr "Mercredi"
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr "Jeudi"
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr "Vendredi"
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr "Samedi"
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr "Dimanche"
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr "Jour du mois :"
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr "(1-28)"
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr "Heure de la journée :"
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr "(Fuseau horaire du serveur : %(tz)s)"
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 "Activer la récupération automatique des métadonnées pour les nouveaux livres"
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9423,11 +9266,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr "Activer l'application Smart Metadata"
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9440,11 +9283,11 @@ msgstr ""
 "Lorsque cette option est désactivée, les métadonnées récupérées remplacent "
 "les données existantes telles quelles à partir du fournisseur préféré."
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 msgid "Metadata Fields to Update"
 msgstr "Champs de métadonnées à mettre à jour"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
@@ -9455,25 +9298,23 @@ msgstr ""
 "lors de la récupération automatique des métadonnées, ce qui permet de "
 "conserver vos données existantes."
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr "Tags/Genres"
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identifiants (ISBN, etc.)"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 msgid "Cover Image"
 msgstr "Image de couverture"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr "Astuce"
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
@@ -9484,15 +9325,15 @@ msgstr ""
 "aux champs sélectionnés, tandis que le mode Direct remplacera tous les "
 "champs sélectionnés par les données du fournisseur."
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr "Taille maximale du fichier de couverture (MB) :"
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr "Plage : 1 à 200 MB (valeur par défaut : 15)"
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
@@ -9501,11 +9342,11 @@ msgstr ""
 "fournisseurs de métadonnées ou des URL pour éviter les sauvegardes lentes ou "
 "bloquées."
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr "Dépassement du délai de traitement d’ingestion"
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
@@ -9515,19 +9356,19 @@ msgstr ""
 "avant expiration du délai. Les fichiers dont le traitement expire sont "
 "déplacés vers le dossier de sauvegarde des échecs pour analyse."
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr "Délai d'expiration (minutes):"
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr "Plage : 5-120 minutes (par défaut : 15)"
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr "Nettoyage des temporailles périmées"
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
@@ -9538,27 +9379,27 @@ msgstr ""
 "désactive le nettoyage. Les modifications s'appliquent lors du prochain "
 "cycle de nettoyage."
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr "Durée de conservation (minutes) :"
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr "Plage : 0 à 10080 minutes (valeur par défaut : 120)"
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr "Intervalle de nettoyage des données temporaires (en secondes) :"
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr "Plage : 0 à 86 400 secondes (valeur par défaut : 600)"
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr "Délai d'envoi automatique pour les nouveaux livres"
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9571,20 +9412,20 @@ msgstr ""
 "s'applique qu'aux utilisateurs qui ont activé l'envoi automatique dans leur "
 "profil."
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr "Retard (minutes) :"
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr "Plage : 1 à 60 minutes (valeur par défaut : 5)"
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 "Hiérarchie des fournisseurs de récupération automatique des métadonnées"
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
@@ -9595,25 +9436,25 @@ msgstr ""
 "nouveaux livres. Glissez-déposez pour réorganiser les fournisseurs. Seuls "
 "les fournisseurs activés seront utilisés."
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 "Les fournisseurs sont classés par ordre décroissant. Faites glisser pour "
 "réorganiser."
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr "Fournisseurs de métadonnées activés"
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr "Les fournisseurs non vérifiés sont désactivés globalement."
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Paramètres de récupération automatique des livres à couverture rigide"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
@@ -9624,11 +9465,11 @@ msgstr ""
 "synchronisation de la progression de lecture et des annotations avec "
 "Hardcover.app lorsque vous utilisez des liseuses compatibles."
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr "Jeton Hardcover requis"
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
@@ -9639,18 +9480,18 @@ msgstr ""
 "configurer un jeton global dans la configuration de base. Sans jeton valide, "
 "cette fonctionnalité restera désactivée."
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
@@ -9661,25 +9502,25 @@ msgstr ""
 "automatiquement ; les correspondances peu fiables sont mises en file "
 "d'attente pour être examinées manuellement."
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr "Calendrier des lancements :"
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 "Fréquence d'exécution automatique de la tâche de récupération des "
 "identifiants Hardcover"
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr "Seuil de confiance minimum :"
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr "Plage : 0,50-1,00 (valeur par défaut : 0,85)"
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
@@ -9690,15 +9531,15 @@ msgstr ""
 "être examinés manuellement. Valeurs plus élevées = moins de correspondances "
 "automatiques, mais une plus grande précision."
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr "Taille du lot :"
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr "Plage : 10 à 200 livres par exécution (valeur par défaut : 50)"
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
@@ -9707,15 +9548,15 @@ msgstr ""
 "petits réduisent la charge de l'API ; les lots plus importants traitent "
 "votre bibliothèque plus rapidement."
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr "Délai de limitation du débit (en secondes) :"
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr "Plage : 0 à 60 secondes (valeur par défaut : 5,0)"
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
@@ -9723,33 +9564,33 @@ msgstr ""
 "Délai entre les requêtes API vers Hardcover. Empêche la limitation du débit "
 "et protège votre clé API. Utilise un délai exponentiel en cas d'erreurs."
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 msgid "Web UI Settings"
 msgstr "Paramètres de l'interface web"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "Réglages de sauvegarde automatisée"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9757,36 +9598,35 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr "Activer les notifications de contributions aux traductions"
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -9796,11 +9636,11 @@ msgstr ""
 "dans l’interface Web lorsque vous utilisez une langue autre que l’anglais, "
 "si la traduction de la langue choisie n’est pas complète."
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Synchroniser Magic Shelves avec Kobo"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
@@ -9809,11 +9649,11 @@ msgstr ""
 "votre appareil Kobo sous forme de collections. Remarque : vous devez "
 "également activer Kobo Sync dans la configuration de base."
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Activer les arrières plan flous sur Mobile (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -9822,15 +9662,15 @@ msgstr ""
 "également rendu sur les petits écrans. Désactivez cet effet si vous "
 "constatez un décalage dans le défilement ou l'animation."
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 msgid "Automatic Backup Settings"
 msgstr "Réglages de sauvegarde automatisée"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -9838,11 +9678,11 @@ msgstr ""
 "Si actif, une copie de tous les fichiers importés sera stockée dans <i>/"
 "config/processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -9850,21 +9690,21 @@ msgstr ""
 "Si actif, les fichiers originaux ingérés et convertis seront stockés dans le "
 "dossier /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9877,11 +9717,11 @@ msgstr ""
 "les sous-répertoires de /config/processed_books organisés et de minimiser "
 "l’utilisation de l’espace disque."
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -9891,32 +9731,32 @@ msgstr ""
 "automatiquement converti au format choisit ici (sauf pour les formats "
 "sélectionnés dans la liste à ignorer ci-dessous)"
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 msgid "Choose a target format:"
 msgstr "Choisissez un format cible :"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9924,21 +9764,21 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "Calibre peut détecter les titres de livre en double lors de l'import et en "
 "fonction du"
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr "fusion automatique"
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -9946,35 +9786,35 @@ msgstr ""
 "paramétrage. Il peut être configuré pour supprimer l'un des doublons ou "
 "conserver les deux (par défaut)."
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Rejeter l'import en double, conserver la copie de librairie"
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 "Ecrase la copie de la bibliothèque avec le fichier nouvellement importé"
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Crée un enregistrement en double, en conservant les deux copies."
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
@@ -9983,31 +9823,31 @@ msgstr ""
 "désactivé, la recherche des doublons ne s'exécute pas et aucune notification "
 "n'est affichée."
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Detection"
 msgstr "Activer la détection des doublons"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr "Méthode de détection des doublons"
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr "Hybride (préfiltrage SQL + validation Python)"
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr "Python uniquement (le plus lent, le plus robuste)"
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr "SQL hérité uniquement (expérimental)"
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
@@ -10016,11 +9856,11 @@ msgstr ""
 "candidats, puis applique la logique Python robuste pour obtenir les "
 "résultats finaux."
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 msgid "Automatic Duplicate Scanning"
 msgstr "Détection automatique des doublons"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
@@ -10028,27 +9868,27 @@ msgstr ""
 "Configurez les analyses en arrière-plan des doublons. Celles-ci s'exécutent "
 "automatiquement sans bloquer l'interface utilisateur."
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr "Activer la recherche automatique des doublons"
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr "Après les analyses d'importation"
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr "Exécuter après chaque importation (anti-rebond)"
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr "Manuel uniquement"
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr "Après importation, délai anti-rebond (secondes)"
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
@@ -10056,16 +9896,16 @@ msgstr ""
 "Attendez ce nombre de secondes après la dernière importation avant de lancer "
 "une analyse en arrière-plan."
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr "Analyses programmées (expression cron)"
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 "Laissez ce champ vide pour désactiver les analyses planifiées. Exemple :"
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
@@ -10075,15 +9915,15 @@ msgstr ""
 "désactiver les analyses après importation tout en conservant les "
 "planifications cron."
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr "Prochaine analyse prévue :"
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
@@ -10093,33 +9933,33 @@ msgstr ""
 "sont des doublons. Les livres doivent correspondre à TOUS les critères "
 "sélectionnés pour être considérés comme des doublons."
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr "Tenir compte des titres des livres lors de la détection des doublons"
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 "Prendre en compte les auteurs des livres lors de la détection des doublons"
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr "Tenir compte de la langue du livre lors de la détection des doublons"
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 "Prendre en compte les séries de livres lors de la détection des doublons"
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr "Prendre en compte l'éditeur du livre lors de la détection des doublons"
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr "Tenir compte du format de fichier lors de la détection des doublons"
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
@@ -10127,11 +9967,11 @@ msgstr ""
 "Au moins un critère doit être sélectionné. Le titre et l'auteur sont "
 "recommandés comme critères principaux."
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr "Classement des priorités des formats en double"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
@@ -10142,11 +9982,11 @@ msgstr ""
 "déposez pour réorganiser les formats par ordre de priorité (plus élevé = "
 "meilleur)."
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr "Astuce :"
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
@@ -10156,11 +9996,11 @@ msgstr ""
 "haute qualité », les livres avec les formats les mieux classés seront "
 "conservés. Les formats moins prioritaires seront supprimés."
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr "Notifications en double et résolution automatique"
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
@@ -10168,11 +10008,11 @@ msgstr ""
 "Configurez la manière dont vous êtes averti des livres en double et activez "
 "éventuellement la résolution automatique."
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Notifications"
 msgstr "Activer les notifications en double"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
@@ -10183,15 +10023,15 @@ msgstr ""
 "d'édition verront un badge sur le bouton de la barre latérale Doublons et "
 "une notification contextuelle lorsqu'ils se connecteront."
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Activer la résolution automatique des doublons"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr "Attention :"
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
@@ -10199,77 +10039,77 @@ msgstr ""
 "Cela supprimera automatiquement les livres selon la stratégie ci-dessous. "
 "Les fichiers originaux seront sauvegardés dans"
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr "Stratégie de résolution automatique"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr "Conserver les plus récents"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 "Supprimer les anciennes copies, conserver le livre ajouté le plus récemment"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr "Conserver le plus ancien"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr "Supprimer les copies les plus récentes, conserver les plus anciennes"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge Formats"
 msgstr "Fusionner les formats"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr "Fusionner les formats dans le dernier livre, supprimer le reste"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr "Conserver le format de la plus haute qualité"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 "Préférez les formats en fonction de votre classement des priorités de format "
 "de duplication"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep Most Metadata"
 msgstr "Conserver la plupart des métadonnées"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr "Conserver le registre contenant les informations les plus complètes"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr "Conserver la taille de fichier la plus grande"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 "Conserver le livre dont la taille totale des fichiers est la plus importante"
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 "Choisissez le livre à conserver lorsque les doublons sont automatiquement "
 "résolus."
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 msgid "Rate Limiting"
 msgstr "Limitation de débit"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr "Période de refroidissement (minutes)"
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
@@ -10277,7 +10117,7 @@ msgstr ""
 "Délai minimum entre les résolutions automatiques (0 pour désactiver). "
 "Empêche les suppressions rapides lors des importations par lots."
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -10286,277 +10126,265 @@ msgstr ""
 "détecté de nouveaux doublons. Les groupes de doublons rejetés ne sont jamais "
 "résolus automatiquement."
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr "Avis %(count)s Match(s) en attente"
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr "Cliquer pour voir plus"
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Suivant"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Marquer comme non lu"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Marquer comme lu"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 msgid "Marked as read"
 msgstr "Marqué comme lu"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 msgid "Marked as unread"
 msgstr "Marqué comme non lu"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Ajouter comme archive"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Restauré depuis l'archive"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Restaurer à partir de l'archive"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Ajouter comme archive"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 msgid "Restored from archive"
 msgstr "Restauré depuis l'archive"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Reloaded metadata from disk"
 msgstr "Fournisseurs de métadonnées activés"
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Unhide from your library"
 msgstr "Masquer cette étagère dans votre barre latérale"
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "Masquer cette étagère dans votre barre latérale"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 msgid "Rating updated"
 msgstr "Évaluation mise à jour"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 msgid "Rating cleared"
 msgstr "Évaluation effacée"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "Livre %(index)s sur %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr "ID"
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr "UUID"
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr "UUID copié dans le presse-papiers"
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr "Impossible de copier l'UUID"
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr "Copier l'UUID"
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr "Tailles de fichiers"
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Description :"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 msgid "Select eReader Email Addresses"
 msgstr "Sélectionnez les adresses e-mail de l'eReader"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 msgid "Choose email addresses:"
 msgstr "Choisissez les adresses e-mail :"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 msgid "Select All"
 msgstr "Sélectionner tout"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr "Adresses e-mail supplémentaires :"
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 "Entrez les adresses e-mail supplémentaires (séparées par des virgules) :"
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr "exemple@domaine.com, autre@domaine.com"
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr "Entrez une ou plusieurs adresses e-mail séparées par des virgules"
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 msgid "Select format:"
 msgstr "Sélectionner le format :"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 msgid "Failed to update tags"
 msgstr "Échec de la mise à jour des tags"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 msgid "Failed to update shelves"
 msgstr "Échec de la mise à jour des étagères"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
@@ -10564,63 +10392,63 @@ msgstr ""
 "Livres ayant les mêmes titres, auteurs et langues. Les livres dans "
 "différentes langues ne sont pas considérés comme des doublons."
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Scan en double"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 msgid "Scan for Duplicates Now"
 msgstr "Rechercher les doublons maintenant"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr "Sélectionner les doublons"
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 msgid "Select None"
 msgstr "Ne rien sélectionner"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 msgid "Delete Selected"
 msgstr "Effacer la sélection"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Scan en double"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View Background Tasks"
 msgstr "Présentation des tâches en arrière-plan"
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr "Résolution automatique des doublons"
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
@@ -10628,29 +10456,29 @@ msgstr ""
 "Résolvez automatiquement tous les groupes en double en conservant un seul "
 "livre et en supprimant les autres selon une stratégie définie."
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr "Stratégie :"
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 "Conserver les plus récents - Supprimer les anciennes copies, conserver les "
 "plus récentes"
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 "Conserver les plus anciens - Supprimer les copies plus récentes, conserver "
 "les plus anciennes"
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 "Fusionner les formats - Fusionner les formats dans le livre le plus récent, "
 "supprimer le reste"
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
@@ -10658,63 +10486,63 @@ msgstr ""
 "Conserver le format de la plus haute qualité - Privilégiez les formats en "
 "fonction de votre classement des priorités de formats en double"
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 "Conserver la plupart des métadonnées - Conserver le livre contenant les "
 "informations les plus complètes"
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 "Conserver le fichier le plus volumineux - Conserver le livre dont la taille "
 "totale est la plus importante"
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 msgid "Preview"
 msgstr "Aperçu"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr "Exécuter la résolution"
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 "Cela supprimera définitivement les livres. Les fichiers originaux seront "
 "sauvegardés sur"
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 msgid "Merge Selected"
 msgstr "Fusionner la sélection"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr "Supprimer ce groupe en double"
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 msgid "View book details"
 msgstr "Voir les détails du livre"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 msgid "Edit book metadata"
 msgstr "Modifier les métadonnées du livre"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 msgid "Archive/delete book"
 msgstr "Archiver/supprimer un livre"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 msgid "No Duplicate Books Found"
 msgstr "Pas de livres en double trouvés"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 "Votre bibliothèque ne contient aucun livre dont le titre et l'auteur sont "
 "identiques."
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
@@ -10722,123 +10550,123 @@ msgstr ""
 "Cette recherche des livres avec des titres et des auteurs identiques pour "
 "éviter les faux-positifs."
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Execute Auto-Resolution"
 msgstr "Exécuter la résolution"
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Sélectionner le format :"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr "Cette action ne peut être défaite !"
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 msgid "The following books will be permanently deleted:"
 msgstr "Les livres suivants vont être effacés de manière permanante :"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Merge Books"
 msgstr "Fusionner les livres"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 msgid "The following book will be kept:"
 msgstr "Le registre suivant sera tenu :"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "Les livres suivants seront fusionnés dans celui-ci (puis supprimés) :"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 "Remarque : les formats de fichiers des livres sources seront ajoutés au "
 "livre cible."
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr "Aperçu de la résolution"
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr "Succès"
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr "Les livres en double sélectionnés ont été supprimés avec succès !"
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr "Une erreur est survenue pendant le traitement de votre requête."
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "Choisissez le type de compte mail"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr "Utilisez un compte mail standard"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr "Compte Gmail"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr "Configuration du compte Gmail"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Révoquer l’accès Gmail"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "Mot de passe SMTP"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Limite de la taille de la pièce jointe"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 msgid "Save and Send Test Email"
 msgstr "Sauvegarder les réglages et tester l’envoi d’un courriel"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Domaines autorisés (Liste blanche)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Ajouter un domaine"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Saisir le nom de domaine"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Domaines refusés (Liste noire)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr "(Magique)"
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10846,23 +10674,23 @@ msgstr ""
 "Ouvrir le fichier .kobo/Kobo/Kobo eReader.conf dans un éditeur de texte et "
 "ajouter (ou éditer):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Jeton Kobo :"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "Liste"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr "Avis Hardcover Match 🔖"
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr "Tout rattrapé !"
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
@@ -10871,15 +10699,15 @@ msgstr ""
 "vérification. De nouvelles correspondances apparaîtront ici lorsque la tâche "
 "de récupération automatique sera exécutée."
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr "Retour au panneau d'administration"
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr "Examen requis"
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
@@ -10889,11 +10717,11 @@ msgstr ""
 "Veuillez vérifier chaque correspondance et sélectionner le résultat correct, "
 "ou ignorer/rejeter si aucune correspondance valable n'existe."
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr "Correspondances en attente"
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
@@ -10903,66 +10731,60 @@ msgstr ""
 "livres. Les correspondances hautement fiables sont appliquées "
 "automatiquement ; celles-ci nécessitent une vérification manuelle."
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 msgid "Reject All Pending"
 msgstr "Tout rejeter en attente"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 msgid "Search Query"
 msgstr "Requête de recherche"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr "Correspondances potentielles"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr "Meilleurs %(count)s"
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr "Confiance"
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr "Raison de la correspondance"
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 msgid "View on Hardcover"
 msgstr "Voir sur Hardcover"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr "Sélectionner cette correspondance"
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 msgid "Reject All"
 msgstr "Refuser tout"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr "Ignorer pour l'instant"
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 msgid "Processing..."
 msgstr "En cours…"
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr "Sélectionner cette correspondance"
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr "Échec de l'application de la correspondance"
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
@@ -10970,41 +10792,38 @@ msgstr ""
 "Voulez-vous vraiment rejeter toutes les correspondances pour ce livre ? "
 "Cette action ne peut pas être annulée."
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr "✗ Rejeter toutes les correspondances"
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject match"
 msgstr "Échec du rejet de la correspondance"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr ""
 "Voulez-vous vraiment rejeter toutes les correspondances en attente ? Cette "
 "action ne peut pas être annulée."
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Pending"
 msgstr "✗ Tout rejeter en attente"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject all pending matches"
 msgstr "Échec du rejet de toutes les correspondances en attente"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr "→ Ignorer pour l'instant"
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr "Impossible d’ignorer la correspondance"
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
@@ -11013,271 +10832,270 @@ msgstr ""
 "L'instance Calibre-Web Automated n'est pas configurée, veuillez contacter "
 "votre administrateur"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Signaler un problème"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Retour à l’accueil"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "Déconnecter l’utilisateur"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr "Avis mobile"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 "La modification de l'étagère magique fonctionne mieux sur les ordinateurs de "
 "bureau ou les tablettes."
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr "Actualiser l'étagère pour mettre à jour les dernières modifications"
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 msgid "Edit shelf rules"
 msgstr "Modifier les règles relatives aux étagères"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr "Masquer cette étagère dans votre barre latérale"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Show this shelf in your sidebar"
 msgstr "Afficher cette étagère dans votre barre latérale"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 msgid "Show Shelf"
 msgstr "Afficher l'étagère"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 msgid "Hide Shelf"
 msgstr "Masquer l'étagère"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Ajouter à l'étagère"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr "La synchronisation KOReader est désactivée."
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Accueil"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Basculer la navigation"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Chercher dans librairie"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Catalogue de livres électroniques Calibre-Web Automated"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Déconnexion"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 msgid "Settings"
 msgstr "Paramètres"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 msgid "Refresh Library"
 msgstr "Actualiser la bibliothèque"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Aucune information concernant cette version n’est disponible"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Catalogue de livres électroniques Calibre-Web Automated"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr "Voir le Changelog"
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Doubles"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr "Contribuer ici !"
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Veuillez ne pas rafraîchir la page"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 msgid "Create Shelf"
 msgstr "Créer une étagère"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr "Étagères magiques ✨"
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Précédent"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Détails du livre"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Cette action ne peut être défaite !"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Effacer la sélection"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Format"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Supprimer les formats :"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 msgid "Duplicate Books Detected"
 msgstr "Livres en double détectés"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr "Vous avez des livres en double non résolus dans votre bibliothèque"
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 msgid "Duplicate Groups Found"
 msgstr "Groupes en double trouvés"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr "Rappelez-moi plus tard"
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr "Afficher et résoudre les doublons"
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Mise à l’échelle optimale"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "Astuce"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "Configuration"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Ajouter à l'étagère"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Marquer les livres sélectionnés comme lus"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Marqué comme non lu"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Supprimer le livre"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Supprimer le livre"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -11286,92 +11104,92 @@ msgstr ""
 "Cela supprimera définitivement les livres. Les fichiers originaux seront "
 "sauvegardés sur"
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Sélectionner d'abord un livre"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Échec de la restauration : %(err)s"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr "Filtrer par initial"
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "Grille"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 msgid "Show Password"
 msgstr "Afficher le mot de passe"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Se rappeler de moi"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Mot de passe oublié ?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Connectez-vous avec Magic Link"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 msgid "Log in with SSO"
 msgstr "Se connecter avec SSO"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 "La connexion standard est désactivée. Veuillez utiliser l'une des autres "
 "méthodes de connexion."
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Afficher le journal Calibre-Web : "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Calibre-Web Log: "
 msgstr "Journal Calibre-Web : "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Le flux de sortie ne peut pas être affiché"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Afficher le journal d'accès : "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Télécharger les journaux Calibre-Web"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "Télécharger les journaux d’accès"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr "Modèle système"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 "Il s'agit d'une étagère modèle préconfigurée. Vous pouvez la modifier "
 "librement."
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 msgid "Share with Everyone (Public)"
 msgstr "Partager avec tout le monde (public)"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
@@ -11380,51 +11198,51 @@ msgstr ""
 "disposant de l'autorisation « Modifier les étagères publiques » peuvent la "
 "modifier/supprimer."
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Sélectionner les étiquettes autorisées/refusées"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Sélectionner les colonnes personnalisées autorisées/refusées"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Sélectionner les étiquettes d'utilisateur autorisées/refusées"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr ""
 "Sélectionner les colonnes personnalisées d'utilisateur autorisées/refusées"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Saisir une étiquette"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Ajouter une restriction de visualisation"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "Ce format de livre sera définitivement effacé de la base de données"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Le livre va être supprimé définitivement de la base de données"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "et du disque dur"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Note Kobo importante : les livres supprimés vont rester sur l'appareil Kobo "
 "appairé."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11432,285 +11250,285 @@ msgstr ""
 "Les livres doivent d'abord être archivés et l'appareil synchronisé avant "
 "qu'un livre puisse être supprimé en tout sécurité."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Choisir l’emplacement du fichier"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "type"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "nom"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "taille"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "Répertoire parent"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "Ok"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Catalogue de livres électroniques Calibre-Web Automated"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "Lecteur ePub"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "Actions"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "Noir"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "Taille de police"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Page suivante"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr "Police"
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 msgid "Default"
 msgstr "Par défaut"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr "Yahei"
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr "SimSun"
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 msgid "KaiTi"
 msgstr "KaiTi"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 msgid "Arial"
 msgstr "Arial"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 msgid "Spread"
 msgstr "Diffusion"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr "Deux colonnes"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr "Une colonne"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr ""
 "Mettre à jour la mise en page du texte quand les bandeaux latéraux sont "
 "ouverts."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 #, fuzzy
 msgid "Note"
 msgstr "Note :"
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Lecteur de bandes dessinées"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Raccourcis clavier"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Page précédente"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Page suivante"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 msgid "Single Page Display"
 msgstr "Affichage une seule page"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr "Affichage en bord long"
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Mise à l’échelle optimale"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Mise à l’échelle sur la largeur"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Mise à l’échelle sur la hauteur"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Mise à l’échelle d’origine"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Rotation droite"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Rotation gauche"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Inverser l’image"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "Affichage"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 msgid "Single Page"
 msgstr "Page seule"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr "Bord long"
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Échelle"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Optimal"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Largeur"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Hauteur"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Origine"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Rotation"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Inverser"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Horizontal"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Vertical"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 msgid "Direction"
 msgstr "Direction"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "De gauche à droite"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "De droite à gauche"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr "Revenir en haut"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 msgid "Remember Position"
 msgstr "Se souvenir de la position"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "Barre de défilement"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "Montrer"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "Lecteur DJVU"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "Lecteur PDF"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "Lecteur de fichiers txt"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Enregistrer un nouveau compte"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Choisissez un nom d'utilisateur"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Votre adresse mail"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Magic Link - Autoriser un nouvel appareil"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "Utilisez votre autre appareil, connectez-vous et visitez :"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "Une fois fait, vous serez automatiquement connecté à cet appareil."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Le lien expirera après 10 minutes."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
@@ -11719,259 +11537,255 @@ msgstr ""
 "planifiée. Les vignettes sont toujours générées à la demande, quel que soit "
 "ce paramètre."
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "Générer des miniatures de couverture des séries"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Aucun résultat trouvé"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Chercher le terme :"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Résultats pour :"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Date de publication (depuis)"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Date de publication (jusqu’à)"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr "Vide"
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Exclure les étiquettes"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Exclure les séries"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "Étagères exclues"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Exclure les langues"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Extensions"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Exclure les extensions"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Évaluation supérieure à"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Évaluation inférieure à"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "Depuis :"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "Vers :"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Supprimer cette étagère"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "Éditer les propriétés de l’étagère"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Livre caché"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "Organiser les livres manuellement"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "Désactiver l’ordre de modification"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "Activer l’ordre de modification"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Exécuter sur le livre sélectionné"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Meilleurs %(count)s"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Livre introuvable."
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Supprimer cette étagère"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Could not add the books. Please try again."
 msgstr "Échec de la connexion au compte OAuth. Veuillez réessayer."
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Ajouter à l'étagère"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Chercher dans librairie"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Chercher dans librairie"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Partager avec tout le monde"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "Synchronisez cette étagère avec l’appareil Kobo"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Order saved"
 msgstr "Mode de tri"
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Étagère introuvable"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Livre caché"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Statistiques de la librairie Calibre"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Livres dans la bibiothèque"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Auteurs dans la bibliothèque"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Catégories dans la librairie"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Séries dans la librairie"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Statistiques système"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "Programme"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Version installée"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr "Présentation des tâches en arrière-plan"
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Durée"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr "Actions"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr "Prochains envois programmés"
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr "Heure prévue"
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 msgid "State"
 msgstr "État"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
@@ -11980,15 +11794,15 @@ msgstr ""
 "que tâches à l'heure prévue. Vous pouvez annuler un envoi en attente avant "
 "qu'il ne soit exécuté."
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr "Opérations prévues prochainement"
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr "Type"
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
@@ -11997,14 +11811,14 @@ msgstr ""
 "persisteront après les redémarrages. Annulez pour empêcher leur "
 "déclenchement."
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 "Cette tâche sera annulée. Tout progrès réalisé par cette tâche sera "
 "enregistré."
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
@@ -12012,148 +11826,148 @@ msgstr ""
 "S'il s'agit d'une tâche planifiée, elle sera réexécutée à la prochaine heure "
 "prévue."
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 msgid "Scheduled item cancelled successfully"
 msgstr "Élément planifié annulé avec succès"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr "Erreur lors de l'annulation d'un élément planifié"
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Catalogue de livres électroniques Calibre-Web Automated"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Portainer:"
 msgstr "Important :"
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Set up automatic updates"
 msgstr "Activer la recherche automatique des doublons"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "Your Profile"
 msgstr "Votre profil"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "User Settings"
 msgstr "Paramètres de l'utilisateur"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr "Information Compte"
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 "Si vous devez modifier votre adresse e-mail ou votre mot de passe, vous "
 "pouvez le faire ici."
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Réinitialiser le mot de passe de l’utilisateur"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 msgid "eReader Configuration"
 msgstr "Configuration de la liseuse électronique"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 msgid "Send to eReader Email Address"
 msgstr "Envoyer à l'adresse e-mail de l'eReader"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr "Utilisez une virgule pour séparer plusieurs adresses"
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
@@ -12161,11 +11975,11 @@ msgstr ""
 "Adresse(s) e-mail pour vos appareils eReader. Séparez les adresses multiples "
 "par des virgules."
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr "Activer la fenêtre contextuelle Envoyer vers la liseuse"
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
@@ -12176,7 +11990,7 @@ msgstr ""
 "d'envoyer uniquement à une sélection d'adresses enregistrées lors de l'envoi "
 "vers une liseuse."
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
@@ -12184,13 +11998,13 @@ msgstr ""
 "Lorsque cette option est désactivée, les e-mails sont envoyés à toutes les "
 "adresses de liseuses configurées sans confirmation."
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 "Envoyer automatiquement les nouveaux livres vers mon ou mes liseuses "
 "électroniques"
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
@@ -12199,111 +12013,111 @@ msgstr ""
 "automatiquement envoyés à toutes les adresses e-mail des liseuses "
 "configurées ci-dessus."
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr "Préférences linguistiques et thématiques"
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 msgid "Interface Language"
 msgstr "Langue de l'interface"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Langue des Livres"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 "Filtrez la bibliothèque pour n'afficher que les livres dans une langue "
 "spécifique."
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 msgid "Book Language Filter"
 msgstr "Filtre de langue du livre"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr "Intégrations OAuth et API"
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "Réglages OAuth"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Relier"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Dissocier"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr "Jeton API Hardcover"
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr "Jeton API pour l'intégration du fournisseur de métadonnées Hardcover."
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Jeton de synchronisation Kobo"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Créer/visualiser"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "Forcer une synchronisation complète Kobo"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr ""
 "Synchroniser uniquement les livres dans les étagères sélectionnées avec Kobo"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr ""
 "Synchroniser uniquement les livres dans les étagères sélectionnées avec Kobo"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 msgid "Sidebar Display Settings"
 msgstr "Paramètres d'affichage de la barre latérale"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 "Choisissez les sections à afficher dans votre barre de navigation latérale."
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Ajouter les valeurs de colonnes personnalisées autorisées/refusées"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr "Ordre du catalogue OPDS"
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
@@ -12312,7 +12126,7 @@ msgstr ""
 "dans l'ordre souhaité. Les identifiants inconnus sont ignorés et les entrées "
 "manquantes sont ajoutées automatiquement."
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
@@ -12320,75 +12134,75 @@ msgstr ""
 "Faites glisser pour réorganiser les entrées racine OPDS. Les entrées "
 "manquantes sont ajoutées automatiquement."
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr "Autorisations de l'utilisateur"
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr "Configurez les actions que cet utilisateur est autorisé à effectuer."
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Order"
 msgstr "Ordre des étagères magiques"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 "Choisissez comment vos étagères magiques sont classées dans la barre "
 "latérale."
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr "Mode de tri"
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr "Manuel (glisser pour réorganiser)"
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr "Nom (A-Z)"
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr "Nom (Z-A)"
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr "Nombre de livres (décroissant)"
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr "Nombre de livres (croissant)"
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr "Création (plus récent en premier)"
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr "Création (plus ancien en premier)"
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 msgid "Recently modified"
 msgstr "Modifié récemment"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr "Modifié le moins récemment"
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 "L'ordre manuel n'est utilisé que lorsque le mode de tri est défini sur "
 "Manuel."
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr "Visibilité des étagères magiques"
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
@@ -12397,33 +12211,33 @@ msgstr ""
 "Les étagères système ne peuvent pas être supprimées, seulement masquées. Les "
 "étagères publiques d'autres utilisateurs peuvent également être masquées."
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr "Étagères système par défaut :"
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 msgid "Public Shelves:"
 msgstr "Étagères publiques :"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr "%(visible)s sur %(total)s étagères par défaut visibles"
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr "%(visible)s sur %(total)s étagères publiques visibles"
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Supprimer l'utilisateur"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12431,154 +12245,154 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Changer le mot de passe"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Changer le mot de passe"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Créer/visualiser"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Last used"
 msgstr "Dernière modification"
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Générer l'URL d'authentification Kobo"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr "Visible"
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Sélectionner…"
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Supprimer la sélection"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "Éditer l’utilisateur"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "Entrer le nom d'utilisateur"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 msgid "Enter Email"
 msgstr "Entrez l’adresse mail"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "Enter eReader Email"
 msgstr "Envoyer vers une adresse mail eReader"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "eReader Email"
 msgstr "Lecteur électronique E-mail"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 msgid "Enter eReader Email Subject"
 msgstr "Entrez l'objet de l'e-mail eReader"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 msgid "eReader Email Subject"
 msgstr "Objet de l'e-mail eReader"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Lieu"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "Langues de livre visibles"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "Modifier les étiquettes autorisées"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Étiquettes autorisées"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Modifier les étiquettes efusées"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Étiquettes refusées"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "Modifier les valeurs de colonnes autorisées"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "Valeurs de colonnes autorisées"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "Modifier les valeurs de colonnes refusées"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "Valeurs de colonnes refusées"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "Changer le mot de passe"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "Modifier les étagères publiques"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "Synchroniser les étagères sélectionnées avec Kobo"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "Synchroniser les étagères sélectionnées avec Kobo"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 msgid "Show Read/Unread Section"
 msgstr "Afficher la section Lu / Non lu"
 

--- a/cps/translations/gl/LC_MESSAGES/messages.po
+++ b/cps/translations/gl/LC_MESSAGES/messages.po
@@ -17,33 +17,33 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 #, fuzzy
 msgid "Server restarted, please reload page."
 msgstr "Servidor reiniciado. Por favor, recargue a páxina"
 
-#: cps/admin.py:210
+#: cps/admin.py
 #, fuzzy
 msgid "Performing Server shutdown, please close window."
 msgstr "O servidor estase apagando. Por favor, peche a xanela"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr ""
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Orde descoñecida"
 
-#: cps/admin.py:232
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
@@ -51,223 +51,221 @@ msgstr ""
 "Posto en cola un correo electrónico de proba enviado a %(email)s, por favor, "
 "comproba o resultado nas Tarefas"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr ""
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 
-#: cps/admin.py:414
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover ID applied successfully"
 msgstr "{} usuarios borrados con éxito"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr ""
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr ""
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr ""
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr ""
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr ""
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Páxina de administración"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "Axustes OAuth"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Configuración Básica"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Configuración da Interface de Usuario"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 "Columna personalizada No.%(column)d non existe na base de datos calibre"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Editar Usuarios"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Todo"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Usuario non atopado"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} usuarios borrados con éxito"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Mostrar Todo"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Petición mal formada"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "O nome do convidado non se pode cambiar"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "O convidado non pode ter este rol"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr ""
 "Non queda ningún usuario administrador, non se pode eliminar ao usuario"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "O Valor ten que ser verdadeiro ou falso"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Rol non válido"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "O convidado non pode ter esta vista"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "Vista non válida"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr "O sitio do convidado determínase automáticamente e non se pode cambiar"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Non hai unha localización válida"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Non se indicou unha lingua válida para o libro"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Parámetro non atopado"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "A configuración da DB non se pode escribir"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Columna de lectura non válida"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Columna restrinxida non válida"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "De verdade queres borrar o Token de Kobo?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "De verdade desexas borrar este dominio?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "De verdade queres borrar este usuario?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "De verdade queres eliminar este andel?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr "De verdade queres cambiar a linguaxe dos usuarios seleccionados?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "De verdade queres cambiar as linguas visibles do libro dos usuarios "
 "seleccionados?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr "De verdade queres cambiar o rol seleccionado do usuario seleccionado?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
@@ -275,7 +273,7 @@ msgstr ""
 "De verdade queres cambiar as restricións escollidas dos usuarios "
 "seleccionados?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -283,14 +281,14 @@ msgstr ""
 "De verdade queres cambiar as restricións de visibilidade dos usuarios "
 "seleccionados?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "De verdade queres cambiar o comportamento da sincronización do andel para o "
 "usuario seleccionado?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
@@ -298,127 +296,122 @@ msgstr ""
 "De verdade queres cambiar o comportamento da sincronización do andel para o "
 "usuario seleccionado?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "De verdade queres cambiar a localización da biblioteca Calibre?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Denegar"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Permitir"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "Elimináronse {} entradas de sincronización"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Token non atopado"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Etiqueta non atopada"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Acción non válida"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json non está configurado para a aplicación web"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "A localización do arquivo de rexistro non é válida. Por favor, Introduce a "
 "ruta correcta"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "A localización do rexistro de accesos non é válida. Por favor, Introduce a "
 "ruta correcta"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 "Por favor, Introduce un provedor LDAP, porto, DN e o User Object Identifier"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Por favor, introduce unha conta de servizo LDAP e o seu contrasinal"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "Por favor, introduce unha conta de servizo LDAP"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "LDAP Group Object Filter necesita ter un identificador de formato \"%s\""
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "O LDAP Group Object Filter ten parénteses que non casan"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "LDAP Group Object Filter necesita ter un identificador de formato \"%s\""
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "O LDAP Group Object Filter ten parénteses que non casan"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "O filtro de usuarios LDAP necesita ter un identificador de formato \"%s\""
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "O filtro de LDAP \"Member User\" ten parénteses que non casan"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -426,29 +419,24 @@ msgstr ""
 "As localizacións do certificado da CA do LDAP, do certificado ou da chave "
 "non válidos. Por favor introduce a ruta correcta"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Engadir novo usuario"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Cambiar os parámetros do correo"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr ""
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Error na base de datos: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -456,53 +444,53 @@ msgstr ""
 "Posto en cola un correo electrónico de proba enviado a %(email)s, por favor, "
 "comproba o resultado nas Tarefas"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Ocurreu un error enviando o correo electrónico de proba: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Por favor, configure o seu correo electrónico primeiro..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Actualizáronse os axustes do servidor de correo electrónico"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "Editar Usuarios"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Configura primeiro os parámetros do servidor SMTP..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "Por favor, configure o seu correo electrónico primeiro..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "Unha nova contrasinal enviouse ao seu enderezo de correo electrónico"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -510,7 +498,7 @@ msgstr ""
 "Posto en cola un correo electrónico de proba enviado a %(email)s, por favor, "
 "comproba o resultado nas Tarefas"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -519,932 +507,917 @@ msgstr ""
 "Posto en cola un correo electrónico de proba enviado a %(email)s, por favor, "
 "comproba o resultado nas Tarefas"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "Editar a Configuración das Tarefas Programadas"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "Indicada unha hora incorrecta de comezo de tarefa"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "Indicada unha duracción incorrecta para a tarefa"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "Actualizouse a configuración das tarefas programadas"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Sucedeu un erro descoñecido. Por favor volva a intentalo máis tarde."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "Título"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Editar o Usuario %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Reiniciada a contrasinal para o usuario %(user)s"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Configura primeiro os parámetros do servidor SMTP..."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Visor do ficheiro de rexistro"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Solicitando paquete de actualización"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Descargando paquete de actualización"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Descomprimendo paquete de actualización"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Remplazando archivos"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "As conexións coa base datos están pechadas"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Detendo o servidor"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Actualización finalizada. Por favor, prema OK e recargue a páxina"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "A actualización fallou:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "Erro HTTP"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Erro de conexión"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Tempo esgotado mentras se trataba de establecer a conexión"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Erro xeral"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr ""
 "A actualización do arquivo non se puido gardar no directorio temporal (Temp "
 "Dir)"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "Non se puideron substituír os ficheiros durante a actualización"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "Erro ao extraer polo menos un usuario LDAP"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Erro ao crear polo menos un usuario LDAP"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Erro: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Erro: o servidor LDAP non devolveu ningún usuario"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "Polo menos, un usuario LDAP non se atopou na base de datos"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "Usuario {} importado con éxito"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr ""
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "A localización da base de datos non é válida. Por favor, Introduce a ruta "
 "correcta"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "A base de datos non é modificable"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "A localización do Keyfile non é válida, por favor, Introduce a ruta correcta"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "A localización do Certfile non é válida, por favor, Introduce a ruta correcta"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr ""
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "Actualizados os axustes da base de datos"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "Configuración da base de datos"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Por favor, cubra todos os campos!"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "O correo electrónico non ven dun dominio válido"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Engadir un usuario novo"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Usuario '%(user)s' creado"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr ""
 "Atopada unha conta existente para este correo electrónico ou nome de usuario."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Usuario '%(nick)s' eliminado"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "Non se pode borrar ao Usuario Invitado"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "Non queda ningún usuario administrador, non se pode borrar ao usuario"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr ""
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Usuario '%(nick)s' actualizado"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr ""
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr ""
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Erro de conexión"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr ""
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "Non hai información do lanzamento dispoñible"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr ""
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr ""
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr ""
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "Sucedeu un erro descoñecido. Por favor volva a intentalo máis tarde."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "Erro de conexión"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Erro de conexión"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "O ficheiro %(file)s subiuse"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr ""
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr ""
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr ""
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr ""
 
-#: cps/constants.py:265
+#: cps/constants.py
 #, fuzzy
 msgid "Finnish"
 msgstr "Rematado"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr ""
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr ""
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr ""
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr ""
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr ""
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr ""
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr ""
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr ""
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr ""
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr ""
 
-#: cps/constants.py:276
+#: cps/constants.py
 #, fuzzy
 msgid "Polish"
 msgstr "Editor"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr ""
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr ""
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr ""
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr ""
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr ""
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr ""
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr ""
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr ""
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr ""
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr ""
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "non instalado"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Faltan permisos de execución"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, fuzzy, python-format
 msgid "Change cover — %(title)s"
 msgstr "Intercambiar autor e título"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Erro de conexión"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr ""
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Book ID"
 msgstr "Libros"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Título do libro"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "Autor"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr ""
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "Formatos de arquivo"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filename"
 msgstr "nome"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr ""
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr ""
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "Cargar formato"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "Descoñecido"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr ""
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "Rol non válido"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "Unir libros seleccionados"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "O formato %(format)s non se atopou no disco"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB Fixer started for selected book."
 msgstr "Unir libros seleccionados"
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr ""
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr ""
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid image data format."
 msgstr "Enderezo de correo non válido"
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Profile picture updated successfully."
 msgstr "{} usuarios borrados con éxito"
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Ningún"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "Borrar libro"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "Borrar libro"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "Borrar libro"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "Non se atoparon resultados"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 #, fuzzy
 msgid "Invalid resolution strategy"
 msgstr "Rol non válido"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Carga feita, procesando, por favor agarde..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 #, fuzzy
 msgid "Failed to queue upload for processing"
 msgstr "Erro ao crear unha ruta para a cuberta"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Falta a fonte ou o formato de destino para a conversión"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "Libro posto na cola para a súa conversión a %(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Houbo un erro ao convertir este libro: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 #, fuzzy
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "Non se permite subir arquivos coa extensión '%(ext)s' a este servidor"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr "Non se permite subir arquivos coa extensión '%(ext)s' a este servidor"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "O arquivo que se vai cargar debe ter unha extensión"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 "oh, oh, o libro seleccionado non está disponible. O arquivo non existe ou "
 "non está accesible"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "O usuario non ten permisos para subir a cuberta"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 "Os identificadores non distinguen entre maiúsculas e minúsculas, "
 "sobrescribindo o identificador antigo"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "%(langname)s non é unha lingua válida"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Metadatos actualizados con éxito"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "Erro editando libro: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Descoñecido"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1452,97 +1425,97 @@ msgstr ""
 "O libro cargado probablemente existe na biblioteca, considera cambialo antes "
 "de subilo outra vez: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 "El archivo %(filename)s non puido gravarse no directorio temporal (Temp Dir)"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Fallo ao mover o arquivo de cuberta %(file)s: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Formato de libro eliminado con éxito"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Libro eliminado con éxito"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "Vostede non ten permisos para borrar libros"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "editar metadatos"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "%(seriesindex)s non é un número válido, saltando"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr "O usuario non ten permisos para cargar formatos de ficheiro adicionais"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Fallo ao crear a ruta %(path)s (permiso denegado)"
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Fallo ao gardar o arquivo %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Arquivo con formato %(ext)s engadido a %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Token non atopado"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "O formato %(format)s non se atopou no disco"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1550,7 +1523,7 @@ msgstr ""
 "A configuración de Google Drive non se completou, intente desactivar e "
 "activar Google Drive outra vez"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1558,89 +1531,88 @@ msgstr ""
 "O dominio Callback non se comprobou, siga os pasos para comprobalo na "
 "consola de desenvolvedor de Google"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "%(format)s formato non atopado para o id do libro: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(format)s non atopado en Google Drive: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s non atopado: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "Enviar ao Kindle"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "%(format)s formato non atopado para o id do libro: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "%(format)s formato non atopado para o id do libro: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 #, fuzzy
 msgid "Test Email"
 msgstr "Comprobar correo electrónico"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Correo electrónico de rexistro para o usuario: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Convertir %(orig)s a %(format)s e enviar ao Kindle"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Enviado %(format)s ao Kindle"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "%(book)s send to eReader"
 msgstr "Enviar ao Kindle %(book)s"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr ""
 "O arquivo solicitado non pode lerse. Quizais existen problemas cos permisos?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "O estado de lectura non pode fixarse: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
@@ -1648,83 +1620,83 @@ msgstr ""
 "Fallo ao intentar borrar a carpeta do libro %(id)s, a ruta ten subcarpetas: "
 "%(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "O borrado do libro %(id)s fallou: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
 "%(path)s"
 msgstr "Borrando o libro %(id)s, a ruta de libro non é válida: %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "O renomeado do título de: '%(src)s' a '%(dest)s' fallou co erro: %(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Ficheiro %(file)s non atopado en Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "O renomeado do título de: '%(src)s' a '%(dest)s' fallou co erro: %(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "A ruta %(path)s do libro non se atopou en Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr ""
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Este nome de usuario xa está en uso"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 #, fuzzy
 msgid "Invalid Email address format"
 msgstr "Enderezo de correo non válido"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr ""
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 "O módulo Python 'advocate' non está instalado pero se necesita para as "
 "cargas de cubertas"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Erro ao descargar a cuberta"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr "O arquivo de cuberta non é unha imaxe válida"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Erro no formato da cuberta"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
@@ -1732,126 +1704,126 @@ msgstr ""
 "Non ten permiso para acceder a localhost ou á rede local para as cargas de "
 "cubertas"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Erro ao crear unha ruta para a cuberta"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "Soamente se admiten como cuberta os arquivos jpg/jpeg/png/webp/bmp"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "Contido do arquivo de cuberta non válido"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Soamente se admiten como cuberta os arquivos jpg/jpeg"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr ""
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "Non se atopa o arquivo binario de UnRar"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr "Erro executando UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr ""
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr ""
 
-#: cps/helper.py:2125
+#: cps/helper.py
 #, fuzzy
 msgid "Calibre binaries not viable"
 msgstr "A base de datos non é modificable"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Faltan permisos de execución"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing Calibre"
 msgstr "Erro executando UnRar"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr ""
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Configuración de Kobo"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Rexistrado con %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
@@ -1860,7 +1832,7 @@ msgstr ""
 "O servidor de correo non está configurado, por favor, avisa ao teu "
 "administrador!"
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1868,35 +1840,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "Iniciou sesión como : '%(nickname)s'"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "O enlace a %(oauth)s realizouse con éxito"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1904,4149 +1876,4081 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr ""
 "O servidor de correo non está configurado, por favor, avisa ao teu "
 "administrador!"
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "%(oauth)s desenlazado con éxito"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Erro ao desenlazar %(oauth)s"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "Non vinculado con %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Erro ao iniciar sesión con GitHub."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Erro ao obter a información do usuario de GitHub."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Erro ao iniciar sesión con Google."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Erro ao obter información do usuario de Google."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "Failed to log in with Generic OAuth."
 msgstr "Erro ao iniciar sesión con GitHub."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "Erro en GitHub Oauth, por favor, volva a intentalo máis tarde."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "Erro GitHub Oauth {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Erro en Google Oauth, por favor volva a intentalo máis tarde."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Erro Google Oauth {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, fuzzy, python-brace-format
 msgid "OAuth error: {}"
 msgstr "Erro GitHub Oauth {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "Libros alfabéticos"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "Libros ordeados alfabéticamente"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Libros populares"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "Publicacións populares do catálogo baseadas nas descargas."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Libros mellor valorados"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Publicacións populares do catálogo baseadas na valoración."
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "Libros descargados"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Últimos libros"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Libros ao chou"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Mostrar libros ao chou"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Libros lidos"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Versión actual"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Libros non lidos"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Autores"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Libros ordeados por autor"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Editores"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Libros ordeados por editor"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Categorías"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Libros ordeados por categorías"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Series"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Libros ordeados por series"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Linguas"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Libros ordeados por lingua"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Valoracións"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Libros ordeados por valoración"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Formatos de arquivo"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Libros ordeados por formato de arquivo"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Andeis"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "Libros organizados en andeis"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "sincronizar andeis seleccionados con Kobo"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Libros organizados en andeis"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "Descrición"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} Estrelas"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Buscar"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Inicio de sesión"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Token non atopado"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "O token expirou"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Correcto! Por favor volte ao seu dispositivo"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Libros"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Mostrar libros recentes"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Mostrar libros populares"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Libros descargados"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Mostrar libros descargados"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Mostrar libros mellor valorados"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Read and Unread"
 msgstr "Mostrar lidos e non lidos"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Mostrar non lidos"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Descubrir"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Category Section"
 msgstr "Mostrar selección de categorías"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Series Section"
 msgstr "Mostrar selección de series"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Author Section"
 msgstr "Mostrar selección de autores"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Publisher Section"
 msgstr "Mostrar selección de editores"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Language Section"
 msgstr "Mostrar selección de linguas"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Ratings Section"
 msgstr "Mostrar selección de valoracións"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show File Formats Section"
 msgstr "Mostrar selección de formatos de arquivo"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Libros arquivados"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Archived Books"
 msgstr "Mostrar libros arquivados"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Lista de libros"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Mostrar lista de libros"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr ""
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Mostrar libros mellor valorados"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Publicado despóis de "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Publicado antes de "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Valoración <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Valoración >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, fuzzy, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Estado de lectura = %(status)s"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 "Erro na busca de columnas personalizadas, por favor reinicia Calibre-Web"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Búsqueda avanzada"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Andel especificado non válido"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr ""
 "Sentímolo, non ten permisos para engdir un libro ao andel: %(shelfname)s"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "O libro xa forma parte do andel: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "O libro engadiuse ao andel: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "Non ten permiso para engadir un libro ao andel"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Os libros xa forman parte do andel: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "Os libros engadíronse ao andel: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Non se pudideron engadir libros ao andel: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "Andel especificado non válido"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Non se pudideron engadir libros ao andel: %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Os libros xa forman parte do andel: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "Os libros engadíronse ao andel: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "O libro eliminouse do andel: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "Síntoo, non ten permiso para quitar un libro do andel"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Crear un andel"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Síntoo, non ten permiso para editar o andel: %(sname)s"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Editar un andel"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "Erro borrando o estante"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "Andel eliminado con éxito"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Cambiar a orde do andel: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "Síntoo, non ten permiso para crear un andel público"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Andel %(title)s creado"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Andel %(title)s cambiado"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Ocorreu un erro"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "Xa existe un andel público co nome '%(title)s'."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "Xa existe un andel privado co nome '%(title)s'."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Andel: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Erro ao abrir un andel. O andel non existe ou non se pode acceder"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Excluir andeis"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Anónimo"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Non autenticado"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Sí"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Non"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Leer estado"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Tema"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Claro"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Oscuro"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "Sepia"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Engadir ao andel"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Autor"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Navegar"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Pechar"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Borrar"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Unir"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Editor"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Lido"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Título"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Subir arquivo"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Conta"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Administrador"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Publicado"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Orixe"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "Acerca de"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Arquivado"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "Convertir"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Descrición"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Descargar"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Editar"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "Enderezo de correo electrónico"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Activar a sincronización con Kobo"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Cifraxe"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "Agochar"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Identificadores"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Lingua"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Contrasinal"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Porto"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Progreso"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Valoración"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Gardar"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "Seleccionar"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Estado"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Tarefa"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Tarefas"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Usuario"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Nome de usuario"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Vista"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Esperando"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Fallou"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Comezado"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Rematado"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "Rematado"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Estado descoñecido"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Dato inesperado mentres líase a información de actualización"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr "Actualización non dispoñiible. Xa tes instalada a versión máis recente"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6054,15 +5958,15 @@ msgstr ""
 "Unha nova actualización está dispoñible. Preme no botón inferior para "
 "actualizar á versión máis reciente."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Non se pode conseguir información sobre a actualización"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr "Preme no botón de abaixo para actualizar á última versión estable."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6071,272 +5975,270 @@ msgstr ""
 "Hai unha nova actualización dispoñible. Preme no botón de abaixo para "
 "actualizar á versión: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Non hai información do lanzamento dispoñible"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Descubrir (Libros ao chou)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Libros populares (os máis descargados)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "Libros descargados por %(user)s"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Autor/es: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Editor/es: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Series: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "Valoración: Ningunha"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Valoración: %(rating)s estrelas"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Formato do arquivo: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Categoría: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Lingua: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Libros populares"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Libro agochado"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "Erro borrando o estante"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "Enderezo de correo non válido"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 #, fuzzy
 msgid "Invalid request"
 msgstr "Rol non válido"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr ""
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 #, fuzzy
 msgid "Error creating shelf"
 msgstr "Erro borrando o estante"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Crear un andel"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 #, fuzzy
 msgid "Shelf name is required"
 msgstr "Este campo é necesario"
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "Erro borrando o estante"
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "Editar un andel"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "Usuario non atopado"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "{} usuarios borrados con éxito"
 
-#: cps/web.py:1710
+#: cps/web.py
 #, fuzzy
 msgid "Error duplicating shelf"
 msgstr "Erro borrando o estante"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 #, fuzzy
 msgid "Error deleting shelf"
 msgstr "Erro borrando o estante"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "Erro borrando o estante"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 #, fuzzy
 msgid "Error unhiding shelf"
 msgstr "Erro borrando o estante"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Descargas"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Lista de formatos"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 #, fuzzy
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Configura primeiro os parámetros do servidor SMTP..."
 
-#: cps/web.py:2400
+#: cps/web.py
 #, fuzzy
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 "Por favor actualiza o teu perfil co enderezo de correo do teu kindle..."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "Libro posto na cola de envío a %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Oh, oh! Houbo un erro no envío do libro: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "Libro posto na cola de envío a %(eReadermail)s"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Rexistro"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 #, fuzzy
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr ""
 "O servidor de correo non está configurado, por favor, avisa ao teu "
 "administrador!"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr ""
 "O servidor de correo non está configurado, por favor, avisa ao teu "
 "administrador!"
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "O seu correo electrónico non está permitido para rexistrarse"
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "Mandouse un correo electrónico de verificación á súa conta de correo."
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
@@ -6345,7 +6247,7 @@ msgstr ""
 "A instancia de Calibre-Web non está configurada, por favor contacta co teu "
 "administrador"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
@@ -6354,36 +6256,36 @@ msgstr ""
 "O servidor de correo non está configurado, por favor, avisa ao teu "
 "administrador!"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 #, fuzzy
 msgid "Cannot activate LDAP authentication"
 msgstr "Non se pode activar a autenticación LDAP"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr ""
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, fuzzy, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "Iniciou sesión como : '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "Iniciou sesión como : '%(nickname)s'"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
@@ -6392,13 +6294,13 @@ msgstr ""
 "A instancia de Calibre-Web non está configurada, por favor contacta co teu "
 "administrador"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6407,713 +6309,683 @@ msgstr ""
 "Fallback login como: '%(nickname)s', non se pode acceder ao servidor LDAP ou "
 "usuario descoñecido"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, fuzzy, python-format
 msgid "Could not login: %(message)s"
 msgstr "Non se puido entrar: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 #, fuzzy
 msgid "Wrong Username or Password"
 msgstr "Usuario ou contrasinal no válido"
 
-#: cps/web.py:2832
+#: cps/web.py
 #, fuzzy
 msgid "New Password was sent to your email address"
 msgstr "Unha nova contrasinal enviouse ao seu enderezo de correo electrónico"
 
-#: cps/web.py:2836
+#: cps/web.py
 #, fuzzy
 msgid "An unknown error occurred. Please try again later."
 msgstr "Sucedeu un erro descoñecido. Por favor volva a intentalo máis tarde."
 
-#: cps/web.py:2838
+#: cps/web.py
 #, fuzzy
 msgid "Please enter valid username to reset password"
 msgstr "Por favor, introduce un usuario válido para restablecer a contrasinal"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, fuzzy, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "Iniciou sesión como : '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 #, fuzzy
 msgid "Success! Profile Updated"
 msgstr "Perfil actualizado"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "Atopada unha conta existente para ese enderezo de correo electrónico"
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 #, fuzzy
 msgid "Invalid book ID."
 msgstr "Rol non válido"
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr ""
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "Non se atopou ningún arquivo gmail.json válido con información OAuth"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "Enviar ao Kindle %(book)s"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "Enviar ao Kindle"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-send completed successfully"
 msgstr "{} usuarios borrados con éxito"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr ""
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr ""
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "Enviar ao Kindle %(book)s"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Non se atopou Calibre ebook-convert %(tool)s"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "O formato %(format)s non se atopou no disco"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "O conversor de Ebook fallou cun erro descoñecido"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Kepubify-converter fallou: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "Arquivo convertido non atopado, ou máis dun arquivo no directorio %(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre fallou co erro: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Fallou Ebook-converter: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Reconectando a base de datos de Calibre"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "Borrar libro"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Borrar libro"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Descomprimendo paquete de actualización"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Non se atoparon resultados"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Activar a sincronización con Kobo"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "Correo electrónico"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 #, fuzzy
 msgid "Backing up Metadata"
 msgstr "editar metadatos"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "Na Librería"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "Xeradas %(count)s miniaturas de cubertas"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "Miniaturas de cubertas"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "Xeradas {0} miniaturas de series"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "Limpando caché de miniaturas de cubertas"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "Libros organizados en andeis"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Cambiar a contrasinal"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Crear un andel"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "Axustes OAuth"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Axustes"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "seleccionar unha opción"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "Engadir ao andel"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Público)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "Descargas"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Descargas"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "Ordear pola data do libro, máis recente primeiro"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "Ordear pola data do libro, máis antigo primeiro"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Autor"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Autor"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Publicado antes de "
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Publicado antes de "
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Ordear pola data do libro, máis recente primeiro"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "Ordear pola data do libro, máis antigo primeiro"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "Enviar ao enderezo de correo electrónico do Kindle"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "Enviar ao Kindle"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Ver libros"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Andel público"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr ""
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "Importar usuarios LDAP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Axustes do servidor de correo electrónico"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "Servidor SMTP"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "Porto SMTP"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "Login SMTP"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Dende o correo electrónico"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Service"
 msgstr "Servizo de correo electrónico"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail por Oauth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Directorio da base de datos de Calibre"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Nivel de rexistro"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Porto externo"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Libros por páxina"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Cargas"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Navegación anónima"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Rexistro público"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Acceso remoto mediante enlace máxico"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Acceso mediante Proxy inverso"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Nome de cabeceira do Proxy inverso"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Editar a configuración básica"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Editar a configuración da interfaz de usuario"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Editar a configuración da base de datos de Calibre"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "Tarefas programadas"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "Hora de comezo das tarefas"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "Duración máxima das tarefas"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "Xerar as miniaturas das cubertas das series"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Reconectar á librería de Calibre"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr ""
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "Refrescar a caché de miniaturas das cubertas"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Setup KOReader Sync"
 msgstr "Lector epub"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr ""
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Administración"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Descargar o paquete de depuración"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Ver arquivos de rexistro"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Reiniciar"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Apagar"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "Información de versión"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Versión"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Detalles"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "A actualización fallou:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Canle de actualización"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Versión actual"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Comprobar actualizacións"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Realizar actualización"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "De verdade queres reiniciar?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "Vale"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "De verdade quere deter?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Actualizando. Por favor, non recargue a páxina"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7121,454 +6993,431 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Libros nesta biblioteca"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Cargando..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "A actualización fallou:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Erro de conexión"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Series: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "via"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "Na Librería"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "reducir"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Máis de"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Borrar libro"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Borrar formatos:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Convertir formato de libro:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Convertir dende:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "select an option"
 msgstr "seleccionar unha opción"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Convertir a:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Convertir libro"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Erro"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Cargar formato"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "ID de serie"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Data de publicación"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Tipo de identificador"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Valor de identificador"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Borrar"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Engadir identificador"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Obter portada de URL (JPEG, a portada descargarase e almacenarase na base de "
 "datos)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Cargar portada dende un disco local"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "Activar a sincronización con Kobo"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Ver libro ao gardar"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Obter metadatos"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Palabra chave"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "Buscar por palabras chave "
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Cargando..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Erro na busca!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "Non se atoparon resultados! Por favor intenta con outra palabra chave."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "Este campo é necesario"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 #, fuzzy
 msgid " Exchange author & title"
 msgstr "Intercambiar autor e título"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "Crear un andel"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr ""
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Update Title Sort automatically  "
 msgstr "Actualizar orde do título automáticamente"
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Actualizar orde do autor automáticamente"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Introduce título"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Introduce a orde do título"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Orde do título"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Introduce orde do autor"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Orde do autor"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Introduce os autores"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Introduce as categorías"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Introduce as series"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Introduce as linguas"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Data de publicación"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Introduce os Editores"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Introducir os comentarios"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Comments"
 msgstr "Comentarios"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Archived?"
 msgstr "Arquivado"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Read?"
 msgstr "Lido"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "Introduce "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "De verdade estás seguro?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "Libros co título uniranse de:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "No libro co título:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr ""
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr ""
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr ""
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr ""
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr ""
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Editar metadatos"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "Crear un andel"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr ""
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Engadir"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
@@ -7576,164 +7425,164 @@ msgstr ""
 "O servidor de correo non está configurado, por favor, avisa ao teu "
 "administrador!"
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 #, fuzzy
 msgid "Message"
 msgstr "Unir"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Unha nova contrasinal enviouse ao seu enderezo de correo electrónico"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Enviar ao Kindle"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Voltar"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Localización da base de datos Calibre"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7749,13 +7598,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7766,7 +7615,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7777,43 +7626,43 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr ""
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
 "can be wherever you desire"
 msgstr ""
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Usar Google Drive?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Autenticar Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Carpeta de Google Drive para Calibre"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "Metadata Watch Channel ID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Revogar"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Reconectar á librería de Calibre"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7823,140 +7672,140 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "De verdade quere deter?"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Reconectar á librería de Calibre"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr ""
 "A localización da base de datos non é válida. Por favor, Introduce a ruta "
 "correcta"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Usar autenticación estándar"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Usar autenticación LDAP"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Usar OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Configuración do servidor"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Porto do servidor"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Localización do arquivo de certificado SSL (deixar en branco se non hai un "
 "servidor SSL)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Localización do arquivo clave SSL (dejar en blanco si no hay un servidor SSL)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Canle de actualización"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Estable"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Nocturno"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "Anfitrións de confianza (Separados por comas)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Configuración do arquivo de rexistro"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr ""
 "Localización e nombre do archivo de rexistro de acceso (access.log non ten "
 "ningunha entrada)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Habilitar rexistro de acceso"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr ""
 "Localización e nombre do archivo de rexistro de acceso (access.log non ten "
 "ningunha entrada)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "Configuración do servidor"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 "Convertir caracteres non ingleses no título e no autor mentres se graba no "
 "disco"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Permitir cargas"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr "(Por favor asegúrese que os usuarios teñen permisos de carga)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Formatos de arquivo permitidos para carga"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Permitir navegación anónima"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Permitir rexistro público"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "Utilizar correo electrónico como nome de usuario"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Permitir inicio de sesión remoto (\"magic link\")"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7964,154 +7813,154 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Peticións proxy á tenda Kobo descoñecidas"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Porto externo do servidor (para peticións API)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Usar Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Goodreads API Key"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Hardcover Sync"
 msgstr "Activar a sincronización con Kobo"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "O token expirou"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Goodreads API Key"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8119,422 +7968,422 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Permitir Autenticación Proxy Inversa"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Tipo de inicio de sesión"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "Nome de anfitrión ou enderezo IP do servidor LDAP"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "Porto do servidor LDAP"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "Cifrado LDAP"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Ruta LDAP CACertificate (So necesaria para certificado de autenticación de "
 "cliente)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Ruta LDAP Certificate (So necesaria para certificado de autenticación de "
 "cliente)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Ruta LDAP Keyfile (So necesaria para certificado de autenticación de cliente)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "Autenticación LDAP"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Simple"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "Nome de usuario de administrador LDAP"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "Contrasinal de administrador LDAP"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "Nome distinguido LDAP (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "Filtro de obxectos de usuario LDAP"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "O servidor LDAP é OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr ""
 "As seguintes configuracións son necesarias para a importación de usuarios"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "Filtro de obxectos de grupo LDAP"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "Nome de grupo LDAP"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "Campo de membros de grupo LDAP"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "Filtro de detección LDAP Member User"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "Auto detectar"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "Filtro personalizado"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "Filtro LDAP Member User"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "Obter metadatos"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
 msgstr ""
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "Editar a configuración da interfaz de usuario"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "Token non atopado"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "Erro de conexión"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "Axustes OAuth"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Id"
 msgstr "Id de cliente de OAuth de %(provider)s"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Secret"
 msgstr "Secreto OAuth de Cliente de %(provider)s"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "Ver configuración"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "Nome de usuario"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr ""
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "Servizo de correo electrónico"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr ""
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "Nome de grupo LDAP"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr ""
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Axustes por defecto para novos usuarios"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Permitir descargas"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Permitir visor de libros"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Permitir cargas de arquivos"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Permitir editar"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Permitir borrar libros"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Permitir cambiar a contrasinal"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Permitir editar andeis públicos"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr ""
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Obter a Credencial OAuth de %(provider)s"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "Id de cliente de OAuth de %(provider)s"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "Secreto OAuth de Cliente de %(provider)s"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Binarios externos"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Path to Calibre Binaries"
 msgstr "Ruta para Calibre E-Book Converter"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Calibre E-Book Converter Settings"
 msgstr "Axustes de Calibre E-Book Converter"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Ruta para Kepubify E-Book Converter"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "Localización do binario de UnRar"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Security Settings"
 msgstr "Axustes OAuth"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8542,341 +8391,336 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr ""
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr ""
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr ""
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Session protection"
 msgstr "seleccionar unha opción"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr ""
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr ""
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "User Password policy"
 msgstr "Restablecer contrasinal de usuario"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr ""
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr ""
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Ver configuración"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Número de libros aleatorios a mostrar"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr ""
 "Número de autores para mostrar antes de agochar (0 = desactivar o "
 "agochamento)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "Borrar"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "caliBlur! Tema Escuro"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Expresión regular para ignorar columnas"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Enlazar á columna de Calibre de lido/sen ler"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "Enlazar á columna de Calibre de lido/sen ler"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Ver restricións baseadas na columna de Calibre"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Expresión regular para ordear títulos"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Ver configuración"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Custom CSS"
 msgstr "Filtro personalizado"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Axustes por defecto para novos usuarios"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "Versión"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Usuario administrador"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "Páxina de administración"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "Lingua predeterminada"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "Axustes por defecto para novos usuarios"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "Lingua visible predeterminada dos libros"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "Visibilidade predeterminada para novos usuarios"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Visibilidade predeterminada para novos usuarios"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Mostrar libros aleatorios na vista detallada"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Engadir etiquetas Permitidas/denegados"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Engadir valores personalizados Permitidos/denegados"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Subir arquivo"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "Arquivado"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "Descargar"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Comezar"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8885,14 +8729,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8900,96 +8744,95 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "Unir libros seleccionados"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "{} usuarios borrados con éxito"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "Erro borrando o estante"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "Non se atoparon resultados"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "Introduce o nome do usuario"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "Buscar na librería"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "Crear un andel"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "Unir libros seleccionados"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "Erro borrando o estante"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Rexistro de Calibre-Web: "
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8997,11 +8840,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -9012,11 +8855,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -9026,162 +8869,162 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "Libros arquivados"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9189,11 +9032,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9201,110 +9044,108 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "Metadatos actualizados con éxito"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identificadores"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "Descubrir"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
 "investigation."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9312,157 +9153,157 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Axustes OAuth"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "Axustes"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "Axustes OAuth"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9470,103 +9311,102 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "sincronizar andeis seleccionados con Kobo"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Axustes OAuth"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9574,44 +9414,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Convertir formato de libro:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9619,874 +9459,862 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Permitir rexistro público"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Axustes OAuth"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Permitir rexistro público"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Permitir rexistro público"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Borrar formatos:"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Obter metadatos"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Valoración"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Seguinte"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Marcar como non lido"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Marcar como lido"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "Marcar como non lido"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "Marcar como non lido"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Engadir a arquivo"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Restaurar dende o arquivo"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Restaurar dende o arquivo"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Engadir a arquivo"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "Restaurar dende o arquivo"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "Buscar na librería"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "Actualizados os axustes da base de datos"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "Valoración superior a"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "Libro %(index)s de %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr ""
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Descrición:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "Enviar ao enderezo de correo electrónico do Kindle"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "Enviar ao enderezo de correo electrónico do Kindle"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "Crear un andel"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "Borrar formatos:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "Erro ao crear unha ruta para a cuberta"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "Erro ao crear unha ruta para a cuberta"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr ""
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Borrar libro"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "Mostrar libros mellor valorados"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "Seleccionar"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "Unir libros seleccionados"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Borrar libro"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "Previo"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "Unir libros seleccionados"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "Detalles do libro"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "editar metadatos"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "Unir libros seleccionados"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "Non se atoparon resultados"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr ""
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Borrar formatos:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be permanently deleted:"
 msgstr "O libro borrarase permanentemente da base de datos"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "Libros non lidos"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "O libro borrarase permanentemente da base de datos"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "O libro borrarase permanentemente da base de datos"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr ""
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr ""
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr ""
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "Escolle tipo de servidor"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Standard Email Account"
 msgstr "Usar conta de correo electrónico estándar"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Gmail Account"
 msgstr "Escolle tipo de servidor"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Setup Gmail Account"
 msgstr "Escolle tipo de servidor"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Revogar acceso a Gmail"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "Contrasinal SMTP"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Tamaño límite do arquivo achegado"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Save and Send Test Email"
 msgstr "Gardar e enviar un correo electrónico de proba"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Dominios permitidos para rexistrarse"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Engadir dominio"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Introducir nome de dominio"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Dominios prohibidos (Blaclist)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10494,162 +10322,153 @@ msgstr ""
 "Abre o arquivo .kobo/Kobo/Kobo eReader.conf nun editor de texto e engade (ou "
 "edita):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Token de sincronización de Kobo"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "Lista"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "Crear un andel"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "Termo de busca:"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "Ver libro ao gardar"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "Crear un andel"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "Cargando..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
 msgstr "De verdade queres cambiar o rol seleccionado do usuario seleccionado?"
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "Erro ao crear unha ruta para a cuberta"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr "De verdade queres cambiar o rol seleccionado do usuario seleccionado?"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "Crear un andel"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "Erro ao crear unha ruta para a cuberta"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
@@ -10658,420 +10477,419 @@ msgstr ""
 "A instancia de Calibre-Web non está configurada, por favor contacta co teu "
 "administrador"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Crear una incidencia"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Voltar ao inicio"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "Pechar sesión"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "Editar un andel"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show this shelf in your sidebar"
 msgstr "Sincronizar este andel cun dispositivo Kobo"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "Mostrar Todo"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "Andel público"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Engadir ao andel"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Inicio"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Alternar navegación"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Buscar na librería"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Catálogo de libros electrónicos de Calibre-Web"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Pechar sesión"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "Axustes"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "Buscar na librería"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Non hai información do lanzamento dispoñible"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Catálogo de libros electrónicos de Calibre-Web"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Borrar libro"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Por favor, non actualice a páxina"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Crear un andel"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Previo"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Detalles do libro"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "De verdade quere deter?"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Unir libros seleccionados"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Cargar formato"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Borrar formatos:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Borrar libro"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Non se atoparon resultados"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Escalar ao mellor"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "Para:"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "Configuración"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Engadir ao andel"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Unir libros seleccionados"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Marcar como non lido"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Borrar libro"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Borrar libro"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Crear un andel"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Erro de conexión"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr ""
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "Reixa"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "Contrasinal SMTP"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Lembrarme"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Esqueceu a contrasinal?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Iniciar sesión cun enlace máxico"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 #, fuzzy
 msgid "Log in with SSO"
 msgstr "Iniciar sesión cun enlace máxico"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Mostrar o rexistro de Calibre-Web: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Calibre-Web Log: "
 msgstr "Mostrar o rexistro de Calibre-Web: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "A saída do fluxo non se pode mostrar"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Mostrar rexistro de acceso:"
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Descargar o rexistro de Calibre-Web"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "Descargar o rexistro de acceso"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "Compartir con todos"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Seleccionar etiquetas Permitidas/Negadas"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Seleccionar valores propios de columnas Permitidas/Denegadas"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Seleccionar etiquetas de usuario Permitido/Denegado"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr "Seleccionar columnas personalizadas de usuario Permitido/Denegado"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Introduce a etiqueta"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Engadir restricción de vista"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "Este formato de libro borrarase permanentemente da base de datos"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "O libro borrarase permanentemente da base de datos"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "e do disco duro"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Nota de Kobo importante: os libros eliminados permanecerán nos dispositivos "
 "Kobo emparellados."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11079,579 +10897,575 @@ msgstr ""
 "Antes de que un libro poida eliminarse con seguridade debe arquivarse e "
 "sincronizarse co dispositivo."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Escolla a localización do arquivo"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "tipo"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "nome"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "tamaño"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "Directorio pai"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "Vale"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Catálogo de libros electrónicos de Calibre-Web"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "Lector epub"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "Accións"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "Negro"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr ""
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Páxina seguinte"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr ""
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 #, fuzzy
 msgid "Default"
 msgstr "Borrar"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr ""
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr ""
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 #, fuzzy
 msgid "KaiTi"
 msgstr "Esperando"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 #, fuzzy
 msgid "Arial"
 msgstr "Vertical"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 #, fuzzy
 msgid "Spread"
 msgstr "Lido"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 #, fuzzy
 msgid "Two columns"
 msgstr "Columna de lectura non válida"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 #, fuzzy
 msgid "One column"
 msgstr "Columna de lectura non válida"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Refluxo do texto cando as barras laterais están abertas."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Lector de Cómics"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Atallos de teclado"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Páxina anterior"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Páxina seguinte"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page Display"
 msgstr "Páxina de administración"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Escalar ao mellor"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Escalar ao ancho"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Escalar ao alto"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Escalado nativo"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Xirar cara a dereita"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Xirar cara a esquerda"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Voltear a imaxe"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page"
 msgstr "Páxina de administración"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr ""
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Escalar"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Mellor"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Ancho"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Alto"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Nativo"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Rotar"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Voltear"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Horizontal"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Vertical"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Direction"
 msgstr "Descrición"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "De esquerda a dereita"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "De dereita a esquerda"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Reset to Top"
 msgstr "Voltar ao inicio"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Remember Position"
 msgstr "Lembrarme"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "Barra de desprazamento"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "Mostrar"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "Lector DJVU"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "Lector PDF"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "Lector txt"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Rexistre unha conta nova"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Escolla un nome de usuario"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "O teu enderezo de correo"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Enlace Máxico - Autorizar un novo dispositivo"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "Utiliza otro dispositivo, inicia sesión e visita:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr ""
 "Unha vez verificado, iniciará sesión automáticamente neste dispositivo."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "O enlace de verificación caducará despois de 10 minutos."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "Xerar miniaturas de cubertas de series"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Non se atoparon resultados"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Termo de busca:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Resultados para:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Data de publicación dende"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Data de publicación ata"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr ""
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Excluir etiquetas"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Excluir series"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "Excluir andeis"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Excluir linguas"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Extensións"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Excluir extensións"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Valoración superior a"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Valoración inferior a"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "De:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "Para:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Borrar este andel"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "Editar propiedades do andel"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Libro agochado"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "Ordear libros manualmente"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "Desactivar o cambio de orde"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "Activar o cambio de orde"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Unir libros seleccionados"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Conta"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Token non atopado"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Borrar este andel"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Engadir ao andel"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Buscar na librería"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Buscar na librería"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Compartir con todos"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "Sincronizar este andel cun dispositivo Kobo"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Usuario non atopado"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Libro agochado"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Estatísticas da Biblioteca"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Libros nesta biblioteca"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Autores nesta biblioteca"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Categorías nesta biblioteca"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Series nesta biblioteca"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Estadísticas do sistema"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "Programa"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Versión instalada"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Tempo de execución"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Actions"
 msgstr "Accións"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "Rotar"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 "Esta tarefa cancelarase. Non se gardará ningún progreso feito por esta "
 "tarefa."
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
@@ -11659,395 +11473,395 @@ msgstr ""
 "Se esta é unha tarefa programada, volverá a lanzarse na próxima hora "
 "programada."
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "{} usuarios borrados con éxito"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Catálogo de libros electrónicos de Calibre-Web"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "O teu enderezo de correo"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "Axustes"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Restablecer contrasinal de usuario"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "Configuración do servidor"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "Enviar ao enderezo de correo electrónico do Kindle"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "Introduce as linguas"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Linguaxe de libros"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "Non se indicou unha lingua válida para o libro"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "Axustes OAuth"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Ligar"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Desligar"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Token de sincronización de Kobo"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Crear/Ver"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "Forzar sincronización completa de kobo"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "Sincronizar con Kobo soamente os libros dos andeis seleccionados"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "Sincronizar con Kobo soamente os libros dos andeis seleccionados"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "Axustes OAuth"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Engadir columnas de valores propios de Permitidos/Denegados"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Magic Shelves Order"
 msgstr "sincronizar andeis seleccionados con Kobo"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "Libros engadidos recentemente"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "Editar andeis públicos"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Borrar usuario"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12055,158 +11869,158 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Cambiar a contrasinal"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Cambiar a contrasinal"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Crear/Ver"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Xerar Auth URL de Kobo"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Selección..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Eliminar selección"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "Editar usuario"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "Introduce o nome do usuario"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Email"
 msgstr "Comprobar correo electrónico"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email"
 msgstr "Enviar ao enderezo de correo electrónico do Kindle"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email"
 msgstr "Comprobar o correo electrónico"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "Enviar ao enderezo de correo electrónico do Kindle"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "Comprobar o correo electrónico"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Lingua"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "Linguas de libros visibles"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "Editar etiquetas Permitidas"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Etiquetas Permitidas"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Editar Etiquetas Denegadas"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Etiquetas Denegadas"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "Editar valores permitidos para a columna"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "Valores permitidos da columna"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "Editar valores non permitidos para a columna"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "Valores non permitidos dea columna"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "Cambiar a contrasinal"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "Editar andeis públicos"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "sincronizar andeis seleccionados con Kobo"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "sincronizar andeis seleccionados con Kobo"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Read/Unread Section"
 msgstr "Mostrar selección lidos/non lidos"

--- a/cps/translations/hu/LC_MESSAGES/messages.po
+++ b/cps/translations/hu/LC_MESSAGES/messages.po
@@ -20,44 +20,44 @@ msgstr ""
 "Generated-By: Babel 2.13.1\n"
 "X-Generator: Poedit 3.9\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Statisztika"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr "Calibre adatbázis elérhetetlen. Állítsa be újra a könyvtár útvonalát."
 
-#: cps/admin.py:208
+#: cps/admin.py
 msgid "Server restarted, please reload page."
 msgstr "A kiszolgáló újraindult, töltse be újra az oldalt!"
 
-#: cps/admin.py:210
+#: cps/admin.py
 msgid "Performing Server shutdown, please close window."
 msgstr "A kiszolgáló leállítása folyamatban, zárja be ezt az ablakot!"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "Siker! Az adatbázis újra csatlakoztatva"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Ismeretlen parancs"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 "Siker! A könyvek bekerültek a metaadat-mentési várólistára, kérjük "
 "ellenőrizze a Feladatok menüpontban az eredményt"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
@@ -65,46 +65,46 @@ msgstr ""
 "Hiba: Hardcover token nem elérhető. Állítsa be HARDCOVER_TOKEN környezeti "
 "változót vagy állítsa be az Alapbeállításokban."
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 "Siker! Hardcover automatikus párosítási feladat elindítva. Az előrehaladást "
 "a Feladatok panelen követheti."
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr "Hiba a Hardcover automatikus párosítás elindításakor: %(error)s"
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr "Hardcover találatok ellenőrzése"
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr "Hiba az ellenőrzési lista betöltésekor: %(error)s"
 
-#: cps/admin.py:414
+#: cps/admin.py
 msgid "Hardcover ID applied successfully"
 msgstr "Hardcover ID sikeresen alkalmazva"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr "Találat %(action)s"
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr "Nincsenek elutasítható függőben lévő találatok"
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr "Elutasítva %(count)s találat"
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
@@ -112,169 +112,167 @@ msgstr ""
 "Címlapkép gyorsítótár frissítés elindítva {} könyvhöz. Ez eltarthat egy "
 "darabig."
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr "Nem található könyv borítóval a feldolgozáshoz."
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr "Nem sikerült elindítani a címlapkép frissítést: {}"
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Admin oldal"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "Hardcover token kötelező"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Alapvető beállítások"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Felhasználói felület beállításai"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr "A %(column)d egyéni oszlop nem létezik a Calibre adatbázisban"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Felhasználók szerkesztése"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Mind"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Felhasználó nem található"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} felhasználók sikeresen törölve"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Minden megjelenítése"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Hibás kérés"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "A Guest felhasználó neve nem módosítható"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "Vendég felhasználó nem veheti fel ezt a szerepet"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr "Nincs admin felhasználó, nem lehet eltávolítani az Admin szerepet"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "Az érték csak igaz vagy hamis lehet"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Érvénytelen szerep"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "Vendég felhasználó nem kaphatja meg ezt a nézetet"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "Érvénytelen nézet"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr "A Vendég felhasználó nyelvi beállítása automatikus, nem szerkeszthető"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Nincs érvényes nyelv megadva"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Hiányzik a könyv érvényes nyelve"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Paraméter nem található"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "A beállítások adatbázisa nem írható"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Érvénytelen olvasva/olvasatlan állapot oszlop"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Érvénytelen korlátozások oszlop"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Tényleg törölni szeretné a Kobo tokent?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "Tényleg törölni szeretné ezt a domaint?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "Tényleg törölni szeretné ezt a felhasználót?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Valóban törölni akarja ezt a polcot?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr ""
 "Biztosan meg szeretné változtatni a nyelvi beállításait a kiválasztott "
 "felhasználóknak?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "Biztosan meg akarja változtatni a kiválasztott felhasználó(k)nál a megjelenő "
 "könyvnyelveket?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 "Biztosan meg akarja változtatni a kiválasztott felhasználó(k) kiválasztott "
 "szerepét?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
@@ -282,7 +280,7 @@ msgstr ""
 "Biztosan módosítani szeretné a kiválasztott felhasználó(k)ra vonatkozó "
 "korlátozásokat?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -290,14 +288,14 @@ msgstr ""
 "Biztosan módosítani szeretné a kiválasztott felhasználó(k) láthatósági "
 "korlátozásait?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "Biztosan módosítani szeretné a kiválasztott felhasználó(k) "
 "polcszinkronizálási módját?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
@@ -305,129 +303,124 @@ msgstr ""
 "Biztosan módosítani szeretné a kiválasztott felhasználó(k) "
 "polcszinkronizálási módját?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Biztosan meg akarja változtatni a Calibre könyvtár helyét?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Elutasítás"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Engedélyezés"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "{} szinkronizált bejegyzés törölve"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Könyv nem található."
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Címke nem található"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Érvénytelen művelet"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json fájl nincs beállítva a webalkalmazáshoz"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "A naplófájl helye nem érvényes, kérjük, adja meg a helyes elérési utat"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "A hozzáférési naplófájl helye nem érvényes, kérjük, adja meg a helyes "
 "elérési utat"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 "Kérjük, adja meg az LDAP szolgáltatót, a portot, a DN-t és a felhasználói "
 "objektum azonosítót"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Kérjük, adja meg az LDAP-szolgáltatási fiókot és jelszót"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "Kérjük, adja meg LDAP-szolgáltatási fiókját"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Az LDAP csoport objektumszűrőnek egy \"%s\" formátumazonosítóval kell "
 "rendelkeznie"
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "Az LDAP csoport objektumszűrőjében nincs megfelelő zárójel"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Az LDAP felhasználói objektumszűrőnek rendelkeznie kell egy \"%s\" "
 "formátumazonosítóval"
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "Az LDAP felhasználói objektumszűrőben nincs megfelelő zárójel"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Az LDAP-tag felhasználói szűrőnek egy \"%s\" formátumú azonosítóval kell "
 "rendelkeznie"
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "Az LDAP-tag felhasználói szűrőben nincs megfelelő zárójel"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -435,29 +428,24 @@ msgstr ""
 "LDAP CACertificate, tanúsítvány vagy kulcs helye érvénytelen. Kérjük, adja "
 "meg a helyes elérési utat"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Új felhasználó hozzáadása"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "E-mail szerver beállításainak szerkesztése"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "Siker! A Gmail-fiók hitelesítve."
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Hoppá! Adatbázis hiba: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -465,53 +453,53 @@ msgstr ""
 "A %(email)s címre küldendő teszt e-mail sorba állítva. Kérjük, ellenőrizze a "
 "Feladatok menüpontban az eredményt"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Hiba történt a teszt levél küldése során: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Kérjük, először állítsa be az e-mail címét..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Az e-mail kiszolgáló beállításai frissítve"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "Felhasználók szerkesztése"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Kérjük, először állítsa be az SMTP levelező beállításokat..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "Kérjük, először állítsa be az e-mail címét..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "Először válasszon ki könyvet"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -519,7 +507,7 @@ msgstr ""
 "A %(email)s címre küldendő teszt e-mail sorba állítva. Kérjük, ellenőrizze a "
 "Feladatok menüpontban az eredményt"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -528,160 +516,158 @@ msgstr ""
 "A %(email)s címre küldendő teszt e-mail sorba állítva. Kérjük, ellenőrizze a "
 "Feladatok menüpontban az eredményt"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "Ütemezett feladatok beállításainak szerkesztése"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "A feladat megadott kezdési ideje érvénytelen"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "A feladat időtartama érvénytelen"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "Az ütemezett feladatok beállításai frissültek"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Ismeretlen hiba történt. Később próbálja újra!"
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 msgid "title"
 msgstr "cím"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "A felhasználó szerkesztése: %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "%(user)s felhasználó jelszava sikeresen alaphelyzetbe állítva"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Hoppá! Kérjük, állítsa be az SMTP levelezési beállításokat."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Naplófájl-megtekintő"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Frissítési csomag kérése"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Frissítési csomag letöltése"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Frissítési csomag kitömörítése"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Fájlok cserélése"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Adatbázis kapcsolatok lezárva"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Szerver leállítása"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "A frissítés települt, kattinton az OK-ra és az oldal újra tölt"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "A frissítés nem sikerült:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "HTTP hiba"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Kapcsolódási hiba"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Időtúllépés a kapcsolódás során"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Általános hiba"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr "A frissítési fájl nem menthető a temp könyvtárba"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "A fájlok frissítés közben nem cserélhetők ki"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "Legalább egy LDAP-felhasználó kibontása nem sikerült"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Nem sikerült legalább egy LDAP-felhasználót létrehozni"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Hiba: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Hiba: Az LDAP-kiszolgáló nem adott vissza felhasználót"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "Legalább egy LDAP-felhasználó nem található az adatbázisban"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} felhasználó sikeresen importálva"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr "A könyvek elérési útvonala érvénytelen"
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Az adatbázis helye nem érvényes, kérjük, adja meg a helyes elérési utat"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "Az adatbázis nem írható"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "A kulcsfájl helye nem érvényes, kérjük, adja meg a helyes elérési utat"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "A tanúsítványfájl helye nem érvényes, kérjük, adja meg a helyes elérési utat"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
@@ -689,13 +675,13 @@ msgstr ""
 "Felhasználók automatikus létrehozása nem engedélyezhető reverse proxy "
 "autentikáció engedélyezése nélkül"
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 "Felhasználók automatikus létrehozása érvényes reverse proxy header nevet "
 "igényel"
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
@@ -703,7 +689,7 @@ msgstr ""
 "Érvénytelen OAuth átirányítási cím formátum. A teljes URL-t adja meg "
 "protokollal együtt (pl.: https://your-domain.com)"
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
@@ -711,75 +697,75 @@ msgstr ""
 "OAuth átirányítási cím nem tartalmazhatja az elérési útvonalat. Csak az alap "
 "URL-t adja meg (pl.: https://your-domain.com)"
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr "A jelszó hossza 1 és 40 karakter között kell legyen"
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "Adatbázis beállítások frissítve"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "Adatbázis beállítások"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Az összes mezőt ki kell tölteni!"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "Az e-mail tartománya nem érvényes"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Új felhasználó hozzáadása"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "A következő felhasználó létrehozva: %(user)s"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr ""
 "Már létezik felhasználó ehhez az e-mail címhez vagy felhasználói névhez."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "A felhasználó törölve: %(nick)s"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "A vendég felhasználó nem törölhető"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "Nem marad admin felhasználó, nem lehet felhasználót törölni"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "Az e-mail nem lehet üres, és érvényes e-mail címnek kell lennie"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "A felhasználó frissítve: %(nick)s"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr "Kapcsolódás sikeres! OIDC felfedezési végpont elérhető.%(endpoints)s"
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
@@ -787,12 +773,12 @@ msgstr ""
 "Kapcsolódás sikertelen: OIDC felfedezési végpont nem található (404). "
 "Ellenőrizze az alap URL-t."
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr "Sikertelen kapcsolódás: a szerver által visszaadott státusz %(code)s"
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
@@ -800,14 +786,14 @@ msgstr ""
 "Sikertelen kapcsolódás: Nem érhető el a szerver. Ellenőrizze az URL-t és a "
 "hálózati kapcsolatot."
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 "Sikertelen kapcsolódás: Időtúllépés. A szerver lehet túl lassú vagy "
 "elérhetetlen."
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
@@ -815,12 +801,12 @@ msgstr ""
 "Sikertelen kapcsolódás: Érvénytelen JSON a válaszban. Lehet, hogy nem OIDC "
 "végpont."
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Sikertelen kapcsolódás: %(error)s"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
@@ -829,27 +815,27 @@ msgstr ""
 "Metaadatokból hiányzó OIDC mezők: %(fields)s. Lehet, hogy nem érvényes OIDC "
 "metaadat végpont."
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr "Metaadat URL érvényes! %(count)s OAuth végpont található."
 
-#: cps/admin.py:3322
+#: cps/admin.py
 msgid " User info endpoint is available."
 msgstr "Felhasználó információ végpont elérhető."
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 " Megjegyzés: Felhasználó infó végpont nem található, ami hitelesítési "
 "gondokat okozhat."
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr "Metaadat URL nem található (404). Ellenőrizze az URL helyességét."
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
@@ -857,51 +843,51 @@ msgstr ""
 "Sikertelen kapcsolódás: Nem lehet kapcsolódni a metaadat URL-hez. "
 "Ellenőrizze a hálózati kapcsolatot."
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr "Sikertelen kapcsolódás: Időtúllépés."
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr "Sikertelen kapcsolódás: Érvénytelen JSON a válaszban."
 
-#: cps/admin.py:3340
+#: cps/admin.py
 msgid "An unknown error occurred."
 msgstr "Ismeretlen hiba történt."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 msgid "Restore already in progress."
 msgstr "Visszaállítás már folyamatban."
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr "Visszaállítás sikertelen: Calibre könyvtár útvonal nincs beállítva."
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 "Visszaállítás sikertelen: metadadat.db nem található ezen az útvonalon: "
 "%(path)s"
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 "Visszaállítás sikertelen: app.db nem található ezen az útvonalon: %(path)s"
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Visszaállítás sikertelen: %(err)s"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 "Visszaállítás sikeres de az app.db tisztítás nem sikerült. Tekintse meg a "
 "naplófájlokat a részletekért."
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
@@ -910,200 +896,199 @@ msgstr ""
 "Visszaállítás sikeres. Biztonsági mentések és naplófájlok elkészültek: "
 "%(dir)s. Minden könyvhöz kapcsolódó adat visszaállítva."
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 msgid "No file uploaded."
 msgstr ""
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr "Cseh"
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr "Német"
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr "Görög"
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr "Spanyol"
 
-#: cps/constants.py:265
+#: cps/constants.py
 msgid "Finnish"
 msgstr "Finn"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr "Francia"
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr "Galego"
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr "Magyar"
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr "Indonéz"
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr "Olasz"
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr "Japán"
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr "Kmer"
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr "Koreai"
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr "Holland"
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr "Norvég"
 
-#: cps/constants.py:276
+#: cps/constants.py
 msgid "Polish"
 msgstr "Lengyel"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr "Portugál"
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr "Portugál (Brazil)"
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr "Orosz"
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr "Szlovák"
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr "Szlovén"
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr "Svéd"
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr "Török"
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr "Ukrán"
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr "Vietnámi"
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr "Kínai (egyszerűsített, Kína)"
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr "Kínai (Hagyományos, Tajvan)"
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "nincs telepítve"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Hiányzik a futtatási jogosultság"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr "Vissza a metaadatok szerkesztéséhez"
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, python-format
 msgid "Change cover — %(title)s"
 msgstr "Borító csere — %(title)s"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr "Ennek a könyvnek a borítója zárolva van. Először oldja fel."
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr "Adjon meg egy borító URL-t."
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr "Ehhez a könyvhöz nincs beágyazott borító, amit ki lehetne nyerni."
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 msgid "Unknown cover source."
 msgstr "Ismeretlen borító forrás."
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr "Nem sikerült menteni a zárolási állapotot."
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr "Csak http(s) URL-ek előnézete jeleníthető meg."
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Could not render the e-reader preview."
 msgstr "Nem sikerült létrehozni a Kobo előnézetet."
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr "Nem sikerült betölteni a forrásképet az előnézethez."
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr "A borító mentése sikertelen."
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr "Téma váltás ideiglenesen kikapcsolva a v5.0.0 verzióig"
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
@@ -1111,262 +1096,253 @@ msgstr ""
 "Könyvtárfrissítés 🔄 Ellenőrzés, hogy nem maradt‑e ki egyetlen könyv sem. "
 "Kérem várjon..."
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 "Érvénytelen cron kifejezés ismétlődő kereséshez. Változtatások nincsenek "
 "elmentve."
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr "Időbélyeg"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Book ID"
 msgstr "Könyv azonosító"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Könyv címe"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Book Author"
 msgstr "Könyv szerző"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr "Kiváltó ok"
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Filepath"
 msgstr "Elérési útvonal"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Filename"
 msgstr "Fájlnév"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr "Kézi?"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr "Javítások száma"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr "Eredeti biztonsági mentve?"
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr "Elvégzett javítások"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr "Eredeti formátum"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "End Format"
 msgstr "Célformátum"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 msgid "Unknown User"
 msgstr "Ismeretlen felhasználó"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr "✅ Minden monitorozási szolgáltatás megfelelően fut! 👍"
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr "⛔ Az Ingest szolgáltatás aktív, de a metaadat-változásfigyelő nem"
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr "⛔ A metaadat-változásfigyelő aktív, de az Ingest szolgáltatás nem"
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 "⛔ Sem az Ingest szolgáltatás, sem a metaadat-változásfigyelő nem aktív"
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr "Hiba történt"
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 "EPUB javító használata egy könyvhöz nem támogatott Google Drive "
 "könyvtáraknál."
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 msgid "Invalid book selection."
 msgstr "Érvénytelen könyvkijelölés."
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr "Könyv nem található."
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 msgid "Selected book has no EPUB format."
 msgstr "A kijelölt könyv nem elérhető EPUB formátumban."
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 msgid "EPUB file not found on disk."
 msgstr "EPUB fájl nem található a lemezen."
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 msgid "EPUB Fixer started for selected book."
 msgstr "EPUB javító elindult a kijelölt könyvekhez."
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr "Nem sikerült elindítani az EPUB javítót a kijelölt könyvekhez."
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr "Ehhez az oldalhoz csak rendszergazdák férhetnek hozzá."
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr "A felhasználói név és a kép kötelező."
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr "Érvénytelen kép formátum. Érvényes képnek kell lennie."
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr "Nem támogatott kép típus. Csak PNG és JPEG az elfogadott."
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr "A kép túl nagy. 500 KB-nál kisebb képeket használjon."
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr "Érvénytelen Base64 kép adat."
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 msgid "Invalid image data format."
 msgstr "Érvénytelen kép formátum."
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr "Hiba kép adat érvényesítés közben."
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr "Profilkép sikeresen frissítve."
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Nincs"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 msgid "Duplicate Books"
 msgstr "Ismétlődő könyvek"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr "Ismétlődő csoport már elutasítva"
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 msgid "Duplicate group dismissed"
 msgstr "Ismétlődő könyvcsoport elutasítva"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 msgid "Duplicate group restored"
 msgstr "Ismétlődő könyvcsoport visszaállítva"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr "Ismétlődő csoport nem lett elutasítva"
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 msgid "Duplicate scan queued"
 msgstr "Ismétlődő könyvek ellenőrzése ütemezve"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr "Ismétlődő keresés befejezve (tartalék mód)"
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 msgid "Invalid resolution strategy"
 msgstr "Érvénytelen megoldási stratégia"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
@@ -1374,96 +1350,93 @@ msgstr ""
 "A könyvbeolvasó mappa nem írható. Ellenőrizze a /cwa-book-ingest mappa "
 "jogosultságait."
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr "Hiányzó vagy érvénytelen könyv azonosító a feltöltendő formátumban"
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr "Nem tölthető fel a formátum: A könyv már nem létezik a könyvtárban"
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Feltöltés kész, feldolgozás alatt, kérlek várj..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 msgid "Failed to queue upload for processing"
 msgstr "A feltöltés feldolgozásra való sorba állítása nem sikerült"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Az átalakításhoz hiányzik a forrás- vagy célformátum!"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr ""
 "A könyv sikeresen bekerült az átalakítási sorba a(z) %(book_format)s "
 "formátumhoz"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Hiba történt a könyv átalakításakor: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "A fájlformátum feltöltése nem engedélyezett ezen a szerveren"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr ""
 "A(z) \"%(ext)s\" kiterjesztésű fájlok feltöltése nincs engedélyezve ezen a "
 "szerveren"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "A feltöltendő fájlnak kiterjesztéssel kell rendelkeznie!"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 "Hiba történt az e-könyv megnyitásakor. A fájl nem létezik vagy nem érhető el"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "A felhasználónak nincs joga borítót feltölteni"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr "A borító zárolva van. Először oldja fel a borítóválasztó oldalon."
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 "Az azonosítók nem különböztetnek meg a kis- és nagybetűket. A régi "
 "azonosítók felülírása"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "%(langname)s nem érvényes nyelv"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "A metaadatok sikeresen frissültek"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "Hiba a könyv szerkesztésénél: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Ismeretlen"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1471,97 +1444,97 @@ msgstr ""
 "A feltöltött könyv valószínűleg már megtalálható a könyvtárban. Fontolja meg "
 "módosítását, mielőtt újat tölt fel: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "A %(filename)s fájl nem menthető a temp könyvtárba"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "A borítófájl %(file)s áthelyezése sikertelen: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "A könyvformátum sikeresen törölve"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "A könyv sikeresen törölve"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "Nincs jogosultsága könyvek törlésére"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "Metaadatok szerkesztése"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "Sorozatindex: %(seriesindex)s nem érvényes szám, kihagyva"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr "A felhasználónak nincs joga további fájlformátumokat feltölteni"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr ""
 "Nem sikerült létrehozni az elérési utat (hozzáférés megtagadva): %(path)s."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Nem sikerült elmenteni a %(file)s fájlt."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "A(z) %(ext)s fájlformátum hozzáadva a könyvhöz: %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Könyv nem található."
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "EPUB fájl nem található a lemezen."
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr "Nem sikerült menteni a zárolási állapotot."
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr "Nem sikerült menteni a zárolási állapotot."
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1569,7 +1542,7 @@ msgstr ""
 "A Google Drive beállítása nem fejeződött be, próbálja meg kikapcsolni és "
 "újra aktíválni a Google Drive-ot"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1577,87 +1550,86 @@ msgstr ""
 "A visszahívási tartomány nem ellenőrzött, kövesse az alábbi lépéseket a "
 "tartomány ellenőrzéséhez a Google Developer Console-ban:"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "A(z) %(format)s formátum nem található a következő könyvhöz: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(format)s nem található a Google Drive-on: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s nem található: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "Küldés e-olvasóra"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "A(z) %(format)s formátum nem található a következő könyvhöz: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "A(z) %(format)s formátum nem található a következő könyvhöz: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 msgid "Test Email"
 msgstr "Teszt e-mail"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Regisztrációs e-mail a következő felhasználóhoz: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "%(orig)s konvertálása %(format)s formátumra és küldés e-olvasóra"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, python-format
 msgid "Send %(format)s to eReader"
 msgstr "%(format)s küldése e-olvasóra"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s küldése e-olvasóra"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "A kért fájl nem olvasható. Esetleg jogosultsági probléma lenne?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "Az olvasási állapot nem állítható be: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
@@ -1665,12 +1637,12 @@ msgstr ""
 "A %(id)s könyv könyvtárának törlése sikertelen, az útvonal alkönyvtárakkal "
 "rendelkezik: %(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "A %(id)s könyv törlése sikertelen: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1679,7 +1651,7 @@ msgstr ""
 "A %(id)s könyv törlése csak az adatbázisból. A könyv elérési útja az "
 "adatbázisban érvénytelen: %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
@@ -1687,64 +1659,64 @@ msgstr ""
 "A szerző átnevezése erről: \"%(src)s\" erre: \"%(dest)s\" nem sikerült a "
 "következőhiba miatt: %(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "A \"%(file)s\" fájl nem található a Google Drive-on"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "A cím átnevezése \"%(src)s\"-ról \"%(dest)s\"-ra nem sikerült a következő "
 "hiba miatt: %(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "A könyv elérési útja (\"%(path)s\") nem található a Google Drive-on"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr "Létező fiókot találtunk ehhez az e-mail címhez"
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Ez a felhasználónév már foglalt"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr "Érvénytelen e-mail cím formátum"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr "A jelszó nem felel meg a jelszó érvényesítési szabályoknak"
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 "A Python modul „advocate” nincs telepítve, de szükséges a borítók "
 "feltöltéséhez"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Hiba a borító letöltése közben"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr "Borítókép meghaladja a maximum %(size)s MB méretet"
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr "A borítófájl nem érvényes képfájl, vagy nem tárolható"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Borító formátum hiba"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
@@ -1752,107 +1724,107 @@ msgstr ""
 "Nem férhet hozzá a localhost-hoz vagy a helyi hálózathoz, hogy borítókat "
 "töltsön fel"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "A borító útvonalának létrehozása sikertelen"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "Csak jpg/jpeg/png/webp/bmp fájlok támogatottak borítófájlként"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "Hibás borítófájl"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Csak jpg/jpeg fájlok támogatottak borítófájlként"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr "Borító"
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "UnRar bináris fájl nem található"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr "Hiba az UnRar végrehajtása közben"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr "A megadott könyvtár nem található"
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr "Kérjük, adjon meg egy könyvtárat, ne fájlt!"
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr "A Calibre bináris fájlok nem használhatók"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr "Hiányzó Calibre bináris fájlok: %(missing)s"
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Hiányzó végrehajtható engedély: %(missing)s"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr "Hiba a Calibre futtatása közben"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr "Az összes könyv sorba állítása a metaadatok biztonsági mentéséhez"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Kobo beállítása"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr "Nemrég hozzáadott"
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr "Magasra értékelt"
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr "Jelenleg olvasott"
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr "Még olvasatlan"
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr "Friss kiadványok"
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Regisztráció a %(provider)s-hez/hoz"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
@@ -1862,11 +1834,11 @@ msgstr ""
 "jogosultsági körök (scope) helytelen beállítása lehet. Ellenőrizze az OAuth "
 "jogosultsági körök beállításait, vagy keresse a rendszergazdát."
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr "Bejelentkezés sikertelen: OAuth token lejárt. Jelentkezzen be újra."
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
@@ -1874,7 +1846,7 @@ msgstr ""
 "Bejelentkezés sikertelen: Nem sikerült csatlakozni az OAuth szolgáltató "
 "felhasználó infó végpontjához. Próbálja újra vagy keresse a rendszergazdát."
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
@@ -1882,7 +1854,7 @@ msgstr ""
 "Bejelentkezés sikertelen: Az OAuth szolgáltató érvénytelen felhasználó "
 "adatokkal tért vissza. Forduljon a rendszergazdához."
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1893,37 +1865,37 @@ msgstr ""
 "mezők: %(fields)s. Ellenőrizze az OAuth beállításait vagy keresse a "
 "rendszergazdát."
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr "Nem sikerült összekapcsolni az OAuth fiókot. Próbálja újra."
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 "OAuth hiba: A szolgáltató érvénytelen felhasználó információval tért vissza. "
 "Próbálja újra."
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr "Ez a(z) %(oauth)s fiók már egy másik felhasználóhoz van kapcsolva"
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "Be vagy jelentkezve mint: %(nickname)s"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Link %(oauth)s-hoz/hez sikeres"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1934,60 +1906,60 @@ msgstr ""
 "fiókjához. Keresse a rendszergazdát, hogy létrehozzon egy fiókot, vagy "
 "összekapcsoljon egy létezővel."
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr "OAuth hitelesítési hiba. Próbálja újra vagy keresse a rendszergazdát."
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 msgid "OAuth system error. Please contact administrator."
 msgstr "OAuth rendszerhiba. Kérjük, forduljon a rendszergazdához!"
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "A %(oauth)s-hoz/hez való kapcsolódás megszüntetése sikeres volt"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "A %(oauth)s-hoz/hez való kapcsolódás megszüntetése sikertelen"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "Nincs kapcsolata %(oauth)s-tal"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "A Github-fiókkal való bejelentkezés sikertelen."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Nem sikerült lekérni a felhasználói adatokat a GitHub-ról."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "A Google-fiókkal való bejelentkezés sikertelen."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Nem sikerült lekérni a felhasználói adatokat a Google-tól."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 msgid "Failed to log in with Generic OAuth."
 msgstr "Bejelentkezés általános OAuth segítségével sikertelen."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr "OAuth hitelesítési hiba: Token érvényesítési hiba. Próbálja újra."
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr "OAuth hitelesítés váratlan hibába ütközött. Keresse a rendszergazdát."
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
@@ -1997,3222 +1969,3166 @@ msgstr ""
 "hibával állítsa be az \"OAuth átirányítási címet\" a Beállítások > "
 "Alapbeállítások szerkesztése > OAuth oldalon."
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "GitHub Oauth hiba, kérjük, próbálja meg később újból."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "GitHub Oauth hiba: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Google Oauth hiba, kérjük, próbálja meg később újból."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Google Oauth hiba: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr "OAuth hiba: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "Könyvek ábécé sorrendben"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr ""
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Népszerű könyvek"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "Ebből a katalógusból származó népszerű kiadványok letöltések alapján."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Legmagasabbra értékelt könyvek"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Ebből a katalógusból származó népszerű kiadványok értékelések alapján."
 
-#: cps/opds.py:182
+#: cps/opds.py
 msgid "Recently added Books"
 msgstr "Nemrég hozzáadott könyvek"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "A legfrissebb könyvek"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Véletlenszerű könyvek"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Véletlenszerű könyvajánló"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Elolvasott könyvek"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Jelenlegi verzió"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Olvasatlan könyvek"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Szerzők"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Könyvek szerző szerint rendezve"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Kiadók"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Könyvek kiadók szerint rendezve"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Címkék"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Könyvek címke szerint rendezve"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Sorozatok"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Könyvek sorozat szerint rendezve"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Nyelvek"
 
-#: cps/opds.py:237
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by Languages"
 msgstr "Könyvek sorozat szerint rendezve"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Értékelések"
 
-#: cps/opds.py:243
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by Rating"
 msgstr "Könyvek címke szerint rendezve"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Fájlformátumok"
 
-#: cps/opds.py:249
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by file formats"
 msgstr "Könyvek sorozat szerint rendezve"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Polcok"
 
-#: cps/opds.py:255
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in shelves"
 msgstr "Könyvek sorozat szerint rendezve"
 
-#: cps/opds.py:260
+#: cps/opds.py
 msgid "Magic Shelves"
 msgstr "Varázspolcok"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Könyvek sorozat szerint rendezve"
 
-#: cps/opds.py:317
+#: cps/opds.py
 msgid "description"
 msgstr "leírás"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} csillag"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Keresés"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Belépés"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "A token nem található."
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "A token érvényessége lejárt"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Sikerült! Újra használható az eszköz"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Könyvek"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Legutóbbi könyvek megjelenítése"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Népszerű könyvek megjelenítése"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Letöltött könyvek"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Letöltött könyvek megjelenítése"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Legmagasabbra értékelt könyvek megjelenítése"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 msgid "Show Read and Unread"
 msgstr "Olvasva/olvasatlan mutatása"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Olvasatlan könyvek megjelenítése"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Felfedezés"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Category Section"
 msgstr "Címkék mutatása"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Series Section"
 msgstr "Sorozatok mutatása"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Author Section"
 msgstr "Szerzők mutatása"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Publisher Section"
 msgstr "Kiadók mutatása"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Language Section"
 msgstr "Nyelvek mutatása"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Ratings Section"
 msgstr "Értékelések mutatása"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show File Formats Section"
 msgstr "Fájlformátumok mutatása"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Archivált könyvek"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Archived Books"
 msgstr "Archivált könyvek mutatása"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr "Kedvencek"
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Könyvek listája"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Könyvek listájának megjelenítése"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr "Ismétlődő könyvek"
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 msgid "Show Duplicate Books"
 msgstr "Ismétlődő könyvek mutatása"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Kiadva ezután: "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Kiadva ezelőtt: "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Értékelés <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Értékelés <= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Olvasási státusz = '%(status)s'"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 "Hiba az egyéni oszlopok keresése során. Kérjük, indítsa újra a Calibre-Web "
 "alkalmazást"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Részletes keresés"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "A megadott polc érvénytelen!"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "Nincs engedélye könyvet hozzáadni ehhez a polchoz"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "A könyv már a következő polcon van: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 "%(book_id)s érvénytelen könyvazonosító. Nem lehetett hozzáadni a polchoz"
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "A könyv hozzá lett adva a következő polchoz: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "Nem adhat hozzá könyvet a polchoz"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "A könyvek már a következő polcon vannak: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "A könyvek hozzá lettek adva a következő polchoz: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Nem sikerült hozzáadni a könyveket a polchoz: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "A megadott polc érvénytelen!"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Nem sikerült hozzáadni a könyveket a polchoz: %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "A könyvek már a következő polcon vannak: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "A könyvek hozzá lettek adva a következő polchoz: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "A könyv el lett távolítva a polcról: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "Sajnálom, de nem távolíthat el könyvet erről a polcról"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Polc létrehozása"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Nincs engedélye szerkeszteni ezt a polcot"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Polc szerkesztése"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "Hiba a polc törlése során"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "Polc sikeresen törölve"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "A következő polc átrendezése: %(name)s"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "Sajnáljuk, de nem hozhat létre nyilvános polcot"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "A következő polc létre lett hozva: %(title)s"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "A következő polc megváltoztatva: %(title)s"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Hiba történt"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "Már létezik egy nyilvános polc a '%(title)s' névvel."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "Már létezik egy saját polc a „%(title)s” névvel."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Polc: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Hiba a polc megnyitásakor. A polc nem létezik vagy nem elérhető"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr "Érvénytelen rendezési mód: %(mode)s"
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr "Nem sikerült menteni a sorrendet"
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 msgid "Reorder Shelves"
 msgstr "Polcok átrendezése"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr "Név (A → Z)"
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr "Név (Z → A)"
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr "Könyvek száma (legtöbb → legkevesebb)"
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr "Könyvek száma (legkevesebb → legtöbb)"
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr "Létrehozva (legújabb → legrégebbi)"
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr "Létrehozva (legrégebbi → legújabb)"
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr "Módosítva (legutóbbi → legrégebbi)"
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr "Módosítva (legrégebbi → legutóbbi)"
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr "Kézi (húzd át alább)"
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr "{title} részleteinek megnyitása"
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr "{title} olvasása"
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr "Normál (felhasználónév / jelszó)"
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Névtelen"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Hitelesítetlen"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr "Egyszerű (szolgáltatási fiók)"
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr "Címke hozzáadása"
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr "Címke eltávolítása"
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Igen"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Nem"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr "Egyezési feltétel"
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr "Szabály mezője"
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr "Szabály operátora"
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Olvasási állapot"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Téma"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Világos"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Sötét"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "Szépia"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr "Szabály hozzáadása"
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Hozzáadás polchoz"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Szerző"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Böngészés"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Bezárás"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr "Borító frissítve."
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr "Intelligens polc létrehozása"
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Törlés"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr "{title} szerkesztése"
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Összevonás"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Kiadó"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Olvasva"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr "Módosítások mentése"
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr "Mentés…"
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Cím"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Feltöltés"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr "A feltöltés sikertelen."
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr "Újdonságok"
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr "Súgó — új frissítések érhetők el"
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Felhasználói fiók"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Rendszergazda"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Kiadva"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr "Fájlformátum"
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Forrás"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr "Hozzáadás dátuma"
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr "Kiadási dátum"
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr "ezzel kezdődik"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr "tartalmazza"
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr "nem tartalmazza"
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr "erre végződik"
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr "az elmúlt N napban"
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr "nem egyenlő"
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr "egyenlő"
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr "nem az elmúlt N napban"
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr "ekkor vagy ezután"
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr "ekkor vagy ezelőtt"
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr "3:4 (általános)"
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr "Néhány véletlenszerű könyv a könyvtáradból"
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr "API kulcsok"
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "Névjegy"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr "Bármelyik"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr "Frissítés…"
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr "Archiválás"
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Archiválva"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr "Kérdés a Discordon"
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr "{number}. könyv"
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr "{task} megszakítása"
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr "Borítócsere"
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr "Kényelmes"
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr "Kompakt"
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "Konvertálás"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr "Nem sikerült létrehozni a polcot."
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr "Nem sikerült létrehozni a polcot."
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr "Nem sikerült törölni a polcot."
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr "Nem sikerült betölteni a statisztikákat."
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr "Nem sikerült betölteni a feladatokat."
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr "Nem sikerült betölteni a felhasználókat."
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr "Nem sikerült átnevezni a polcot."
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr "Nem sikerült menteni a sorrendet."
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr "Nem sikerült menteni a polcot."
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr "Nem sikerült frissíteni a polcot."
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr "Létrehozás"
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr "A létrehozás sikertelen."
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr "{name} létrehozva."
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr "Jelenlegi"
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr "Jelenlegi borító"
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr "Hozzáadás dátuma"
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr "A törlés sikertelen."
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr "Törlöd a(z) „{name}” polcot? Ez nem vonható vissza."
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 "Törlöd a(z) „{name}” felhasználót? A polcai és az olvasási adatai is "
 "törlődnek."
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr "{name} törlése"
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr "{name} törölve."
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr "Sűrű"
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Leírás"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr "Felfedezés — Véletlenszerű válogatás"
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr "Elrejtés"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr "Dokumentáció"
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Letöltés"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr "Elmosott szél — lágy bokeh szegély"
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr "Tükrözött szél — a grafika kiterjesztése (ajánlott)"
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Szerkesztés"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr "Intelligens polc szerkesztése"
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "E-mail"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Kobo szinkronizáció engedélyezése"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Titkosítás típusa"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr "Nem sikerült betölteni a polcokat."
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr "Kitöltés stílusa"
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr "Szűrés: {items}"
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr "Szűrés: {items}…"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr "Adjon nevet az intelligens polcnak."
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr "Súgó és támogatás"
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr "Súgó menüt"
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "Elrejtés"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr "Felfedezés szakasz elrejtése"
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr "Népszerű"
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr "Népszerű — Legtöbbször letöltött"
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr "Ikon"
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Azonosítók"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr "KOReader állapot"
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Nyelv"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr "Utoljára módosítva"
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr "Továbbiak betöltése"
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr "Betöltés…"
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr "Betöltés…"
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr "Borító zárolása"
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr "Legyen olvasott"
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr "Legyen olvasatlan"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr "Egyezés"
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr "Név"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr "Hibát jelentenél? Próbáld ki az új"
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr "Új"
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr "Új polc neve"
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr "Új polc neve…"
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr "Új intelligens polc"
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr "Még nem találhatók jelöltek. Próbáljon más keresést vagy frissítést."
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr "Nincs találat itt: {items}, erre: „{query}”."
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr "Még nincsenek polcok. Hozz létre egyet fent a könyvek gyűjtéséhez."
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr "Még nincs elem itt: {items}."
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr "{number}. oldal"
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Jelszó"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
@@ -5220,857 +5136,845 @@ msgstr ""
 "Válassz borítót bármely támogatott forrásból, illessz be egy URL-t, tölts "
 "fel egy fájlt, vagy használd a könyvbe beágyazott borítót."
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Állapot"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr "Nyilvános"
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Értékelés"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr "Olvasási állapot szűrő"
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr "Frissítés"
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr "Levétel polcról"
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr "Szabály eltávolítása"
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr "Probléma jelentése a Discordon"
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr "Probléma jelentése a GitHubon"
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Mentés"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr "Keresés…"
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "Kiválasztás"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr "Küldés"
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr "A küldés sikertelen."
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr "Összes megjelenítése itt: {items}"
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr "Válogatás keverése"
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr "Intelligens polcok"
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr "Valami hiba történt. Próbáld újra."
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr "Rendezési sorrend"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Státusz"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr "Támogatás a Ko-fi-on →"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr "Táblázatos nézet"
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr "Címke"
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Címkék"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr "Cél képarány"
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Feladat"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Feladatok"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr "Ez a polc üres. Könyveket bármely könyv oldaláról hozzáadhatsz."
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr "Legjobbra értékeltek"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr "Archiválás visszavonása"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr "A frissítés sikertelen."
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr "Feltöltés borítóként"
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr "Használja ezt a borítót"
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Felhasználó"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Felhasználónév"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Megtekintés"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr "Zárolás esetén a metaadatok lekérése nem írja felül ezt a borítót."
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr "minden szabály"
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr "bármely szabály"
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr "könyv egyezik"
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr "pl. olvasatlan sci-fi"
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr "érték"
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr "{count} könyv"
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr "{count} könyv"
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr "{count} fájl importálásra vár"
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr "{count} fájl elutasítva"
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr "{count} fájl importálásra vár"
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr "{count} fájl elutasítva"
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr "{count} találat"
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr "{count} találat"
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Várakozás"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Nem sikerült"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Elindítva"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Végrehajtva"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "Véget ért"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "Megszakítva"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Ismeretlen állapot"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Ismeretlen adat a frissítési információk olvasásakor"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr "Nem érhető el újabb frissítés. Már a legújabb verzió van telepítve"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6078,16 +5982,16 @@ msgstr ""
 "Egy új frissítés érhető el. Kattintson a lenti gombra a legújabb verzióra "
 "frissítéshez."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Nem lehetett begyűjteni a frissítési információkat"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr ""
 "Kattintson az alábbi gombra a legújabb stabil verzióra való frissítéshez."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6096,256 +6000,254 @@ msgstr ""
 "Új frissítés érhető el. Kattintson az alábbi gombra a frissítéshez a "
 "következő verzióra: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Megjelenési információ nem érhető el"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Felfedezés (könyvek találomra)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Felkapott könyvek (legtöbbet letöltöttek)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "%(user)s által letöltött könyvek"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Szerző: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Kiadó: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Sorozat: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "Értékelés: Nincs"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Értékelés: %(rating)s csillag"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Fájlformátum: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Címke: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Nyelv: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Népszerű könyvek"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Rejtett könyvek"
 
-#: cps/web.py:1193
+#: cps/web.py
 msgid "Error loading magic shelf"
 msgstr "Hiba varázspolc betöltése közben"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr "Varázspolc&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr "Nincs szabály megadva"
 
-#: cps/web.py:1400
+#: cps/web.py
 msgid "Invalid rules format"
 msgstr "Érvénytelen szabály formátum"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr "Hiba a szabályok feldolgozása közben"
 
-#: cps/web.py:1426
+#: cps/web.py
 msgid "Invalid request"
 msgstr "Érvénytelen kérés"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr "Név és szabályok kötelezőek"
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr "Polc név túl hosszú (max. 100 karakter)"
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 msgid "Error creating shelf"
 msgstr "Hiba polc létrehozásakor"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 msgid "Create Magic Shelf"
 msgstr "Varázspolc létrehozása"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr "Nincs jogosultsága megváltoztatni a publikus státuszt"
 
-#: cps/web.py:1587
+#: cps/web.py
 msgid "Shelf name is required"
 msgstr "Polc név kötelező"
 
-#: cps/web.py:1647
+#: cps/web.py
 msgid "Error updating shelf"
 msgstr "Hiba polc frissítésekor"
 
-#: cps/web.py:1652
+#: cps/web.py
 msgid "Edit Magic Shelf"
 msgstr "Varázspolc szerkesztése"
 
-#: cps/web.py:1668
+#: cps/web.py
 msgid "Shelf not found"
 msgstr "Polc nem található"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr "Nincs jogosultsága"
 
-#: cps/web.py:1704
+#: cps/web.py
 msgid "Shelf duplicated successfully"
 msgstr "Polc sikeresen lemásolva"
 
-#: cps/web.py:1710
+#: cps/web.py
 msgid "Error duplicating shelf"
 msgstr "Hiba polc másolásakor"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 "Rendszer polcok nem törölhetőek. Elrejtheti őket a profil beállításokban."
 
-#: cps/web.py:1755
+#: cps/web.py
 msgid "Error deleting shelf"
 msgstr "Hiba polc törlésekor"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 "Nem rejtheti el a saját polcait. Törölje őket amennyiben nincs rájuk szükség."
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr "A polc már el van rejtve"
 
-#: cps/web.py:1795
+#: cps/web.py
 msgid "Error hiding shelf"
 msgstr "Hiba polc elrejtésekor"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr "A polc nem lett elrejtve"
 
-#: cps/web.py:1818
+#: cps/web.py
 msgid "Error unhiding shelf"
 msgstr "Hiba polc újra megjelenítésekor"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Letöltések"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Fájlformátum lista"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Kérjük, először állítsa be az SMTP levelező beállításokat..."
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr "Hoppá! Kérjük frissítse profilját valós e-olvasó e-mail címmel."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr ""
 "A könyv sikeresen küldésre lett jelölve a következő címre: %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Hiba történt a könyv küldésekor: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr "Nincs e-mail cím kiválasztva"
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr "További e-mail címek hozzáadása nincs engedélyezve a fiókjában."
 
-#: cps/web.py:2500
+#: cps/web.py
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "Siker! A könyv a megadott e-mail cím(ek)re hamarosan elküldve!"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr "Kérjük várjon egy percet a következő felhasználó létrehozásával"
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Regisztrálás"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr ""
 "Nem sikerült csatlakozni a korlátozó háttérrendszerhez. Kérjük, forduljon a "
 "rendszergazdához"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr ""
 "Hoppá! Az e-mail szerver nincs beállítva. Kérjük, forduljon a "
 "rendszergazdához!"
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "Nem engedélyezett a megadott e-mail cím bejegyzése."
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "Jóváhagyó levél elküldve az email címedre."
 
-#: cps/web.py:2624
+#: cps/web.py
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
@@ -6353,35 +6255,35 @@ msgstr ""
 "Hitelesítési hurok észlelve. Bejelentkezési problémák esetén vegye fel a "
 "kapcsolatot a rendszergazdával."
 
-#: cps/web.py:2704
+#: cps/web.py
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr ""
 "OAuth bejelentkezés nincs megfelelően beállítva. Értesítse a rendszergazdát."
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr "Az LDAP-hitelesítés nem aktiválható"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr "Alap bejelentkezés letiltva."
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr "Kérjük várjon egy percet a következő belépéssel"
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr "Felhasználónév nem lehet üres"
 
-#: cps/web.py:2756
+#: cps/web.py
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "\"%(nickname)s\" néven van bejelentkezve"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
@@ -6390,7 +6292,7 @@ msgstr ""
 "Üdvözöljük! Fiókja automatikusan létrejött. Be van jelentkezve mint: "
 "\"%(nickname)s\""
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
@@ -6398,7 +6300,7 @@ msgstr ""
 "Autentikáció sikeres, de a fiók létrehozás nem sikerült. Keresse a "
 "rendszergazdát."
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
@@ -6406,7 +6308,7 @@ msgstr ""
 "Hitelesítés sikeres, de nem található lokális fiók. Keresse a "
 "rendszergazdát, hogy létrehozzon egy fiókot."
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6415,699 +6317,669 @@ msgstr ""
 "Tartalék bejelentkezés \"%(nickname)s\" néven. Az LDAP szerver nem elérhető, "
 "vagy a felhasználó nem található"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr "Nem sikerült bejelentkezni: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 msgid "Wrong Username or Password"
 msgstr "Rossz felhasználónév vagy jelszó"
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr "Az új jelszót elküldtük az emailcímére"
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr "Ismeretlen hiba történt. Próbálja újra később!"
 
-#: cps/web.py:2838
+#: cps/web.py
 msgid "Please enter valid username to reset password"
 msgstr "Érvényes felhasználónevet adjon meg a jelszó visszaállításához"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "Be van jelentkezve mint: \"%(nickname)s\""
 
-#: cps/web.py:3158
+#: cps/web.py
 msgid "Success! Profile Updated"
 msgstr "Siker! Profil frissítve"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "Már létezik felhasználó ehhez az e-mail címhez."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr "Az alkalmazásjelszó címkéje 1–64 karakter hosszú lehet."
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr "A(z) '%(label)s' alkalmazásjelszó visszavonva."
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr "Érvénytelen könyv azonosító."
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr "KOReader szinkronizáció plugin"
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr ""
 "Nem található érvényes gmail.json fájl, amely tartalmazza az OAuth-"
 "hitelesítési adatokat"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr "Hardcover azonosítók automatikus lekérése"
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 msgid "Preparing to send to eReader..."
 msgstr "E-olvasóra küldés előkészítése..."
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr "Elérhető formátumok ellenőrzése..."
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 msgid "Sending to eReader..."
 msgstr "Küldés e-olvasóra..."
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 msgid "Auto-send completed successfully"
 msgstr "Automatikus küldés sikeresen lezajlott"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr "Automatikus küldés"
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr "Ideiglenes mappa tartalmának törlése"
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s küldése e-olvasóra"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Calibre e-könyv konvertáló eszköz %(tool)s nem található"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "A(z) %(format)s formátum nem található a lemezen"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "Az e-könyv konvertáló ismeretlen hibába ütközött"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Kepubify konvertáló hibába ütközött: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "Az átalakított fájl nem található vagy több, mint 1 fájl van a könyvtárban "
 "%(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "A Calibre a következő hibával tért vissza: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Az e-könyv átalakítás nem sikerült: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Calibre adatbázis újracsatlakoztatása"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr "Archivált könyv referenciák törlése"
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan"
 msgstr "Ismétlődő könyv keresés"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan skipped: import in progress"
 msgstr "Ismétlődők keresése befejeződött: %(count)s új csoport"
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Ismétlődő könyvcsoport elutasítása"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Frissítési csomag kitömörítése"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Ismétlődő könyvek ellenőrzése ütemezve"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr "Ismétlődők keresése befejeződött: %(count)s csoport"
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr "Ismétlődők keresése befejeződött: %(count)s új csoport"
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 "Ismétlődők keresése befejeződött: %(count)s csoport automatikusan "
 "megszüntetve"
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Hardcover szinkronizáció engedélyezése"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "E-mail"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr "Metaadatok mentése"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr "Könyvtár konvertálás - teljes futás"
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 msgid "Convert Library"
 msgstr "Könyvtár konvertálás"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr "EPUB javító - teljes futás"
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr "CWA EPUB javító"
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "%(count)s borító bélyegkép generálva"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "Borító bélyegképek"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "{0} sorozat bélyegképei létrehozva"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "Borító bélyegképek gyorsítótárának törlése"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "Könyvek sorozat szerint rendezve"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Borítócsere"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Először válasszon ki könyvet"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "Oldalsó sáv megjelenítési beállítások"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Felhasználó beállítások"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "válassz egy lehetőséget"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 msgid "Add to Shelf"
 msgstr "Hozzáadás polchoz"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Nyilvános)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "Letöltések"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Letöltések"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "Létrehozva (legújabb elől)"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "Létrehozva (legrégebbi elől)"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Szerző"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Szerző"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Létrehozva (legújabb elől)"
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Létrehozva (legrégebbi elől)"
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Rendezés könyv polchoz adása szerint, legújabb elöl"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "Rendezés könyv polchoz adása szerint, legrégebbi elöl"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr "Felhasználók&nbsp;&nbsp;👤"
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "Küldés e-olvasóra e-mail"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 msgid "Send to eReader Subject"
 msgstr "Küldés e-olvasóra tárgy"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Könyvek mutatása"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Nyilvános polc"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr "Profil fotók kezelése"
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "LDAP felhasználók importálása"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "E-mail szerver beállításai&nbsp;&nbsp;📬"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "SMTP szervernév"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "SMTP port"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "SMTP felhasználó"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Küldő e-mail cím"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr "E-mail szolgáltatás"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail OAuth2-hitelesítéssel"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr "Beállítás&nbsp;&nbsp;⚙️"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Calibre adatbázis mappa"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Naplózási szint"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Külső port"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Könyvek oldalanként"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Feltöltések"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Böngészés bejelentkezés nélkül"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Nyilvános regisztráció"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Varázshivatkozás távoli belépés"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Reverse proxy belépés"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Reverse Proxy fejlécnév"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Alapbeállítások szerkesztése"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Felhasználói felület beállításai"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Calibre adatbázis beállításainak szerkesztése"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "Ütemezett feladatok&nbsp;&nbsp;⌛"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "Kezdési idő"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "Maximális időtartam"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr "Ütemezett címlapkép frissítés"
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "Sorozat borítók bélyegképeinek létrehozása"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Calibre adatbázis újracsatlakoztatása"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr "Metaadat biztonsági mentés létrehozása"
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "Bélyegképek gyorsítótárának frissítése"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 msgid "Setup KOReader Sync"
 msgstr "KOReader szinkronizáció beállítása"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr "Hardcover automatikus azonosító-lekérés futtatása"
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Adminisztráció&nbsp;&nbsp;🚀"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Hibakeresési csomag letöltése"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Logok megjelenítése"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Újraindítás"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Leállítás"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "Verzió információ&nbsp;&nbsp;📜"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Verzió"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Részletek"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "A frissítés nem sikerült:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Frissítési forrás"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Jelenlegi verzió"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Frissítés keresése"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Frissítés elkezdése"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Valóban újra akarja indítani a Calibre-Web Automatedet?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Valóban le akarja állítani a Calibre-Web Automatedet?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Frissítés folyamatban, ne töltse újra az oldalt"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7115,192 +6987,179 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import"
 msgstr "Fontos:"
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Könyvek ebben a könyvtárban"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Feltöltés..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "A frissítés nem sikerült:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Kapcsolódási hiba"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr "Megjegyzés:"
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Sorozat: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "keresztül"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "Könyvtárban"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "csökkentsd"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Több tőle:"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Könyv törlése"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Formátumok törlése:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Könyvformátum átalakítása:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Konvertálás erről:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr "válassz egy lehetőséget"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Konvertálás erre:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Könyv konvertálása"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Hiba"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Feltöltés formátuma"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "Sorozat sorszám"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Kiadás éve"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Azonosító típusa"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Azonosító értéke"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Eltávolítás"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Azonosító hozzáadása"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
@@ -7308,54 +7167,54 @@ msgstr ""
 "Válassz borítót bármilyen forrásból, illessz be egy URL-t, tölts fel egy "
 "fájlt, vagy használd a beépített borítót."
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Borító URL (jpg, borító letöltve és elmentve az adatbázisban, a mező újra "
 "üres lesz utána)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Borító feltöltése helyi meghajtóról"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 msgid "Hardcover Sync Blacklist"
 msgstr "Hardcover szinkronizáció tiltólista"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr "Kiemelések Hardcover szinkronizációjának tiltása"
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr "Olvasási állapot Hardcover szinkronizációjának tiltása"
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Könyv megnézése szerkesztés után"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Metaadatok beszerzése"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Kulcsszó"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "Keresőszó"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr "A kiválasztott metaadatok bekerültek a szerkesztő űrlapba."
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr "API kulcsok"
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
@@ -7366,178 +7225,169 @@ msgstr ""
 "használatát. A kulcsokat a rendszer egyszer tárolja az egész példányhoz — "
 "csak adminok férnek hozzá."
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Betöltés..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr "Rendezés:"
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr "Szolgáltatói sorrend (alapértelmezett)"
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr "Borítóméret — legnagyobb elöl"
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr "Borítóméret — legkisebb elöl"
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr "Alkalmaz"
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Keresési hiba!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "Nincs találat! Próbálj másik kulcsszót."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "Ez a mező kötelező"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr "Szerző és cím felcserélése"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 msgid "Select all"
 msgstr "Minden kijelölése"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr "Minden törlése"
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 msgid "Update Title Sort automatically  "
 msgstr "Cím rendezési formátum automatikus frissítése"
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Író rendezési formátum automatikus frissítése"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Cím bevitele"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Cím rendezési formátum bevitele"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Rendezési cím"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Író rendezési formátum bevitele"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Szerző rendezési név"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Szerzők bevitele"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Címkék bevitele"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Sorozatok bevitele"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Nyelvek bevitele"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Kiadás dátuma"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Kiadók bevitele"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Leírás bevitele"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Comments"
 msgstr "Leírás"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 msgid "Archived?"
 msgstr "Archiválva?"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 msgid "Read?"
 msgstr "Olvasva?"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "Bevitel "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Biztosan?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "Ezen című könyvek egyesítve lesznek innen:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "Az alábbi könyvvel:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr "A következő könyvek törlésre kerülnek:"
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr "A következő könyvek archiválva lesznek:"
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr "A következő könyvek archiválása vissza lesz vonva:"
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr "A következő könyvek olvasottra lesznek állítva:"
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr "A következő könyvek olvasatlanra lesznek állítva:"
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Metaadatok szerkesztése"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 "Módosítsa a kívánt mezőket. Az üres mezők nem kerülnek figyelembevételre:"
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
@@ -7545,25 +7395,24 @@ msgstr ""
 "Több érték támogatott szerzőkhöz, címkékhez, nyelvekhez és kiadókhoz. "
 "Vesszővel válassza el őket egymástól (pl.: \"Név1, Név2\")"
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 msgid "Select a Shelf"
 msgstr "Polc kiválasztása"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr "Válasszon egy polcot amire felkerülnek a kiválasztott könyvek:"
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr "-- Polc választása --"
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Hozzáadás"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
@@ -7571,164 +7420,164 @@ msgstr ""
 "Hoppá! Az e-mail szerver nincs beállítva. Kérjük, forduljon a "
 "rendszergazdához!"
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr "Üzenet"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Use current announcement banner text"
 msgstr "Szerverüzenet sáv"
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "E-olvasó e-mail címek kiválasztása"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send announcement"
 msgstr "Szerverüzenet sáv"
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Küldés e-olvasóra"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Vissza"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Calibra adatbázis helye (metadata.db fájl)"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7744,13 +7593,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7761,7 +7610,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7778,11 +7627,11 @@ msgstr ""
 "bejelölése \n"
 "után a megjelenő mezőben adja meg a <code>/books</code> útvonalat."
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr "Könyvfájlok elkülönítése a könyvtártól"
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
@@ -7792,31 +7641,31 @@ msgstr ""
 "fájlnak a <code>/calibre-library</code>-ban kell maradnia, de a könyv fájlok "
 "bárhol lehetnek"
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Használjon Google Drive-ot?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Google Drive hitelesítés"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Google Drive Calibre mappa"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "Metadata Watch Channel ID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Visszavonás"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Végső lehetőség: Calibre adatbázis helyreállítása (kísérleti)"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7833,87 +7682,87 @@ msgstr ""
 "automatikusan mentésre kerül a /config/backup mappába bármilyen romboló "
 "művelet előtt.</b> A visszaállítási napló a mentésekkel együtt lesz elmentve."
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 msgid "Are you sure? This cannot be undone."
 msgstr "Biztos benne? A művelet nem visszavonható."
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Calibra adatbázis helyreállítása (Végső lehetőség)"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr "Új adatbázis útvonal helytelen, érvényes útvonalat adjon meg"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Alap bejelentkezés használata"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "LDAP bejelentkezés használata"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "OAuth használata"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Szerver beállítások"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Szerver port"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL hitelesítő fájl helye (nem SSL szerverekhez üresen kell hagyni)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL kulcsfájl helye (nem SSL szerverekhez üresen kell hagyni)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Frissítési forrás"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Stabil"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Éjszakai"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "Megbízható címek (vesszővel elválasztva)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Naplózási beállítások"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "Naplófájl neve és helye (üresen hagyva: /dev/stdout)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Elérési napló engedélyezése"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "Elérési naplófájl helye és neve (üresen hagyva: access.log)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 msgid "Feature Configuration"
 msgstr "Funkció beállítások"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr "Mentéskor a cím és a szerző nem angol karaktereinek konvertálása"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
@@ -7921,39 +7770,39 @@ msgstr ""
 "Metaadatok beágyazása letöltéskor/konvertáláskor/e-mailben küldéskor "
 "(Calibre/Kepubify futtatható állományok szükségesek)"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Feltöltés engedélyezése"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr "(Győződjön meg róla, hogy a felhasználóknak van feltöltési engedélye)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Engedélyezett feltöltési formátumok"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Böngészés bejelentkezés nélkül engedélyezése"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Nyilvános regisztráció engedélyezése"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "E-mail használata felhasználónévként"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Távoli belépés engedélyezése (\"varázs-hivatkozás\")"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr "Felhasználók elrejthetik a könyveket a saját könyvtárukból"
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7961,45 +7810,45 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Az ismeretlen kérések Kobo Áruházba irányítása"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Szerver külső port (port továbbított API hívásokhoz)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 "Kobo kiemelések szinkronizációja Hardcoverbe (API-kulcs felhasználónként "
 "szükséges)"
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr "Könyvborítók igazítása a Kobo képarányához"
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
@@ -8010,68 +7859,68 @@ msgstr ""
 "kijelzőével. A kitöltés a szerver oldalon történik; az eredeti borítófájlok "
 "a lemezen változatlanok maradnak."
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr "Kobo Libra Color / Libra 2 (1264x1680)"
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr "2:3 (kiadói borító, nincs kitöltés a tipikus borítóknál)"
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr "Egyszínű: a borító leggyakoribb színe"
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr "Egyszínű: a borító átlagos színe"
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr "Egyszínű: egyéni szín"
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr "Egyéni szegélyszín (hex)"
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 "Csak akkor használatos, ha a kitöltési stílus 'Egyszínű: egyéni szín'. "
 "Formátum: #RRGGBB."
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Goodreads használata"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Goodreads API-kulcs"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 msgid "Enable Hardcover Sync"
 msgstr "Hardcover szinkronizáció engedélyezése"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr "Hardcover API kulcs"
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
@@ -8079,44 +7928,44 @@ msgstr ""
 "Ingyenes api kulcs https://hardcover.app/account/api — szükséges a Hardcover "
 "metaadatokhoz."
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "A token érvényessége lejárt"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 msgid "Google Books API Key"
 msgstr "Google Books API-kulcs"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8128,11 +7977,11 @@ msgstr ""
 "Ingyenes kulcs itt: Google Cloud Console\n"
 " — engedélyezd a „Books API”-t, és hozz létre egy API kulcsot."
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Reverse Proxy hitelesítés engedélyezése"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
@@ -8142,11 +7991,11 @@ msgstr ""
 "megbízik. Ez egy külön hitelesítési mód, elkülönül az alábbi HTTPS "
 "biztonsági beállítástól."
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr "Használat HTTPS-sel"
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
@@ -8155,11 +8004,11 @@ msgstr ""
 "engedélyezd, ha HTTPS-en keresztül éred el a szervert, különben ki fogsz "
 "záródni."
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr "Felhasználók automatikus létrehozása reverse proxyból"
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
@@ -8169,79 +8018,79 @@ msgstr ""
 "fejléceket kap. Csak akkor kapcsold be, ha a reverse proxy hitelesítés "
 "megfelelően védett és biztonságosan van beállítva."
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Bejelentkezési mód"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr "OAuth használata (HTTPS kötelező)"
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "LDAP szerver neve vagy IP címe"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "LDAP szerver port"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "LDAP titkosítás"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "LDAP CA-tanúsítvány elérési útja (csak kliensoldali tanúsítványalapú "
 "hitelesítéshez szükséges)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "LDAP tanúsítvány elérési útja (csak kliensoldali tanúsítványalapú "
 "hitelesítéshez szükséges)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "LDAP kulcsfájl elérési útja (csak kliensoldali tanúsítványalapú "
 "hitelesítéshez szükséges)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "LDAP hitelesítés"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Egyszerű"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "LDAP adminisztrátor felhasználónév"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "LDAP rendszergazda jelszó"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "LDAP Distinguished Name (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "LDAP felhasználói objektumszűrő"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "Az LDAP szerver OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr "Felhasználók automatikus létrehozása LDAP-ról"
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
@@ -8250,43 +8099,43 @@ msgstr ""
 "felhasználói fiókokat az új felhasználók számára. Vállalati környezetekben "
 "ajánlott."
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr "A következő beállítások szükségesek felhasználó importhoz"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "LDAP csoport objektumszűrő"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "LDAP csoport név"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "LDAP csoporttag mező"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "LDAP tagsági felhasználói szűrő felismerése"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "Automatikus észlelés"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "Egyedi szűrő"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "LDAP tagsági felhasználói szűrő"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr "Fontos:"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
@@ -8294,27 +8143,27 @@ msgstr ""
 "Az OAuth hitelesítéshez a szervert HTTPS-en keresztül kell elérni. Ha HTTP-t "
 "használsz, a bejelentkezés sikertelen lesz."
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr "Általános OAuth szolgáltató"
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr "OAuth metaadat URL (automatikus felfedezéshez)"
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 msgid "Test Metadata"
 msgstr "Metaadat tesztelés"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr "Hagyja üresen a manuális konfiguráció használatához"
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr "Manuális végpont URL használata (felülírja az automatikus felfedezést)"
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
@@ -8322,43 +8171,43 @@ msgstr ""
 "Jelölje be, ha az OAuth egyes végpontjait manuálisan szeretné konfigurálni "
 "az automatikus felfedezés helyett"
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 msgid "Manual Endpoint Configuration"
 msgstr "Kézi végpont beállítás"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr "OAuth alap URL"
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr "Azonosítási végpont"
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 msgid "Token Endpoint"
 msgstr "Token végpont"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr "UserInfo végpont"
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 msgid "Test Connection"
 msgstr "Kapcsolat tesztelése"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 msgid "OAuth Scopes"
 msgstr "OAuth hatókörök"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr "OAuth jogosultságok szóközzel felsorolva"
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr "OAuth átirányítási cím"
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
@@ -8368,7 +8217,7 @@ msgstr ""
 "„érvénytelen redirect URI” hibákat. A protokollt is add meg (https://). "
 "Hagyd üresen, ha automatikus felismerést szeretnél."
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
@@ -8376,70 +8225,70 @@ msgstr ""
 "Kötelező, ha több hostnéven keresztül éred el, reverse proxy mögött fut, "
 "vagy „érvénytelen redirect URI” hibát kapsz."
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 msgid "OAuth Client Id"
 msgstr "OAuth kliens azonosító"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 msgid "OAuth Client Secret"
 msgstr "OAuth kliens titok"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 msgid "Field Mapping Configuration"
 msgstr "Mező-hozzárendelés beállításai"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 msgid "Username Field"
 msgstr "Felhasználónév mező"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr "JWT mező felhasználónév kinyeréséhez"
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 msgid "Email Field"
 msgstr "E-mail mező"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr "JWT mező e-mail kinyeréséhez"
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "OAuth rendszergazda csoport"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr "OAuth rendszergazda csoport"
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
@@ -8449,101 +8298,101 @@ msgstr ""
 "csoportalapú admin kezelés kikapcsolásához, vagy használd a globális "
 "beállítást a Biztonsági beállításoknál a részletesebb szabályozáshoz."
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Új felhasználók alapértelmezett beállításai"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Letöltés engedélyezése"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "E-könyv olvasó engedélyezése"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Feltöltés engedélyezése"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Szerkesztés engedélyezése"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Könyv törlés engedélyezése"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Jelszó változtatásának engedélyezése"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Nyilvános polcok szerkesztésének engedélyezése"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr "Bejelentkezési gomb felirat"
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "%(provider)s OAuth hitelesítő adat beszerzése"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "%(provider)s OAuth kliens azonosító"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "%(provider)s OAuth kliens titok"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Külső futtatható fájlok"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr "Calibre futtatható fájlok elérési útvonala"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 msgid "Calibre E-Book Converter Settings"
 msgstr "Calibre e-könyv konvertáló beállításai"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Kepubify e-könyv konvertáló elérési útvonala"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 msgid "Location of Unrar binary"
 msgstr "Unrar elérési útvonala"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 msgid "Security Settings"
 msgstr "Biztonsági beállítások"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr "Alap bejelentkezés letiltása (Felhasználónév/Jelszó)"
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
@@ -8552,11 +8401,11 @@ msgstr ""
 "vagy LDAP-on keresztül tudnak belépni. Bekapcsolás előtt győződj meg róla, "
 "hogy van működő alternatív bejelentkezési mód."
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr "OAuth csoportalapú adminisztrátori szerepkörkezelés engedélyezése"
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8568,87 +8417,87 @@ msgstr ""
 "kézzel akarod kezelni az admin szerepköröket a felhasználókezelő panelen, "
 "így az OAuth bejelentkezések nem írják felül a helyi szerepkörbeállításokat."
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr "Bejelentkezési kísérletek korlátozása"
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr "Limiter backend beállítása"
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr "Limiter backend opciói"
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr "Ellenőrizze, hogy a fájlformátum passzol-e a tartalomhoz feltöltéskor"
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 msgid "Session protection"
 msgstr "Munkamenet védelem"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr "Alap"
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr "Erős"
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 msgid "User Password policy"
 msgstr "Jelszó megkötések"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr "Minimum jelszóhossz"
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr "Szám kötelező"
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr "Kisbetű kötelező"
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr "Nagybetű kötelező"
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr "Karakter kötelező (szükséges kínai/japán/koreai karakterekhez)"
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr "Speciális karakter kötelező"
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Általános beállítások"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr "A böngészőfülön és a navigációs sávban megjelenő cím."
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr "Az oldalanként megjelenített könyvek száma lista nézetben (1–200)."
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Találomra mutatott könyvek száma"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr "A főoldalon megjelenő véletlenszerű könyvek száma (1–30)."
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr "Mutatott szerzők száma (0=elrejtés kikapcsolása)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
@@ -8656,15 +8505,15 @@ msgstr ""
 "A könyv részleteinél megjelenített szerzők maximális száma, mielőtt a lista "
 "csonkolásra kerül. 0-ra állítva kikapcsolható."
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 msgid "Default Theme"
 msgstr "Alaptéma"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "caliBlur! sötét téma"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
@@ -8672,39 +8521,39 @@ msgstr ""
 "Alapértelmezett téma új felhasználóknak és névtelen böngészéshez. A "
 "felhasználók választhatnak saját témát a profiljukban."
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Reguláris kifejezés oszlopok kihagyásához"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr "Regex minta az egyéni oszlopok elrejtéséhez a felületen."
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Olvasva/olvasatlan állapot hozzárendelése Calibre oszlophoz"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr ""
 "Olvasva/olvasatlan állapot szinkronizálása egy Calibre igen/nem oszloppal."
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Megtekintési korlátozás Calibre oszlop alapján"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 "A könyvek láthatóságát egy Calibre szöveges egyéni oszlopban lévő értékek "
 "alapján korlátozza."
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Reguláris kifejezés címek sorbarendezéséhez"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
@@ -8712,15 +8561,15 @@ msgstr ""
 "Reguláris kifejezés, amellyel a címek elejéről eltávolíthatók az előtagok a "
 "helyes rendezés érdekében (pl. „The”, „A”, „An”)."
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 msgid "Site Customization"
 msgstr "Oldal testreszabása"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr "Szerverüzenet sáv"
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
@@ -8728,7 +8577,7 @@ msgstr ""
 "Hagyd üresen a sáv elrejtéséhez. Az oldal tetején jelenik meg, amíg minden "
 "felhasználó el nem rejti."
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
@@ -8736,107 +8585,107 @@ msgstr ""
 "Legfeljebb 500 karakter. A HTML escape-elve van. Minden felhasználó külön "
 "rejti el a sávot; a szöveg módosítása újra megjeleníti mindenkinek."
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Custom CSS"
 msgstr "Egyedi szűrő"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Új felhasználók alapértelmezett beállításai"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 "Ezek a beállítások minden újonnan létrehozott felhasználói fiókra érvényesek "
 "lesznek."
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 msgid "Permissions"
 msgstr "Engedélyek"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Rendszergazda felhasználó"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 msgid "Language & Display"
 msgstr "Nyelv és megjelenés"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "Alapnyelv"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 msgid "Default interface language for new users."
 msgstr "Új felhasználók alapértelmezett nyelve."
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "Látható könyvek alapértelmezett nyelve"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 msgid "Default book language filter for new users."
 msgstr "Alapértelmezett könyv nyelv szűrő új felhasználóknak."
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Új felhasználók alapértelmezett látható elemei"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 "Válassza ki, mely oldalsávszakaszok legyenek alapértelmezetten láthatók az "
 "új felhasználóknál."
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Mutasson könyveket találomra a részletes nézetben"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Engedélyezett/tiltott címkék hozzáadása"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Engedélyezett/tiltott egyedi oszlop értékek megadása"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr "URL használata"
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 msgid "Upload a file"
 msgstr "Fájl feltöltése"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
@@ -8847,12 +8696,12 @@ msgstr ""
 "korlátait. A kulcsokat a rendszer egyszer tárolja az egész példányhoz — csak "
 "adminok férnek hozzá."
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Show how each cover would look on your e-reader"
 msgstr "Borítók megjelenítése Kobo nézetben"
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
@@ -8860,60 +8709,55 @@ msgstr ""
 "Itt állíthatod, hogyan jelenjen meg a borító előnézet. Az alapértelmezett "
 "beállítások az Admin → Konfiguráció → Kobo szinkron menüben találhatók."
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr "Jelöltek"
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr "Jelöltek betöltése…"
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr "Lecseréli a borítót erre a jelöltre?"
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Rendering e-reader previews:"
 msgstr "Kobo előnézetek renderelése:"
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run Archive"
 msgstr "Korábbi futások"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 msgid "Download Log"
 msgstr "Napló letöltése"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Kezdés"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr "Időzítés 5p"
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr "Időzítés 15p"
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr "Könyvtár konverzió sikeresen ütemezve"
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr "Hiba könyvtár konverzió ütemezésekor"
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8922,14 +8766,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8937,87 +8781,86 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr "Futtatás egy könyvön"
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr "Keresés cím/író alapján"
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on selected book"
 msgstr "Futtatás kiválasztott könyvön"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer scheduled successfully"
 msgstr "EPUB javító sikeresen beütemezve"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error scheduling EPUB Fixer"
 msgstr "Hiba EPUB javító ütemezésekor"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 msgid "No matches found"
 msgstr "Nem található egyezés"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 msgid "Enter a search term"
 msgstr "Írjon be keresőszót"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 msgid "Failed to search library"
 msgstr "Nem sikerült keresni a könyvtárban"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 msgid "Select a book first"
 msgstr "Először válasszon ki könyvet"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer started for selected book"
 msgstr "EPUB javító elindult a kijelölt könyvekhez"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error starting EPUB Fixer"
 msgstr "Hiba EPUB javító indításakor"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Calibre-Web Automated szolgáltatások engedélyezése/tiltása"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -9025,11 +8868,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -9040,11 +8883,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -9054,7 +8897,7 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
@@ -9064,18 +8907,18 @@ msgstr ""
 "fix.netlify.app</a> alapján készült, amelyet <a href=\"https://github.com/"
 "innocenat\">innocenat</a> fejlesztett."
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
@@ -9086,11 +8929,11 @@ msgstr ""
 "futó visszapótlást akarsz leállítani, a kikapcsolás után indítsd újra a "
 "konténert."
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr "Agresszívabb EPUB javító engedélyezése (veszélyesebb)"
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
@@ -9099,11 +8942,11 @@ msgstr ""
 "alacsonyabb biztonságú kódolás-konverziókat is megpróbál. A biztonságos mód "
 "a legtöbb könyvtárhoz ajánlott."
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 msgid "Enable Archived Book Cleanup"
 msgstr "Archivált könyvek tisztításának engedélyezése"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
@@ -9112,116 +8955,116 @@ msgstr ""
 "ből, ha a könyv már nem létezik a Calibre könyvtárban. Segít az archivált "
 "számok pontosan tartásában."
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr "Tisztogatás ütemezés:"
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr "Gyakori intervallumok"
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr "Minden 15 percben"
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr "Minden 30 percben"
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr "Minden órában"
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr "Minden 2 órában"
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr "Minden 4 órában"
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr "Minden 6 órában"
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr "Minden 12 órában"
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr "Napi/Heti/Havi"
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr "Naponta adott időben"
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr "Hetente adott napon"
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr "Havonta adott napon"
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr "Alapértelmezetten: naponta 3:00 órakor"
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr "Hét napja:"
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr "Hétfő"
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr "Kedd"
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr "Szerda"
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr "Csütörtök"
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr "Péntek"
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr "Szombat"
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr "Vasárnap"
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr "Hónap napja"
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr "(1-28)"
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr "Időpont:"
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr "(Szerver időzóna: %(tz)s)"
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr "Automatikus metaadat letöltés új könyvekhez engedélyezése"
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9229,11 +9072,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr "Okos metaadat hozzárendelés engedélyezése"
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9245,11 +9088,11 @@ msgstr ""
 "nagyobb felbontású borító). Ha ki van kapcsolva, a preferált szolgáltatótól "
 "érkező metaadatok változtatás nélkül felülírják a meglévő adatokat."
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 msgid "Metadata Fields to Update"
 msgstr "Frissítendő metaadat mezők"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
@@ -9259,25 +9102,23 @@ msgstr ""
 "kijelöletlen mezőket a rendszer soha nem módosítja automatikus metaadat-"
 "felvétel során, így a meglévő adataid megmaradnak."
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr "Címkék"
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Azonosítók (ISBN, stb.)"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 msgid "Cover Image"
 msgstr "Borítókép"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr "Tipp"
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
@@ -9288,15 +9129,15 @@ msgstr ""
 "Direct mód minden kijelölt mezőt egyszerűen felülír a szolgáltatótól kapott "
 "adatokkal."
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr "Borítókép maximum méret (MB):"
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr "Intervallum: 1-200 MB (alap: 15)"
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
@@ -9304,11 +9145,11 @@ msgstr ""
 "Korlátozza a metaadat-szolgáltatóktól vagy URL-ekről letöltött borítóképek "
 "maximális méretét, hogy elkerülje a lassú vagy elakadt mentéseket."
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr "Beolvasási feldolgozás időkorlát"
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
@@ -9318,19 +9159,19 @@ msgstr ""
 "időtúllépés történik. A túllépett fájlok a hibás mentési mappába kerülnek "
 "kivizsgálásra."
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr "Időkorlát (percben)"
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr "Intervallum: 5-120 perc (alap: 15)"
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr "Elavult ideiglenes fájlok törlése"
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
@@ -9340,27 +9181,27 @@ msgstr ""
 "idő után törölhetők. Ha bármelyik értéket 0-ra állítod, a tisztítás "
 "kikapcsol. A módosítások a következő tisztítási ciklusban lépnek életbe."
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr "Ideiglenes fájlok elavulási ideje (percben):"
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr "Intervallum: 0-10080 perc (alap: 120)"
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr "Elavult ideiglenes fájlok törlésének intervalluma (másodperc):"
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr "Intervallum: 0-86400 másodperc (alap: 600)"
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr "Automatikus küldés késleltetése új könyveknél"
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9372,19 +9213,19 @@ msgstr ""
 "feldolgozások befejezésének a küldés előtt. Csak azokra a felhasználókra "
 "vonatkozik, akik engedélyezték az automatikus küldést a profiljukban."
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr "Késleltetés (percben):"
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr "Intervallum: 1-60 perc (alap: 5)"
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr "Szolgáltatók rangsora automatikus metaadat letöltéshez"
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
@@ -9394,25 +9235,25 @@ msgstr ""
 "metaadatainak automatikus lekérésekor. A szolgáltatók sorrendje fogd és vidd "
 "módszerrel módosítható. Csak az engedélyezett szolgáltatók lesznek használva."
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 "A szolgáltatók felülről lefelé haladva kerülnek kipróbálásra. Húzd át őket a "
 "sorrend módosításához."
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr "Engedélyezett metaadat szolgáltatók"
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr "Bepipálatlan szolgáltatók globálisan letiltva."
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Hardcover automatikus azonosító-lekérés beállításai"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
@@ -9422,11 +9263,11 @@ msgstr ""
 "könyveihez. Ezek segítségével szinkronizálható az olvasási folyamat és a "
 "jegyzetek a Hardcover.app alkalmazással, kompatibilis e-olvasókon."
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr "Hardcover token kötelező"
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
@@ -9437,18 +9278,18 @@ msgstr ""
 "között, vagy be kell állítanod egy globális tokent az Alap konfigurációban. "
 "Érvényes token nélkül ez a funkció letiltva marad."
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
@@ -9459,24 +9300,24 @@ msgstr ""
 "automatikusan alkalmazásra kerülnek, az alacsony megbízhatóságúak pedig "
 "manuális ellenőrzési sorba kerülnek."
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr "Futási időzítés:"
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 "Milyen gyakran fusson automatikusan a Hardcover azonosítók lekérési feladata"
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr "Minimális bizonyossági küszöb:"
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr "Intervallum: 0.50-1.00 (alap: 0.85)"
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
@@ -9487,15 +9328,15 @@ msgstr ""
 "kerülnek. A magasabb érték kevesebb automatikus egyezést, de nagyobb "
 "pontosságot jelent."
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr "Tételmennyiség:"
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr "Tartomány: 10–200 könyv futásonként (alapértelmezett: 50)"
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
@@ -9504,15 +9345,15 @@ msgstr ""
 "csökkentik az API terhelését, a nagyobb kötegek gyorsabban feldolgozzák a "
 "könyvtárat."
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr "Korlátozás miatti késleltetés (másodpercben):"
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr "Intervallum: 0-60 másodperc (alap: 5.0)"
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
@@ -9521,33 +9362,33 @@ msgstr ""
 "és védi az API kulcsot. Hibák esetén exponenciális visszalépést (backoff) "
 "használ."
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 msgid "Web UI Settings"
 msgstr "Webes felület beállításai"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "Automatikus biztonsági mentés beállításai"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9555,36 +9396,35 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr "Fordításra felhívó értesítés engedélyezése"
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -9593,11 +9433,11 @@ msgstr ""
 "Kikapcsolása esetén nem fog értesítéseket kapni a Web UI-ban ha angoltól "
 "eltérő nyelvet használ, aminek a fordítási állapota nem teljes."
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Kiválasztott varázspolcok szinkronizációja Kobo eszközzel"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
@@ -9606,11 +9446,11 @@ msgstr ""
 "eszközödre. Megjegyzés: a Kobo Sync-et is engedélyezned kell az Alap "
 "konfigurációban."
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Homályos háttér engedélyezése mobileszközökön (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -9618,15 +9458,15 @@ msgstr ""
 "Engedélyezés esetén a homályos háttér hatás kis kijelzőkön is megjelenik. "
 "Kapcsolja ki amennyiben görgetési vagy animáció szaggatást észlel,"
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 msgid "Automatic Backup Settings"
 msgstr "Automatikus biztonsági mentés beállításai"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -9634,11 +9474,11 @@ msgstr ""
 "Engedélyezés esetén egy másolat készül az importált fájlokról a <i>/config/"
 "processed_books/imported</i> mappába"
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -9646,21 +9486,21 @@ msgstr ""
 "Engedélyezés esetén egy másolat készül a beolvasott könyvek eredetijéről "
 "amelyek konvertáláson esnek át a /config/processed_books/converted mappába"
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9673,11 +9513,11 @@ msgstr ""
 "tarthatja a /config/processed_books almappáit és csökkentheti a szükséges "
 "tárterületet."
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -9687,32 +9527,32 @@ msgstr ""
 "automatikusan az itt kiválasztott formátumra lesz konvertálva (kivéve az "
 "alább az ignorálási listában megadott formátumokat)."
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 msgid "Choose a target format:"
 msgstr "Válasszon célformátumot:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9720,21 +9560,21 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "A Calibre importáláskor képes felismerni az azonos könyvcímeket, és ennek "
 "megfelelően a"
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr "automatikus egyesítés"
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -9742,34 +9582,34 @@ msgstr ""
 "beállítástól függően. Beállítható úgy, hogy törölje a duplikált könyvek "
 "egyik példányát, vagy mindkettőt megtartsa (alapértelmezett)."
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Elveti a duplikált importot, a könyvtári példányt megtartja"
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr "Felülírja a könyvtári példányt az újonnan importált fájllal"
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Duplikált rekordot hoz létre, mindkét példányt megtartja"
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
@@ -9777,31 +9617,31 @@ msgstr ""
 "Engedélyezi vagy letiltja a duplikátum-észlelő rendszert. Kikapcsolt "
 "állapotban a duplikátumkeresés nem fut le, és nem jelennek meg értesítések."
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Detection"
 msgstr "Ismétlődő könyvek felismerésének engedélyezése"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr "Ismétlődő könyvek felismerésének módja"
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr "Hibrid (SQL előszűrő + Python validáció)"
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr "Csak Python (leglassabb, legstabilabb)"
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr "Régi csak SQL (kísérleti)"
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
@@ -9810,11 +9650,11 @@ msgstr ""
 "szűkítésére, majd a végső eredményekhez egy megbízhatóbb Python logikát "
 "alkalmaz."
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 msgid "Automatic Duplicate Scanning"
 msgstr "Automatikus ismétlődő könyv keresés"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
@@ -9822,27 +9662,27 @@ msgstr ""
 "Állítsd be a háttérben futó duplikátum-ellenőrzéseket. Ezek automatikusan "
 "futnak, és nem blokkolják a felhasználói felületet."
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr "Automatikus ismétlődő könyv kereső engedélyezése"
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr "Import utáni keresés"
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr "Futás minden import után (várakoztatva)"
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr "Csak kézi"
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr "Várakozás importálás után (másodpercben)"
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
@@ -9850,15 +9690,15 @@ msgstr ""
 "Ennyi másodpercet vár az utolsó import után, mielőtt elindítaná a háttérben "
 "futó ellenőrzést."
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr "Időzített keresések (cron kifejezés)"
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr "Hagyja üresen az ütemezett keresés letiltásához. Példa:"
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
@@ -9867,15 +9707,15 @@ msgstr ""
 "lefuthatnak. A „csak manuális” opcióval az import utáni ellenőrzések "
 "letilthatók, miközben a cron ütemezések továbbra is aktívak maradnak."
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr "Következő időzített keresés:"
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
@@ -9885,31 +9725,31 @@ msgstr ""
 "könyvek duplikátumok-e. A könyveknek az összes kiválasztott feltételnek meg "
 "kell felelniük ahhoz, hogy duplikátumnak számítsanak."
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr "Vegye figyelembe a könyvcímeket a duplikátumok észlelésekor"
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr "Vegye figyelembe a szerzőket a duplikátumok észlelésekor"
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr "Vegye figyelembe a könyv nyelvét a duplikátumok észlelésekor"
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr "Vegye figyelembe a könyvsorozatot a duplikátumok észlelésekor"
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr "Vegye figyelembe a kiadót a duplikátumok észlelésekor"
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr "Vegye figyelembe a fájlformátumot a duplikátumok észlelésekor"
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
@@ -9917,11 +9757,11 @@ msgstr ""
 "Legalább egy feltételt ki kell választani. A cím és a szerző használata "
 "ajánlott alapkritériumként."
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr "Ismétlődő könyvek formátum rangsorolás"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
@@ -9932,11 +9772,11 @@ msgstr ""
 "formátumok sorrendje húzással módosítható, a magasabb pozíció nagyobb "
 "prioritást jelent."
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr "Tipp:"
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
@@ -9946,11 +9786,11 @@ msgstr ""
 "magasabb prioritású formátumokkal rendelkező könyvek kerülnek megtartásra. "
 "Az alacsonyabb prioritású formátumok törlésre kerülnek."
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr "Ismétlődő könyv értesítések és automatikus megszüntetés"
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
@@ -9958,11 +9798,11 @@ msgstr ""
 "Állítsd be, hogyan kapj értesítést a duplikált könyvekről, és opcionálisan "
 "engedélyezheted az automatikus feloldást is."
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Notifications"
 msgstr "Ismétlődő könyv értesítések"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
@@ -9973,15 +9813,15 @@ msgstr ""
 "felhasználók jelzést (badge-et) látnak a Duplikátumok oldalsáv gombon, "
 "valamint bejelentkezéskor értesítő felugró ablakot kapnak."
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Automatikus ismétlődés megszüntetés engedélyezése"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr "Figyelmeztetés:"
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
@@ -9989,77 +9829,77 @@ msgstr ""
 "Ez a funkció automatikusan törli a könyveket az alábbi stratégia alapján. Az "
 "eredeti fájlokról biztonsági mentés készül ide:"
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr "Megszüntetési stratégia"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr "Legújabb megtartása"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 "Törölje a régebbi példányokat, és a legutóbb hozzáadott könyvet tartsa meg"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr "Legrégebbi megtartása"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 "Törölje az újabb példányokat, és a legkorábban hozzáadott könyvet tartsa meg"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge Formats"
 msgstr "Formátumok egyesítése"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr "A formátumokat egyesíti a legújabb könyvbe, a többi példányt törli"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr "Legmagasabb minőségű formátum megtartása"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 "A formátumokat a Duplikátum Formátum Prioritási sorrended alapján részesíti "
 "előnyben"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep Most Metadata"
 msgstr "Legtöbb metaadat megőrzése"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr "Legtöbb információval rendelkező megtartása"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr "Legnagyobb méretű megtartása"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr "Legnagyobb méretű fájllal rendelkező könyv megtartása"
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 "Válaszd ki, melyik könyv maradjon meg a duplikátumok automatikus "
 "feloldásakor."
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 msgid "Rate Limiting"
 msgstr "Korlátozás"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr "Várakozási idő (percben)"
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
@@ -10067,7 +9907,7 @@ msgstr ""
 "Minimális idő az automatikus feloldások között (0 = kikapcsolva). "
 "Megakadályozza a gyors, egymás utáni törléseket tömeges importálások során."
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -10076,277 +9916,265 @@ msgstr ""
 "duplikátumokat észlel. Az elutasított duplikátumcsoportok soha nem kerülnek "
 "automatikus feloldásra."
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr "%(count)s függő találat ellenőrzése"
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr "Több megjelenítése"
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 #, fuzzy
 msgid "Something was broken or glitchy"
 msgstr "Valami hiba történt. Próbáld újra."
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Következő"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Legyen olvasatlan"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Legyen olvasott"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 msgid "Marked as read"
 msgstr "Olvasottnak jelölve"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 msgid "Marked as unread"
 msgstr "Olvasatlannak jelölve"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Hozzáadás archívumhoz"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Archiválás visszavonva"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Archiválás visszavonása"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Hozzáadás archívumhoz"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 msgid "Restored from archive"
 msgstr "Archiválás visszavonva"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Reloaded metadata from disk"
 msgstr "Engedélyezett metaadat szolgáltatók"
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Unhide from your library"
 msgstr "Polc elrejtése az oldalsávból"
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "Polc elrejtése az oldalsávból"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 msgid "Rating updated"
 msgstr "Értékelés frissítve"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 msgid "Rating cleared"
 msgstr "Értékelés törölve"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "%(index)s. könyv a %(range)s közül"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr "Azonosító"
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr "UUID"
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr "UUID kimásolva vágólapra"
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr "UUID nem másolható"
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr "UUID másolása"
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr "Fájl mérete"
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Ismertető:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 msgid "Select eReader Email Addresses"
 msgstr "E-olvasó e-mail címek kiválasztása"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 msgid "Choose email addresses:"
 msgstr "Válasszon e-mail címeket:"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 msgid "Select All"
 msgstr "Mind kiválasztása"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr "Más felhasználók e-olvasói:"
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr "További e-mail címek:"
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr "További e-mail címek megadása (vesszővel elválasztva):"
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr "pelda@domain.hu, masik@domain.hu"
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr "Adjon meg egy vagy több e-mail címet vesszővel elválasztva"
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 msgid "Select format:"
 msgstr "Formátum kiválasztása:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 msgid "Failed to update tags"
 msgstr "Címkék frissítése sikertelen"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 msgid "Failed to update shelves"
 msgstr "Polcok frissítése sikertelen"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
@@ -10354,63 +10182,63 @@ msgstr ""
 "Azonos című, szerzőjű és nyelvű könyvek. A különböző nyelvű könyvek nem "
 "számítanak duplikátumnak."
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Ismétlődő könyv keresés"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 msgid "Scan for Duplicates Now"
 msgstr "Ismétlődők keresése most"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr "Ismétlődők kiválasztása"
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 msgid "Select None"
 msgstr "Kijelölés megszüntetése"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 msgid "Delete Selected"
 msgstr "Kiválasztottak törlése"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Ismétlődő könyv keresés"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View Background Tasks"
 msgstr "Háttérfeladatok áttekintése"
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr "Ismétlődések automatikus megszüntetése"
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
@@ -10418,29 +10246,29 @@ msgstr ""
 "Automatikusan feloldja az összes duplikátumcsoportot úgy, hogy egy könyvet "
 "megtart, a többit pedig törli egy kiválasztott stratégia alapján."
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr "Stratégia:"
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 "Legújabbat tartja meg – a régebbi példányokat törli, és a legutóbb "
 "hozzáadott könyvet hagyja meg"
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 "Legrégebbit tartja meg – az újabb példányokat törli, és a legkorábban "
 "hozzáadott könyvet hagyja meg"
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 "Formátumok egyesítése – a formátumokat a legújabb könyvbe egyesíti, a többi "
 "példányt törli"
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
@@ -10448,62 +10276,62 @@ msgstr ""
 "Legjobb minőségű formátum megtartása – a formátumokat a Duplikátum Formátum "
 "Prioritási sorrended alapján részesíti előnyben"
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 "Legtöbb metaadat megtartása - Legtöbb metaadattal rendelkező könyv megtartása"
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 "Legnagyobb fájlméret megtartása – azt a könyvet tartja meg, amelynek a "
 "teljes fájlmérete a legnagyobb"
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 msgid "Preview"
 msgstr "Előnézet"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr "Megszüntetés végrehajtása"
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 "Ez véglegesen törli a könyveket. Az eredeti fájlokról biztonsági mentés "
 "készül ide:"
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 msgid "Merge Selected"
 msgstr "Kijelöltek egyesítése"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr "Ismétlődő könyvcsoport elutasítása"
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 msgid "View book details"
 msgstr "Könyv részletei"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 msgid "Edit book metadata"
 msgstr "Metaadatok szerkesztése"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 msgid "Archive/delete book"
 msgstr "Könyv archiválása/törlése"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 msgid "No Duplicate Books Found"
 msgstr "Nem található ismétlődő könyv"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 "A könyvtáradban nincs olyan könyv, amelynél a cím és a szerző kombinációja "
 "duplikált lenne."
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
@@ -10511,122 +10339,122 @@ msgstr ""
 "Ez a keresés azonos című ÉS szerzőjű könyveket keres, hogy elkerülje a téves "
 "egyezéseket."
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Execute Auto-Resolution"
 msgstr "Megszüntetés végrehajtása"
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Formátum kiválasztása:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr "A művelet nem visszavonható!"
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 msgid "The following books will be permanently deleted:"
 msgstr "A következő könyvek véglegesen törölve lesznek:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Merge Books"
 msgstr "Könyvek egyesítése"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 msgid "The following book will be kept:"
 msgstr "A következő könyvek meg lesznek tartva:"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "A következő könyvek egyesítve lesznek vele (és utána törölve)"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 "Megjegyzés: a forráskönyvek fájlformátumai hozzá lesznek adva a célkönyvhöz."
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr "Megszüntetés előnézete"
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr "Siker"
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr "A kijelölt duplikált könyvek sikeresen törlésre kerültek!"
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr "Hiba történt a kérés teljesítése közben."
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "E-mail fiók típusa"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr "Sima e-mail fiók"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr "Gmail fiók"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr "Gmail fiók beállítása"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Gmail elérés visszavonása"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "SMTP jelszó"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Csatolmány méretkorlát"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 msgid "Save and Send Test Email"
 msgstr "Mentés és teszt e-mail küldése"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Regisztráláshoz engedélyezett tartományok"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Tartomány hozzáadása"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Tartomány megadása"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Elutasított domainek (tiltólista)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr "(Varázs)"
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10634,23 +10462,23 @@ msgstr ""
 "Nyisd meg a .kobo/Kobo/Kobo eReader.conf fájlt egy szövegszerkesztőben, és "
 "add hozzá (vagy módosítsd):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Kobo token:"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "Lista"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr "Hardcover találatok ellenőrzése 🔖"
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr "Minden kész!"
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
@@ -10659,15 +10487,15 @@ msgstr ""
 "Új találatok akkor jelennek meg itt, amikor az automatikus lekérési feladat "
 "lefut."
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr "Vissza a beállítások oldalra"
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr "Ellenőrzés szükséges"
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
@@ -10677,11 +10505,11 @@ msgstr ""
 "ellenőrizd az egyes találatokat, és válaszd ki a helyeset, vagy hagyd ki / "
 "utasítsd el, ha nincs megfelelő egyezés."
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr "Függő találatok"
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
@@ -10691,66 +10519,60 @@ msgstr ""
 "egyezéseket. A nagy megbízhatóságú találatok automatikusan alkalmazásra "
 "kerülnek; ezeket manuálisan kell ellenőrizni."
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 msgid "Reject All Pending"
 msgstr "Minden függőben lévő elutasítása"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 msgid "Search Query"
 msgstr "Keresőkifejezés"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr "Lehetséges találatok"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr "Legjobb %(count)s"
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr "Bizonyosság"
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr "Találati ok"
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 msgid "View on Hardcover"
 msgstr "Megtekintés Hardcoveren"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr "Találat kiválasztása"
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 msgid "Reject All"
 msgstr "Minden elutasítása"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr "Átugrás mostanra"
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 msgid "Processing..."
 msgstr "Feldolgozás..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr "✓ Találat kiválasztása"
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr "Hiba találat alkalmazása közben"
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
@@ -10758,311 +10580,307 @@ msgstr ""
 "Biztosan el akarja utasítani az összes egyezést ehhez a könyvhöz? A művelet "
 "nem visszavonható."
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr "✗ Minden találat elutasítása"
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject match"
 msgstr "Elutasítás sikertelen"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr ""
 "Biztosan el akarja utasítani az összes függőben lévő egyezést? A művelet nem "
 "visszavonható."
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Pending"
 msgstr "✗ Minden függőben lévő elutasítása"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject all pending matches"
 msgstr "Minden függőben lévő elutasítása sikertelen"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr "→ Átugrás mostanra"
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr "Hiba átugrás közben"
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "Calibre-Web Automated nincs konfigurálva, keresse a rendszergazdát!"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Hibajegy létrehozás"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Vissza a kezdőlapra"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "Kijelentkezés"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr "Mobil értesítés"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 "A Magic shelf szerkesztése asztali gépen vagy tableten működik a legjobban."
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr "Polc frissítése a legújabb változtatásokkal"
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 msgid "Edit shelf rules"
 msgstr "Polc szabályok szerkesztése"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr "Polc elrejtése az oldalsávból"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Show this shelf in your sidebar"
 msgstr "Polc megjelenítése az oldalsávban"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 msgid "Show Shelf"
 msgstr "Polc mutatása"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 msgid "Hide Shelf"
 msgstr "Polc elrejtése"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Hozzáadás polchoz"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr "KOReader szinkronizáció letiltva."
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Kezdőlap"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Navigáció átkapcsolása"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Keresés könyvtárban"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Calibre-Web Automated e-könyv katalógus"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Kilépés"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 msgid "Settings"
 msgstr "Beállítások"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 msgid "Refresh Library"
 msgstr "Könyvtár frissítése"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Megjelenési információ nem érhető el"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Calibre-Web Automated e-könyv katalógus"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr "Változásnapló megtekintése"
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Ismétlődő könyvek"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr "Segíts te is!"
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Kérjük ne frissítse az oldalt!"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 msgid "Create Shelf"
 msgstr "Polc készítése"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr "Varázspolcok ✨"
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Előző"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Könyv részletei"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "A művelet nem visszavonható!"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Kiválasztottak törlése"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Fájlformátum"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Formátumok törlése:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 msgid "Duplicate Books Detected"
 msgstr "Ismétlődő könyvek találva"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr "A könyvtáradban feloldatlan duplikált könyvek vannak."
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 msgid "Duplicate Groups Found"
 msgstr "Ismétlődő csoport találva"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr "Emlékeztess később"
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr "Ismétlődések megtekintése és megszüntetése"
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Méretezés a legjobbra"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "Tipp"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfiguráció"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Hozzáadás polchoz"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Olvasottnak jelölve"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Olvasatlannak jelölve"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Könyv törlése"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Könyv törlése"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -11071,90 +10889,90 @@ msgstr ""
 "Ez véglegesen törli a könyveket. Az eredeti fájlokról biztonsági mentés "
 "készül ide:"
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Először válasszon ki könyvet"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Visszaállítás sikertelen: %(err)s"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr "Szűrés kezdőbetű alapján"
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "Rács"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 msgid "Show Password"
 msgstr "Jelszó mutatása"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Emlékezz rám"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Elfelejtette a jelszavát?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Belépés varázshivatkozással"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 msgid "Log in with SSO"
 msgstr "Belépés SSO-val"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 "A hagyományos bejelentkezés le van tiltva. Kérlek, használj egy alternatív "
 "bejelentkezési módot."
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Calibre-Web napló megtekintése: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Calibre-Web Log: "
 msgstr "Calibre-Web napló: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Folyamatos kimenet, nem jeleníthető meg"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Elérési napló megtekintése: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Calibre-Web napló letöltése"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "Elárési napló letöltése"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr "Rendszer sablon"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr "Ez egy előre beállított sablonpolc. Szabadon szerkeszthető."
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 msgid "Share with Everyone (Public)"
 msgstr "Megosztás mindenkivel (Publikus)"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
@@ -11163,50 +10981,50 @@ msgstr ""
 "szerkesztése” jogosultsággal rendelkező felhasználók szerkeszthetik vagy "
 "törölhetik."
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Engedélyezett/tiltott címkék kiválasztása"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Engedélyezett/tiltott egyedi oszlop értékek kiválasztása"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Fiók engedélyezett/tiltott címkéinek kiválasztása"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr "Fiók engedélyezett/tiltott egyedi oszlop értékeinek kiválasztása"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Címke bevitele"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Megtekintési korlátozás hozzáadása"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "Ez a könyv formátum véglegesen törölve lesz az adatbázisból"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "A könyv törölve lesz a Calibre adatbázisból"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr " és a merevlemezről"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Fontos Kobo megjegyzés: a törölt könyvek továbbra is megmaradnak minden "
 "párosított Kobo eszközön."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11214,284 +11032,284 @@ msgstr ""
 "A könyvek archiválása és az eszköz szinkronizálása szükséges ahhoz, hogy egy "
 "könyvet biztonságosan törölhessen."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Fájl kiálasztása"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "formátum"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "név"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "méret"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "Szülőmappa"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "Ok"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Calibre-Web Automated e-könyv katalógus"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "EPUB olvasó"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "Műveletek"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "Fekete"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "Betűméret"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Következő oldal"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr "Betűtípus"
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 msgid "Default"
 msgstr "Alap"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr "Yahei"
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr "SimSun"
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 msgid "KaiTi"
 msgstr "KaiTi"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 msgid "Arial"
 msgstr "Arial"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 msgid "Spread"
 msgstr "Elrendezés"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr "Két oszlop"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr "Egy oszlop"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Szöveg újratördelése amikor az oldalsávok nyitva vannak."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 #, fuzzy
 msgid "Note"
 msgstr "Megjegyzés:"
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Képregény olvasó"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Gyorsbillentyűk"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Előző oldal"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Következő oldal"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 msgid "Single Page Display"
 msgstr "Egyoldalas megjelenítés"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr "Görgethető megjelenítés"
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Méretezés a legjobbra"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Méretezés a szélességre"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Méretezés a magasságra"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Méretezés a natívra"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Forgatás balra"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Forgatás jobbra"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Kép tükrözése"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "Megjelenés"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 msgid "Single Page"
 msgstr "Egy oldal"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr "Görgethető"
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Méretezés"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Legjobb"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Szélesség"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Magasság"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Natív"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Forgatás"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Tökrözés"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Vízszintes"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Függőleges"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 msgid "Direction"
 msgstr "Irány"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Balról jobbra"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Jobbról balra"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr "Az elejére ugrás"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 msgid "Remember Position"
 msgstr "Pozíció megjegyzése"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "Görgetősáv"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "Megjelenítés"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "DJVU olvasó"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "PDF olvasó"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "TXT olvasó"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Új felhasználó regisztrálása"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Válassz egy felhasználónevet"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Az e-mail címed"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Varász hivatkozás - Új eszköz engedélyezése"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "Másik eszközön jelentkezzen be és látogassa meg:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr ""
 "Az első belépés után automatikusan be leszel léptetve ezen az eszközön."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Ez az ellenőrző link 10 perc múlva lejár."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
@@ -11499,259 +11317,255 @@ msgstr ""
 "Ütemezett karbantartás során automatikusan frissíti az összes bélyegképet. A "
 "bélyegképek ettől függetlenül mindig igény szerint is generálódnak."
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "Sorozat címlapkép létrehozás"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Nem található eredmény"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Keresőkifejezés:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Találatok a következőhöz:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Kiadás éve ettől: "
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Kiadás éve eddig: "
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr "Üres"
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Cimkék kizárása"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Sorozatok kizárása"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "Polcok kizárása"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Nyelvek kizárása"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Fájlformátumok"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Kiterjesztések kizárása"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Értékelés nagyob mint"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Értékelés kisebb mint"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "Ettől:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "Eddig:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Polc törlése"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "Polc tulajdonságok szerkesztése"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Rejtett könyvek"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "Könyvek kézi elrendezése"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "Sorrend változtatás tiltása"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "Sorrend változtatás engedélyezése"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Futtatás kiválasztott könyvön"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Legjobb %(count)s"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Könyv nem található."
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Polc törlése"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Could not add the books. Please try again."
 msgstr "Nem sikerült összekapcsolni az OAuth fiókot. Próbálja újra."
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Hozzáadás polchoz"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Keresés könyvtárban"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Keresés könyvtárban"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Nyilvános polc"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "Polcok szinkronizációja Kobo eszközzel"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Order saved"
 msgstr "Rendezési mód"
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Polc nem található"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Rejtett könyvek"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr "Rendezés"
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr "Még nincs átrendezhető polc."
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr "Húzd át a polcokat a kívánt sorrend kialakításához az oldalsávban."
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr "Sorrend mentve. Az oldalsáv a következő oldalbetöltéskor frissül."
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "A Calibre könyvár statisztikái"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Könyvek ebben a könyvtárban"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Szerzők ebben a könyvtárban"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Címkék ebben a könyvtárban"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Sorozatok ebben a könyvtárban"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Rendszer statisztika"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "Program"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Telepített verzió"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr "Háttérfeladatok áttekintése"
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Futásidő"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr "Műveletek"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr "Közelgő ütemezett küldések"
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr "Ütemezett idő"
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 msgid "State"
 msgstr "Állapot"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
@@ -11760,15 +11574,15 @@ msgstr ""
 "feladatként sorba állnak. A függőben lévő küldést a futás előtt bármikor "
 "törölheted."
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr "Közelgő ütemezett folyamatok"
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr "Típus"
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
@@ -11776,161 +11590,161 @@ msgstr ""
 "Az itt ütemezett Könyvtárkonverzió és EPUB javítás futások újraindítás után "
 "is megmaradnak. Töröld őket, ha nem akarod, hogy elinduljanak."
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 "Ez a feladat törlésre kerül. A feladat által elért eredmények el lesznek "
 "mentve."
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
 msgstr ""
 "Ha ez ütemezett feladat, akkor a következő ütemezett időpontban újra lefut."
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 msgid "Scheduled item cancelled successfully"
 msgstr "Beütemezett feladat sikeresen visszavonva"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr "Hiba ütemezett feladat visszavonása közben"
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Calibre-Web Automated e-könyv katalógus"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Portainer:"
 msgstr "Fontos:"
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Set up automatic updates"
 msgstr "Automatikus ismétlődő könyv kereső engedélyezése"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "Your Profile"
 msgstr "Profilod"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "User Settings"
 msgstr "Felhasználó beállítások"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr "Fiók információ"
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 "Ha módosítani szeretnéd az e-mail címedet vagy jelszavadat, itt megteheted."
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Felhasználó jelszavának alaphelyzetbe állítása"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 msgid "eReader Configuration"
 msgstr "E-olvasó beállítások"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 msgid "Send to eReader Email Address"
 msgstr "E-olvasóra küldés e-mail cím"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr "Több cím esetén vesszőt használj az elválasztáshoz"
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
@@ -11938,11 +11752,11 @@ msgstr ""
 "Az e-olvasó eszközeid e-mail címe(i). Több címet vesszővel elválasztva adj "
 "meg."
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr "„Küldés e-olvasóra” felugró ablak engedélyezése"
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
@@ -11952,7 +11766,7 @@ msgstr ""
 "lehetővé teszi további e-mail címek megadását, illetve a mentett címek közül "
 "csak egy kiválasztott részre történő küldést."
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
@@ -11960,11 +11774,11 @@ msgstr ""
 "Ha ki van kapcsolva, az e-mailek minden beállított e-olvasó címre elküldésre "
 "kerülnek külön megerősítés nélkül."
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr "Új könyvek automatikus küldése az e-olvasó(i)mra."
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
@@ -11972,108 +11786,108 @@ msgstr ""
 "Ha engedélyezve van, az újonnan hozzáadott könyvek automatikusan elküldésre "
 "kerülnek az összes fent megadott e-olvasó e-mail címre."
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr "Nyelv és téma beállítások"
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 msgid "Interface Language"
 msgstr "Felhasználói felület nyelve"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Mutasd a könyveket a következő nyelvvel"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr "Szűrje a könyvtárat, hogy csak az adott nyelvű könyvek jelenjenek meg."
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 msgid "Book Language Filter"
 msgstr "Látható könyvek nyelve"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr "OAuth és API integráció"
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "OAuth beállítások"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Összekapcsolás"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Szétkapcsolás"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr "Hardcover API token"
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr "API token Hardcover metaadat szolgáltató számára."
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Kobo szinkronizáció token"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Létrehozás/megtekintés"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "Erőltetett teljes Kobo szinkronizáció"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr ""
 "Csak a kiválasztott polcokon lévő könyveket szinkronizálja Kobo eszközzel"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr ""
 "Csak a kiválasztott polcokon lévő könyveket szinkronizálja Kobo eszközzel"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 msgid "Sidebar Display Settings"
 msgstr "Oldalsó sáv megjelenítési beállítások"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr "Válassza ki melyik elemek jelenjenek meg az oldalsávban."
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Engedélyezett/tiltott egyedi oszlop értékek megadása"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr "OPDS katalógus rendezés"
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
@@ -12082,7 +11896,7 @@ msgstr ""
 "sorrendben aló felsorolásával. Az ismeretlen azonosítók nem lesznek "
 "figyelembe véve, a hiányzó bejegyzések automatikusan hozzáadódnak."
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
@@ -12090,73 +11904,73 @@ msgstr ""
 "Húzással rendezze az OPDS gyökérbejegyzéseket. A hiányzó elemek "
 "automatikusan hozzáadódnak."
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr "Felhasználó engedélyek"
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr "Állítsa be milyen műveleteket hajthat végre ez a felhasználó."
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Order"
 msgstr "Varázspolc rendezés"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr "Válassza ki a varázspolcok rendezését az oldalsávban."
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr "Rendezési mód"
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr "Kézi (húzza az átrendezéshez)"
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr "Név (A-Z)"
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr "Név (Z-A)"
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr "Könyvek száma (többtől az alacsonyabbig)"
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr "Könyvek száma (alacsonytól a többig)"
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr "Létrehozva (legújabb elől)"
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr "Létrehozva (legrégebbi elől)"
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 msgid "Recently modified"
 msgstr "Nemrég szerkesztett"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr "Nemrég szerkesztett"
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 "Kézi rendezés csak akkor használatos amikor a rendezési mód kézire van "
 "állítva."
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr "Varázspolc láthatóság"
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
@@ -12165,33 +11979,33 @@ msgstr ""
 "oldalsávban. A rendszer polcok nem törölhetőek, csak elrejthetőek. Mások "
 "nyilvános polcai szintén elrejthetőek."
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr "Alapértelmezett rendszer polcok:"
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 msgid "Public Shelves:"
 msgstr "Nyilvános polcok:"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr "%(visible)s alapértelmezett polc látható ennyiből: %(total)s"
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr "%(visible)s nyilvános polc látható ennyiből: %(total)s"
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "A felhasználó törlése"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr "App jelszó az OPDS / KOReader Sync-hez"
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12205,12 +12019,12 @@ msgstr ""
 "megjelenő tokent. Bármely alkalmazásjelszó bármikor visszavonható anélkül, "
 "hogy ez befolyásolná az aktív webes munkamenetet."
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Új app jelszó"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, fuzzy, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
@@ -12218,140 +12032,140 @@ msgstr ""
 "Alkalmazásjelszó létrehozva ehhez: „%(label)s”. Másold ki most — később már "
 "nem fogod látni: %(token)s"
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr "pl.: Kobo Forma, KOReader iPad"
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 msgid "Create app password"
 msgstr "Új app jelszó"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr "Címke"
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 msgid "Created"
 msgstr "Létrehozva"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr "Utoljára használva"
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr "Soha"
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr "Vissza szeretné vonni az alkalmazás jelszavát?"
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Kobo bejelentkezési URL generálása"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr "Látható"
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Kiválasztás..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Kiválasztottak törlése"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "Felhasználó szerkesztése"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "Felhasználónév bevitele"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 msgid "Enter Email"
 msgstr "E-mail bevitele"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "Enter eReader Email"
 msgstr "E-olvasó e-mail bevitele"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "eReader Email"
 msgstr "E-olvasó e-mail"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 msgid "Enter eReader Email Subject"
 msgstr "E-olvasó e-mail tárgyának bevitele"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 msgid "eReader Email Subject"
 msgstr "E-olvasó e-mail tárgya"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Nyelv"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "Látható könyv nyelv"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "Engedélyezett címkék szerkesztése"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Engedélyezett címkék"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Tiltott címkék szerkesztése"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Tiltott címkék"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "Engedélyezett oszlop értékek szerkesztése"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "Engedélyezett oszlop értékek"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "Tiltott oszlop értékek szerkesztése"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "Tiltott oszlop értékek"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "Jelszó változtatás"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "Nyilvános polcok szerkesztése"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "Kiválasztott polcok szinkronizációja Kobo eszközzel"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "Kiválasztott polcok szinkronizációja Kobo eszközzel"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 msgid "Show Read/Unread Section"
 msgstr "Olvasott/olvasatlan mutatása"
 
@@ -12546,9 +12360,9 @@ msgstr "Olvasott/olvasatlan mutatása"
 #~ "        <a href=\"https://github.com/crocodilestick/Calibre-Web-Automated/"
 #~ "wiki/Configuration#database-configuration\">see here</a>!"
 #~ msgstr ""
-#~ "A CWA úgy van konfigurálva, hogy a Calibre adatbázisa (a <code>metadata."
-#~ "db</code> fájl) mindig a <code>/calibre-library</code> könyvtáron belül "
-#~ "helyezkedjen el. \n"
+#~ "A CWA úgy van konfigurálva, hogy a Calibre adatbázisa (a "
+#~ "<code>metadata.db</code> fájl) mindig a <code>/calibre-library</code> "
+#~ "könyvtáron belül helyezkedjen el. \n"
 #~ "Induláskor a CWA automatikusan átvizsgálja azt a könyvtárat, amelyet a "
 #~ "docker-compose fájlban a <code>/calibre-library</code> útvonalhoz "
 #~ "rendelt, és meglévő Calibre \n"

--- a/cps/translations/id/LC_MESSAGES/messages.po
+++ b/cps/translations/id/LC_MESSAGES/messages.po
@@ -19,33 +19,33 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Statistik"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 #, fuzzy
 msgid "Server restarted, please reload page."
 msgstr "Server dimulai ulang, harap muat ulang halaman"
 
-#: cps/admin.py:210
+#: cps/admin.py
 #, fuzzy
 msgid "Performing Server shutdown, please close window."
 msgstr "Mematikan server, silakan tutup jendela"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr ""
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Perintah tidak diketahui"
 
-#: cps/admin.py:232
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
@@ -53,223 +53,221 @@ msgstr ""
 "Uji email diantrean untuk dikirim ke %(email), harap periksa Tasks untuk "
 "hasilnya"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr ""
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 
-#: cps/admin.py:414
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover ID applied successfully"
 msgstr "{} pengguna berhasil dihapus"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr ""
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr ""
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr ""
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr ""
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr ""
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Halaman Admin"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "Pengaturan OAuth"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Pengaturan Dasar"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Pengaturan Antarmuka"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr "Kolom Kustom No.%(column)d tidak ada di basis data kaliber"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Edit pengguna"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Semua"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Pengguna tidak ditemukan"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} pengguna berhasil dihapus"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Tampilkan semua"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Permintaan salah"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "Nama Tamu tidak dapat diganti"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "Tamu tidak dapat memiliki peran ini"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr ""
 "Tidak ada pengguna admin yang tersisa, tidak dapat menghapus peran admin"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "Nilai harus benar atau salah"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Peran tidak valid"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr " Tamu tidak dapat mengakses tampilan ini"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr " Tampilan tidak valid"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr "Lokal Tamu ditentukan secara otomatis dan tidak dapat disetel"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Tidak Ada Lokal yang Valid Diberikan"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Tidak Ada Bahasa Buku yang Valid Diberikan"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Parameter tidak ditemukan"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "Pengaturan DB tidak dapat ditulisi"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Kolom Baca Tidak Valid"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Kolom Dibatasi Tidak Valid"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Apakah Anda yakin ingin menghapus Token Kobo?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "Apakah Anda yakin ingin menghapus domain ini?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "Apakah Anda yakin ingin menghapus pengguna ini?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Apakah Anda yakin ingin menghapus rak ini?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr ""
 "Apakah Anda yakin ingin merubah lokalisasi untuk pengguna yang dipilih?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "Apakah Anda yakin ingin merubah bahasa buku yang terlihat untuk pengguna "
 "yang dipilih?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr "Apakah Anda yakin ingin merubah peran untuk pengguna yang dipilih?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
@@ -277,7 +275,7 @@ msgstr ""
 "Apakah Anda yakin ingin mengubah batasan yang dipilih untuk pengguna yang "
 "dipilih?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -285,14 +283,14 @@ msgstr ""
 "Apakah Anda yakin ingin merubah batasan visibilitas untuk pengguna yang "
 "dipilih?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "Apakah Anda yakin ingin mengubah perilaku sinkronisasi rak untuk pengguna "
 "yang dipilih?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
@@ -300,123 +298,118 @@ msgstr ""
 "Apakah Anda yakin ingin mengubah perilaku sinkronisasi rak untuk pengguna "
 "yang dipilih?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Apakah Anda yakin ingin mengubah lokasi perpustakaan Calibre?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Tolak"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Izinkan"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "{} entri sinkronisasi dihapus"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Token tidak ditemukan"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Tag tidak ditemukan"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Tindakan Tidak Valid"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json Tidak Diatur Untuk Aplikasi Web"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "Lokasi Logfile tidak Valid, Harap Masukkan Jalur yang Benar"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "Akses Logfile Catatan tidak Valid, Harap Masukkan Jalur yang Benar"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr "Harap Masukkan Provider LDAP, Port, DN dan User Obect Identifier"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Masukkan Akun Layanan LDAP dan Kata Sandi"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "Masukkan Akun Layanan LDAP"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Filter Objek Grup LDAP Harus Memiliki Satu Pengidentifikasi Format \"%s\""
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "Filter Objek Grup LDAP Memiliki Tanda kurung yang Tak Berpasangan"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Filter Objek Pengguna LDAP harus Memiliki Satu Pengidentifikasi Format \"%s\""
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "Filter Objek Pengguna LDAP Memiliki Tanda kurung yang Tak Berpasangan"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Filter Pengguna Anggota LDAP harus Memiliki Satu Pengenal Format \"%s\""
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr ""
 "Filter Pengguna Anggota LDAP Memiliki Tanda Kurung yang Tak Berpasangan"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -424,29 +417,24 @@ msgstr ""
 "Lokasi LDAP Sertifikat CA, Sertifikat, atau Kunci tidak Valid, Harap "
 "Masukkan Jalur yang Benar "
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Tambah Pengguna Baru"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Edit Pengaturan Server Email"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr ""
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Kesalahan basis data: %(error)s"
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -454,53 +442,53 @@ msgstr ""
 "Uji email diantrean untuk dikirim ke %(email)s, harap periksa Tasks untuk "
 "hasilnya"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Terjadi kesalahan saat mengirim email tes: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Harap atur alamat email Anda terlebih dahulu.."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Setelan server email diperbarui"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "Edit pengguna"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Harap atur pengaturan email SMTP terlebih dahulu..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "Harap atur alamat email Anda terlebih dahulu.."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "Kata Sandi baru telah dikirimkan ke alamat email Anda"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -508,7 +496,7 @@ msgstr ""
 "Uji email diantrean untuk dikirim ke %(email)s, harap periksa Tasks untuk "
 "hasilnya"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -517,924 +505,909 @@ msgstr ""
 "Uji email diantrean untuk dikirim ke %(email)s, harap periksa Tasks untuk "
 "hasilnya"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "Edit Pengaturan Tugas Terjadwal"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "Waktu mulai tidak valid untuk tugas yang ditentukan"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "Durasi tidak valid untuk tugas yang ditentukan"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "Pengaturan tugas terjadwal diperbarui"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Terjadi kesalahan yang tidak diketahui. Coba lagi nanti."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "Judul"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Edit pengguna %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Kata sandi untuk pengaturan ulang pengguna %(user) "
 
-#: cps/admin.py:2296
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Harap atur pengaturan email SMTP terlebih dahulu..."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Penampil berkas log"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Meminta paket pembaruan"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Mengunduh paket pembaruan"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Mengekstrak paket pembaruan"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Mengganti berkas"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Koneksi basis data ditutup"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Menghentikan server"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Pembaruan selesai, silakan tekan OK dan muat ulang halaman"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Pembaruan gagal:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "Kesalahan HTTP"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Kesalahan koneksi"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Batas waktu saat membuat koneksi"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Kesalahan umum"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr "Berkas pembaruan tidak dapat disimpan di direktori temp"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "Berkas tidak dapat diganti selama pembaruan"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "Gagal mengekstrak setidaknya Satu Pengguna LDAP"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Gagal Membuat Sedikitnya Satu Pengguna LDAP"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Kesalahan: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr ""
 "Error: Tidak ada pengguna yang dikembalikan sebagai respons dari server LDAP"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "Setidaknya Satu Pengguna LDAP Tidak Ditemukan di Basis Data"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} Pengguna Berhasil Diimpor"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr ""
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "Lokasi Basis Data tidak Valid, Harap Masukkan Jalur yang Benar"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "Basis Data tidak dapat ditulisi"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "Lokasi keyfile tidak Valid, Harap Masukkan Jalur yang Benar "
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr "Lokasi Sertifikat tidak Valid, Harap Masukkan Jalur yang Benar "
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr ""
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "Pengaturan Basis Data diperbarui"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "Pengaturan Basis Data"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Harap masukkan seluruh isian!"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "Email bukan dari domain yang valid"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Tambahkan pengguna baru"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Pengguna '%(user)s' telah dibuat"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "Ditemukan akun yang ada untuk alamat email atau nama ini."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Pengguna '%(nick)s' telah dihapus"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "Tidak dapat menghapus Pengguna Tamu"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "Tidak ada pengguna admin tersisa, tidak dapat menghapus pengguna"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "Alamat email tidak boleh kosong dan harus berupa email yang valid"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Pengguna '%(nick)s' diperbarui"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr ""
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr ""
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Kesalahan koneksi"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr ""
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "Tidak ada informasi rilis yang tersedia"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr ""
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr ""
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr ""
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "Terjadi kesalahan yang tidak diketahui. Coba lagi nanti."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "Kesalahan koneksi"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Kesalahan koneksi"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "Berkas %(file)s telah diunggah"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr ""
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr ""
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr ""
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr ""
 
-#: cps/constants.py:265
+#: cps/constants.py
 #, fuzzy
 msgid "Finnish"
 msgstr "Selesai"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr ""
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr ""
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr ""
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr ""
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr ""
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr ""
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr ""
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr ""
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr ""
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr ""
 
-#: cps/constants.py:276
+#: cps/constants.py
 #, fuzzy
 msgid "Polish"
 msgstr "Penerbit"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr ""
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr ""
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr ""
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr ""
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr ""
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr ""
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr ""
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr ""
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr ""
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr ""
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "belum dipasang"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Izin eksekusi hilang"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, fuzzy, python-format
 msgid "Change cover — %(title)s"
 msgstr "Tukar penulis dan judul"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Kesalahan koneksi"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr ""
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Book ID"
 msgstr "Buku"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Judul Buku"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "Penulis"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr ""
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "Format berkas"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filename"
 msgstr "nama"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr ""
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr ""
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "Format Unggahan"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "Tidak diketahui"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr ""
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "Peran tidak valid"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "Gabungkan buku terpiih"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "%(format)s format tidak ditemukan dalam disk"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB Fixer started for selected book."
 msgstr "Gabungkan buku terpiih"
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr ""
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr ""
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid image data format."
 msgstr "Format alamat email tidak valid"
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Profile picture updated successfully."
 msgstr "{} pengguna berhasil dihapus"
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Tidak ada"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "Hapus"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "Hapus"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "Hapus"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "Tidak ada hasil yang ditemukan"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 #, fuzzy
 msgid "Invalid resolution strategy"
 msgstr "Peran tidak valid"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Unggahan selesai, harap tunggu, data sedang diproses..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 #, fuzzy
 msgid "Failed to queue upload for processing"
 msgstr "Gagal membuat jalur untuk sampul"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Format sumber atau tujuan untuk konversi tidak ada"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "Buku berhasil diantrekan untuk dikonversi ke %(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Terjadi kesalahan saat mengonversi buku ini: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 #, fuzzy
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "Ekstensi berkas '%(ext)s' tidak diizinkan untuk diunggah ke server ini"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr "Ekstensi berkas '%(ext)s' tidak diizinkan untuk diunggah ke server ini"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "Berkas yang akan diunggah harus memiliki ekstensi"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 "Ups! Judul buku yang dipilih tidak tersedia. Berkas tidak ada atau tidak "
 "dapat diakses"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "Pengguna tidak berhak mengganti sampul"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr "IDは大文字小文字を区別しません。元のIDを上書きします"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "'%(langname)s' bukan bahasa yang valid"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Metadata berhasil diperbarui"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "Kesalahan pengeditan buku: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Tidak diketahui"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1442,96 +1415,96 @@ msgstr ""
 "Buku yang diunggah mungkin ada di perpustakaan, pertimbangkan untuk "
 "mengubahnya sebelum mengunggah yang baru: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "Berkas %(filename)s tidak dapat disimpan ke direktori temp"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Gagal Memindahkan Berkas Sampul %(file)s: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Format Buku Berhasil Dihapus"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Buku Berhasil Dihapus"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "Anda tidak memiliki izin untuk menghapus buku"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "edit metadata"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "%(seriesindex)s dilewati karena bukan angka yang valid"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr "Pengguna tidak memiliki izin untuk mengunggah format berkas tambahan"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Gagal membuat jalur %(path)s (Izin ditolak)."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Gagal menyimpan berkas %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Format berkas %(ext)s ditambahkan ke %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Token tidak ditemukan"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "%(format)s format tidak ditemukan dalam disk"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1539,7 +1512,7 @@ msgstr ""
 "Pengaturan Google Drive belum selesai, coba nonaktifkan dan aktifkan kembali "
 "Google Drive"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1547,88 +1520,87 @@ msgstr ""
 "Domain panggilan balik tidak diverifikasi, ikuti langkah-langkah untuk "
 "memverifikasi domain di konsol pengembang google"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "%(format)s format tidak ditemukan untuk id buku: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(format)s tidak ditemukan di Google Drive: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s tidak ditemukan: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "Kirim ke E-Reader"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "%(format)s format tidak ditemukan untuk id buku: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "%(format)s format tidak ditemukan untuk id buku: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 #, fuzzy
 msgid "Test Email"
 msgstr "Email tes"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Email pendaftaran untuk pengguna: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Ubah %(orig)s menjadi %(format)s dan kirim ke E-Reader"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Kirim %(format)s ke E-Reader"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "%(book)s send to eReader"
 msgstr "%%(buku)s telah dikirim ke E-Reader"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "Berkas yang diminta tidak dapat dibaca. Mungkin izinnya salah?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "Status baca tidak bisa disetel: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
@@ -1636,12 +1608,12 @@ msgstr ""
 "Menghapus folder buku untuk buku %(id)s gagal, jalur memiliki subfolder: "
 "%(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "Gagal menghapus buku %(id)s: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1650,7 +1622,7 @@ msgstr ""
 "Menghapus buku %(id)s hanya dari basis data, jalur buku di basis data tidak "
 "valid: %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
@@ -1658,66 +1630,66 @@ msgstr ""
 "Ganti nama pengarang dari: '%(src)s' menjadi '%(dest)s' gagal dengan "
 "kesalahan: %(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Berkas %(file)s tidak ditemukan di Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Ganti nama judul dari: '%(src)s' menjadi '%(dest)s' gagal dengan kesalahan: "
 "%(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Jalur buku %(path)s tidak ditemukan di Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr ""
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Nama pengguna ini sudah digunakan"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 #, fuzzy
 msgid "Invalid Email address format"
 msgstr "Format alamat email tidak valid"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr ""
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 "Modul 'advocate' Python tidak diinstal tetapi diperlukan untuk unggahan "
 "sampul"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Kesalahan Mengunduh Sampul"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr ""
 "Berkas sampul bukan berkas gambar yang valid, atau tidak dapat disimpan"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Kesalahan Format Sampul"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
@@ -1725,134 +1697,134 @@ msgstr ""
 "Anda tidak diizinkan mengakses localhost atau jaringan lokal untuk unggahan "
 "sampul"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Gagal membuat jalur untuk sampul"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "Hanya berkas jpg/jpeg/png/webp/bmp yang didukung sebagai berkas sampul"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "Konten berkas sampul tidak valid"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Hanya berkas jpg/jpeg yang didukung sebagai berkas sampul"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr ""
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "Berkas biner unrar tidak ditemukan"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing UnRar"
 msgstr "Kesalahan saat menjalankan UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr ""
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr ""
 
-#: cps/helper.py:2125
+#: cps/helper.py
 #, fuzzy
 msgid "Calibre binaries not viable"
 msgstr "Basis Data tidak dapat ditulisi"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Izin eksekusi hilang"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing Calibre"
 msgstr "Kesalahan saat menjalankan UnRar"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr "Antrian semua buku untuk cadangan metadata"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Pengaturan Kobo"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Daftar dengan %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "Server email belum diatur, silakan hubungi administrator!"
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1860,35 +1832,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "Anda sekarang login sebagai: %(nickname)s"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Tautan ke %(oauth)s Berhasil"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1896,4162 +1868,4094 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr "Server email belum diatur, silakan hubungi administrator!"
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "Membatalkan tautan ke %(oauth)s Berhasil"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Membatalkan tautan ke %(oauth)s Gagal"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "Tidak Tertaut ke %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Gagal masuk dengan GitHub."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Gagal mengambil info pengguna dari GitHub."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Gagal masuk dengan Google."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Gagal mengambil info pengguna dari Google."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "Failed to log in with Generic OAuth."
 msgstr "Gagal masuk dengan GitHub."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "Kesalahan GitHub Oauth, silakan coba lagi nanti."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "Kesalahan GitHub OAuth: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Kesalahan Google Oauth, harap coba lagi nanti."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Kesalahan Google OAuth: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, fuzzy, python-brace-format
 msgid "OAuth error: {}"
 msgstr "Kesalahan GitHub OAuth: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "Buku Abjad"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "Buku diurutkan menurut abjad"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Buku Populer"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "Publikasi populer dari katalog ini berdasarkan Unduhan."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Buku Berperingkat Teratas"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Publikasi populer dari katalog ini berdasarkan Rating."
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "Buku yang Diunduh"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Buku-buku terbaru"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Buku Acak"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Tampilkan Buku Acak"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Buku Telah Dibaca"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Versi saat ini"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Buku yang Belum Dibaca"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Penulis"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Buku yang diurutkan menurut Penulis"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Penerbit"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Buku yang diurutkan menurut Penerbit"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Kategori"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Buku yang diurutkan menurut Kategori"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Seri"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Buku yang diurutkan menurut Seri"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Bahasa"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Buku yang diurutkan menurut Bahasa"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Peringkat"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Buku yang diurutkan menurut Peringkat"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Format berkas"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Buku yang diurutkan menurut format berkas"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Rak"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "本棚に整理された本"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Sinkronkan Rak yang dipilih dengan Kob"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "本棚に整理された本"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "Deskripsi"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{}★"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Telusuri"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Masuk"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Token tidak ditemukan"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Token telah kedaluwarsa"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Berhasil! Silakan kembali ke perangkat Anda"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Buku"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Tampilkan buku terbaru"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Tampilkan Buku Populer"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Buku yang Diunduh"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Tampilkan Buku yang Diunduh"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Tampilkan Buku Berperingkat Teratas"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Read and Unread"
 msgstr "Tampilkan sudah dibaca dan belum dibaca"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Tampilkan belum dibaca"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Temukan"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Category Section"
 msgstr "Tampilkan pilihan kategori"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Series Section"
 msgstr "Tampilkan pilihan seri"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Author Section"
 msgstr "Tampilkan pilihan penulis"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Publisher Section"
 msgstr "Tampilkan pilihan penerbit"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Language Section"
 msgstr "Tampilkan pilihan bahasa"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Ratings Section"
 msgstr "Tampilkan pilihan peringkat"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show File Formats Section"
 msgstr "Tampilkan pilihan format berkas"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Buku yang Diarsipkan"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Archived Books"
 msgstr "Tampilkan buku yang diarsipkan"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Daftar Buku"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Tampilkan Daftar Buku"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr ""
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Tampilkan Buku Berperingkat Teratas"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Terbit setelah "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Terbit sebelum "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Peringkat ≤ %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Peringkat ≥ %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, fuzzy, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Status Baca = %(status)s"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 "Terjadi kesalahan saat mencari kolom khusus, harap mulai ulang Calibre-Web"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Penelusuran Lanjutan"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Rak yang ditentukan tidak valid"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "Maaf Anda tidak diperbolehkan menambahkan buku ke rak: %(shelfname)s"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "Buku sudah menjadi bagian dari rak: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "Buku telah ditambahkan ke rak: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "Anda tidak diperbolehkan menambahkan buku ke rak: %(name)s"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Buku sudah menjadi bagian dari rak: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "Buku telah ditambahkan ke rak: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Tidak dapat menambahkan buku ke rak: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "Rak yang ditentukan tidak valid"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Tidak dapat menambahkan buku ke rak: %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Buku sudah menjadi bagian dari rak: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "Buku telah ditambahkan ke rak: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "Buku telah dihapus dari rak: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "Maaf Anda tidak diizinkan untuk menghapus buku dari rak ini: %(sname)s"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Buat Rak"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Maaf, Anda tidak diizinkan mengedit rak ini"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Edit Rak"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "Kesalahan menghapus Rak"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "Rak berhasil dihapus"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Ubah urutan Rak: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "Maaf, Anda tidak diizinkan membuat rak publik"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Rak %(title)s dibuat"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Rak %(title)s diubah"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Ada kesalahan"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "Rak publik dengan nama '%(title)s' sudah ada."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "Rak pribadi dengan nama '%(title)s' sudah ada."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Rak: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Terjadi kesalahan saat membuka rak. Rak tidak ada atau tidak dapat diakses"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Kecualikan Rak"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Anonim"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Tidak diautentikasi"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Ya"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Tidak"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Status Baca"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Tema"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Terang"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Gelap"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "Sepia"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Tambah ke rak"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Penulis"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Jelajahi"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Tutup"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Hapus"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Gabungkan"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Penerbit"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Baca"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Judul"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Unggah"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Akun"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Admin"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Diterbitkan"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Sumber"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "Tentang"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Diarsipkan"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Batal"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "Konversi"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Deskripsi"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Unduh"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Edit"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "Alamat Email"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Aktifkan sinkronisasi Kobo"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Enkripsi"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "Sembunyikan"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Pengidentifikasi"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Bahasa"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Kata Sandi"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Kemajuan"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Rating"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Simpan"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "Pilih"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Status"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Tag"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Tugas"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Tugas"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Pengguna"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Nama Pengguna"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Tampilan"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Menunggu"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Gagal"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Dimulai"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Selesai"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "Berakhir"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "Dibatalkan"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Status Tidak Diketahui"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Data tak terduga saat membaca informasi pembaruan"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr "Tidak ada pembaruan yang tersedia. Anda telah memasang versi terbaru"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
 msgstr ""
 "Pembaruan tersedia. Klik tombol di bawah untuk memperbarui ke versi terbaru."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Tidak dapat mengambil informasi pembaruan"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr "Klik tombol di bawah untuk memperbarui ke versi stabil terbaru."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6060,324 +5964,322 @@ msgstr ""
 "Pembaruan tersedia. Klik tombol di bawah untuk memperbarui ke versi: "
 "%(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Tidak ada informasi rilis yang tersedia"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Temukan (Buku Acak)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Buku Populer (Paling Banyak Diunduh)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "Buku telah diunduh oleh %(user)s"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Penulis: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Penerbit: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Seri: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "Peringkat: Tidak ada"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Peringkat: %(rating)s★"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Format berkas: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Kategori: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Bahasa: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Buku Populer"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Buku Tersembunyi"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "Kesalahan menghapus Rak"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "Format alamat email tidak valid"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 #, fuzzy
 msgid "Invalid request"
 msgstr "Peran tidak valid"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr ""
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 #, fuzzy
 msgid "Error creating shelf"
 msgstr "Kesalahan menghapus Rak"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Buat Rak"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 #, fuzzy
 msgid "Shelf name is required"
 msgstr "Isian Ini Diperlukan"
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "Kesalahan menghapus Rak"
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "Edit Rak"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "Pengguna tidak ditemukan"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "{} pengguna berhasil dihapus"
 
-#: cps/web.py:1710
+#: cps/web.py
 #, fuzzy
 msgid "Error duplicating shelf"
 msgstr "Kesalahan menghapus Rak"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 #, fuzzy
 msgid "Error deleting shelf"
 msgstr "Kesalahan menghapus Rak"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "Kesalahan menghapus Rak"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 #, fuzzy
 msgid "Error unhiding shelf"
 msgstr "Kesalahan menghapus Rak"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Unduhan"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Daftar format berkas"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 #, fuzzy
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Harap atur pengaturan email SMTP terlebih dahulu..."
 
-#: cps/web.py:2400
+#: cps/web.py
 #, fuzzy
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 "Harap perbarui profil Anda dengan alamat e-mail Kirim ke Kindle yang valid."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "Buku telah diantrikan untuk dikirim ke %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Oops! Terjadi kesalahan saat mengirim buku: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "Buku telah diantrikan untuk dikirim ke %(eReadermail)s"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Daftar"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 #, fuzzy
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr "Server email belum diatur, silakan hubungi administrator!"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr "Server email belum diatur, silakan hubungi administrator!"
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "Alamat email Anda tidak diizinkan untuk mendaftar"
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "E-mail konfirmasi telah dikirimkan ke alamat email Anda."
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
 msgstr "Instans Calibre-Web belum diatur, harap hubungi administrator Anda"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "Server email belum diatur, silakan hubungi administrator!"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 #, fuzzy
 msgid "Cannot activate LDAP authentication"
 msgstr "Tidak dapat mengaktifkan autentikasi LDAP."
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr ""
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, fuzzy, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "Anda sekarang login sebagai: %(nickname)s"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "Anda sekarang login sebagai: %(nickname)s"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
 msgstr "Instans Calibre-Web belum diatur, harap hubungi administrator Anda"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6386,714 +6288,684 @@ msgstr ""
 "Login Pengganti sebagai: '%(nickname)s', Server LDAP tidak dapat dijangkau, "
 "atau pengguna tidak diketahui."
 
-#: cps/web.py:2801
+#: cps/web.py
 #, fuzzy, python-format
 msgid "Could not login: %(message)s"
 msgstr "Tidak dapat login: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 #, fuzzy
 msgid "Wrong Username or Password"
 msgstr "Pengguna atau Kata Sandi salah"
 
-#: cps/web.py:2832
+#: cps/web.py
 #, fuzzy
 msgid "New Password was sent to your email address"
 msgstr "Kata Sandi baru telah dikirimkan ke alamat email Anda"
 
-#: cps/web.py:2836
+#: cps/web.py
 #, fuzzy
 msgid "An unknown error occurred. Please try again later."
 msgstr "Terjadi kesalahan yang tidak diketahui. Coba lagi nanti."
 
-#: cps/web.py:2838
+#: cps/web.py
 #, fuzzy
 msgid "Please enter valid username to reset password"
 msgstr "Harap masukkan pengguna valid untuk mengatur ulang kata sandi"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, fuzzy, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "Anda sekarang login sebagai: %(nickname)s"
 
-#: cps/web.py:3158
+#: cps/web.py
 #, fuzzy
 msgid "Success! Profile Updated"
 msgstr "Profil diperbarui"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "Ditemukan akun yang ada untuk alamat email ini"
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 #, fuzzy
 msgid "Invalid book ID."
 msgstr "Peran tidak valid"
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr ""
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "Tidak ditemukan berkas gmail.json yang valid dengan informasi OAuth"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "%%(buku)s telah dikirim ke E-Reader"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "Kirim ke E-Reader"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-send completed successfully"
 msgstr "{} pengguna berhasil dihapus"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr ""
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr ""
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s telah dikirim ke E-Reader"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Calibre ebook-convert %(tool)s tidak ditemukan"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "%(format)s format tidak ditemukan dalam disk"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "Konverter ebook gagal dengan kesalahan yang tidak diketahui."
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Kebupify-converter gagal: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "Berkas yang telah dikonversi tidak ditemukan atau terdapat duplikat dalam "
 "folder %(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre gagal dengan kesalahan: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Ebook-converter gagal: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Menghubungkan kembali basis data Calibre"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "Hapus"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Hapus"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Mengekstrak paket pembaruan"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Tidak ada hasil yang ditemukan"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Aktifkan sinkronisasi Kobo"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "Email"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 #, fuzzy
 msgid "Backing up Metadata"
 msgstr "Mencadangkan Metadata"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "Dalam Pustaka"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "%(count)s thumbnail sampul dibuat"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "Thumbnail Sampul"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "{0} thumbnail seri dihasilkan"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "Menghapus cache thumbnail sampul"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "本棚に整理された本"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Ubah Kata Sandi"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Buat Rak"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "Pengaturan OAuth"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Pengaturan"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "pilih opsi"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "Tambah ke rak"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Publik)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "Unduhan"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Unduhan"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "Urutkan menurut tanggal buku, terbaru dulu"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "Urutkan menurut tanggal buku, terlama dulu"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Penulis"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Penulis"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Terbit sebelum "
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Terbit sebelum "
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Urutkan menurut tanggal buku, terbaru dulu"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "Urutkan menurut tanggal buku, terlama dulu"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "Alamat E-mail untuk Kirim ke E-Reader"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "Kirim ke E-Reader"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Lihat Buku"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Rak Publik"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr ""
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "Impor Pengguna LDAP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Pengaturan Server Email"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "Hostname SMTP"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "Port SMTP"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "Login SMTP"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Dari Email"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Service"
 msgstr "Layanan Email"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail via Oauth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Jalur Database Calibre"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Log Level"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Port Eksternal"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Buku per halaman"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Unggah"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Penjelajahan Anonim"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Registrasi Publik"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Login Jarak Jauh dengan Magic Link"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Login Reverse Proxy"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Nama Header Reverse Proxy"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Edit Pengaturan Dasar"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Edit Pengaturan Antarmuka"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Edit Pengaturan Basis Data Caliber"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "Tugas Terjadwal"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "Waktu saat tugas mulai dijalankan"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "Durasi tugas maksimum"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "Buat thumbnail sampul seri"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Sambungkan kembali ke Perpustakaan Caliber"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr ""
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "Segarkan Cache Thumbnail Sampul"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Setup KOReader Sync"
 msgstr "Pembaca EPUB"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr ""
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Administrasi"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Unduh Paket Debug"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Tampilkan Log"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Mulai Ulang"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Matikan"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "Informasi Versi"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Versi"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Detail"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "Pembaruan gagal:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Saluran Pembaruan"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Versi saat ini"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Periksa Pembaruan"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Lakukan Pembaruan"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Apa Anda yakin untuk memulai ulang?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Apa Anda yakin untuk mematikan layanan?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Memperbarui, jangan memuat ulang halaman ini"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7101,617 +6973,594 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Buku dalam Pustaka Ini"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Mengunggah..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "Pembaruan gagal:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Kesalahan koneksi"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Seri: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "melalui"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "Dalam Pustaka"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "kurangi"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Lainnya oleh"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Hapus"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Hapus format:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "KOnversi format buku:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Konversi dari:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "select an option"
 msgstr "pilih opsi"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Konversi ke:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Konversi buku"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Terjadi Kesalahan"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Format Unggahan"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "ID Seri"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Tanggal Terbit"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Tipe Pengidentifikasi"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Nilai Pengidentifikasi"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Hapus"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Tambah Pengidentifikasi"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Ambil Sampul dari URL (JPEG - Gambar akan diunduh dan disimpan dalam basis "
 "data)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Unggah Sampul dari disk lokal"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "Aktifkan sinkronisasi Kobo"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Tampilkan Buku setelah Disimpan"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Ambil Metadata"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Kata Kunci"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "Cari Kata kunci"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Memuat..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Kesalahan pencarian!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "Tidak ada hasil yang ditemukan! Silakan coba kata kunci lain."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "Isian Ini Diperlukan"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 #, fuzzy
 msgid " Exchange author & title"
 msgstr "Tukar penulis dan judul"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "Buat Rak"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr ""
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Update Title Sort automatically  "
 msgstr "Perbarui Pengurutan Judul secara otomatis"
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Perbarui Pengurutan Penulis secara otomatis"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Masukkan Judul"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Masukkan Urutan Judul"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Urutan Judul"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Masukkan Urutan Penulis"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Urutan Penulis"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Masukkan Penulis"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Masukkan Kategori"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Masukkan Seri"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Masukkan Bahasa"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Tanggal Terbit"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Masukkan Penerbit"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Masukkan komentar"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Comments"
 msgstr "Komentar"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Archived?"
 msgstr "Diarsipkan"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Read?"
 msgstr "Baca"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "入力: "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Apakah Anda yakin?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "Buku dengan Judul akan digabungkan dari:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "Ke dalam Buku dengan Judul:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr ""
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr ""
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr ""
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr ""
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr ""
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Edit Metadata"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "Buat Rak"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr ""
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Tambah"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr "Server email belum diatur, silakan hubungi administrator!"
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 #, fuzzy
 msgid "Message"
 msgstr "Gabungkan"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Kata Sandi baru telah dikirimkan ke alamat email Anda"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Kirim ke E-Reader"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Kembali"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Lokasi Database Calibre"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7727,13 +7576,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7744,7 +7593,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7755,43 +7604,43 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr ""
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
 "can be wherever you desire"
 msgstr ""
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Gunakan Google Drive?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Autentikasi Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Silakan tekan simpan untuk melanjutkan penyiapan"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "ID Saluran Metadata Watch"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Tarik Kembali"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Sambungkan kembali ke Perpustakaan Caliber"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7801,131 +7650,131 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "Apa Anda yakin untuk mematikan layanan?"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Sambungkan kembali ke Perpustakaan Caliber"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr "Lokasi basis data baru tidak valid, harap masukkan jalur yang valid"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Gunakan Otentikasi Standar"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Gunakan Otentikasi LDAP"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Gunakan Oauth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Pengaturan Server"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Port Server"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "Lokasi berkas sertifikat SSL (biarkan kosong untuk Server non-SSL)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "Lokasi SSL Keyfile (biarkan kosong untuk Server non-SSL)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Saluran Pembaruan"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Stabil"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Nightly"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "Host Tepercaya (Pisahkan dengan Koma)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Pengaturan Logfile"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "Lokasi dan nama access logfile (access.log jika tanpa entri)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Aktifkan Log Akses"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "Lokasi dan nama access logfile (access.log jika tanpa entri)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "Pengaturan Server"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 "Konversikan karakter non-Inggris dalam judul dan penulis saat menyimpan ke "
 "disk"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Izinkan Unggahan"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr "(Harap pastikan pengguna juga memiliki hak mengunggah)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Format Berkas Unggahan yang Diizinkan"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Izinkan Penjelajahan Anonim"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Izinkan Registrasi Publik"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "Gunakan Email sebagai Nama Pengguna"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Izinkan Login Jarak Jauh dengan Magic Link"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7933,154 +7782,154 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Proxy permintaan tidak dikenal ke Kobo Store"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Port Eksternal Server (untuk panggilan API melalui port forward)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Gunakan Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Kunci API Goodreads"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Hardcover Sync"
 msgstr "Aktifkan sinkronisasi Kobo"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "Token telah kedaluwarsa"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Kunci API Goodreads"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8088,420 +7937,420 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Izinkan Reverse Proxy Authentication"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Tipe Login"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "Nama Host Server atau Alamat IP LDAP"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "Port Server LDAP"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "Enkripsi LDAP"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Jalur CACertificate LDAP (Hanya diperlukan untuk Autentikasi Sertifikat "
 "Klien)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Jalur Sertifikat LDAP (Hanya diperlukan untuk Otentikasi Sertifikat Klien)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Jalur Keyfile LDAP (Hanya diperlukan untuk Otentikasi Sertifikat Klien)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "Otentikasi LDAP"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Sederhana"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "Nama Pengguna Administrator LDAP"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "Kata Sandi Administrator LDAP"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "Distinguished Name (DN) LDAP"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "Filter Objek Pengguna LDAP"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "Server LDAP adalah OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr "Pengaturan Berikut Diperlukan Untuk Impor Pengguna"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "Filter Objek Grup LDAP"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "Nama Grup LDAP"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "Bidang Group Members LDAP"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "Deteksi Filter Pengguna Anggota LDAP"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "Deteksi otomatis"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "Filter Kustom"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "Filter Pengguna Anggota LDAP"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "Ambil Metadata"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
 msgstr ""
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "Edit Pengaturan Antarmuka"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "Token tidak ditemukan"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "Kesalahan koneksi"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "Pengaturan OAuth"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Id"
 msgstr "ID Klien %(provider)s OAuth"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Secret"
 msgstr "Client Secret %(provider)s OAuth"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "Pengaturan Tampilan"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "Nama Pengguna"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr ""
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "Layanan Email"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr ""
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "Nama Grup LDAP"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr ""
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Pengaturan Default untuk Pengguna Baru"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Izinkan Unduhan"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Izinkan Penampil eBook"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Izinkan Unggahan"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Izinkan Edit"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Izinkan Menghapus Buku"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Izinkan Mengganti Kata Sandi"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Izinkan Mengedit Rak Publik"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr ""
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Dapatkan %(provider)s Kredensial OAuth"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "ID Klien %(provider)s OAuth"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "Client Secret %(provider)s OAuth"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Binari Eksternal"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Path to Calibre Binaries"
 msgstr "Jalur ke Konverter E-Book Calibre"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Calibre E-Book Converter Settings"
 msgstr "Pengaturan Konverter E-Book Caliber"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Jalur ke Konverter E-Book Kepubify"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "Lokasi binari UnRar"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Security Settings"
 msgstr "Pengaturan OAuth"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8509,341 +8358,336 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr ""
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr ""
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr ""
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Session protection"
 msgstr "pilih opsi"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr ""
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr ""
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "User Password policy"
 msgstr "Atur ulang kata sandi pengguna"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr ""
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr ""
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Pengaturan Tampilan"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Jumlah Buku Acak untuk Ditampilkan"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr ""
 "Jumlah Penulis untuk Ditampilkan Sebelum Disembunyikan (0=Nonaktifkan "
 "Penyembunyian)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "Hapus"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "Tema Gelap caliBlur!"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Ekspresi Reguler untuk Mengabaikan Kolom"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Tautkan Status Baca/Belum Dibaca ke Kolom Kaliber"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "Tautkan Status Baca/Belum Dibaca ke Kolom Kaliber"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Lihat Batasan berdasarkan kolom Caliber"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Ekspresi Reguler untuk Penyortiran Judul"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Pengaturan Tampilan"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Custom CSS"
 msgstr "Filter Kustom"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Pengaturan Default untuk Pengguna Baru"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "Versi"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Pengguna Admin"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "Halaman Admin"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "Bahasa Bawaan"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "Pengaturan Default untuk Pengguna Baru"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "Bahasa Buku Bawaan yang Terlihat"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "Visibilitas Default untuk Pengguna Baru"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Visibilitas Default untuk Pengguna Baru"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Tampilkan Buku Acak dalam Tampilan Detail"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Tambahkan Tag yang Diizinkan/Ditolak"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Tambahkan nilai kolom khusus yang Diizinkan/Ditolak"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Unggah"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "Diarsipkan"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "Unduh"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Mulai"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8852,14 +8696,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8867,96 +8711,95 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "Gabungkan buku terpiih"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "{} pengguna berhasil dihapus"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "Kesalahan menghapus Rak"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "Tidak ada hasil yang ditemukan"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "Masukkan Nama Pengguna"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "Cari di Pustaka"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "Buat Rak"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "Gabungkan buku terpiih"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "Kesalahan menghapus Rak"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Log Calibre-Web: "
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8964,11 +8807,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -8979,11 +8822,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -8993,162 +8836,162 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "Buku yang Diarsipkan"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9156,11 +8999,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9168,110 +9011,108 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "Metadata berhasil diperbarui"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Pengidentifikasi"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "Sampul"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
 "investigation."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9279,157 +9120,157 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Pengaturan OAuth"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "Pengaturan"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "Pengaturan OAuth"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9437,103 +9278,102 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Sinkronkan Rak yang dipilih dengan Kob"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Pengaturan OAuth"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9541,44 +9381,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "KOnversi format buku:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9586,874 +9426,862 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Izinkan Registrasi Publik"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Pengaturan OAuth"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Izinkan Registrasi Publik"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Izinkan Registrasi Publik"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Hapus format:"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Ambil Metadata"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Rating"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Selanjutnya"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Tandai sebagai Belum dibaca"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Tandai sebagai dibaca"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "Tandai sebagai Belum dibaca"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "Tandai sebagai Belum dibaca"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Tambahkan ke Arsip"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Pulihkan dari arsip"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Pulihkan dari arsip"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Tambahkan ke Arsip"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "Pulihkan dari arsip"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "Cari di Pustaka"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "Pengaturan Basis Data diperbarui"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "Peringkat Diatas"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "Buku %(index)s dari %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr ""
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Deskripsi:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "Alamat E-mail untuk Kirim ke E-Reader"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "Alamat E-mail untuk Kirim ke E-Reader"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "Buat Rak"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "Hapus format:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "Gagal membuat jalur untuk sampul"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "Gagal membuat jalur untuk sampul"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr ""
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Hapus"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "Tampilkan Buku Berperingkat Teratas"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "Pilih"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "Gabungkan buku terpiih"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Hapus"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "Sebelumnya"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "Gabungkan buku terpiih"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "Detail Buku"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "edit metadata"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "Gabungkan buku terpiih"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "Tidak ada hasil yang ditemukan"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr ""
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Hapus format:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be permanently deleted:"
 msgstr "Buku ini akan dihapus secara permanen dari basis data"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "Buku yang Belum Dibaca"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "Buku ini akan dihapus secara permanen dari basis data"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "Buku ini akan dihapus secara permanen dari basis data"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr ""
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr ""
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr ""
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "Pilih Jenis Server"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Standard Email Account"
 msgstr "Gunakan Akun Email Standar"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Gmail Account"
 msgstr "Pilih Jenis Server"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Setup Gmail Account"
 msgstr "Pilih Jenis Server"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Cabut Akses G-Mail"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "Kata Sandi SMTP"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Batas Ukuran Lampiran"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Save and Send Test Email"
 msgstr "Simpan dan Kirim Email Percobaan"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Domain yang Diizinkan (Daftar Putih)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Tambahkan Domain"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Masukkan Nama Domain"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Domain yang Ditolak (Daftar Hitam)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10461,582 +10289,572 @@ msgstr ""
 "Buka berkas .kobo/Kobo/Kobo eReader.conf di editor teks dan tambahkan (atau "
 "edit):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Token Kobo:"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "Daftar"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "Buat Rak"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "Istilah Penelusuran:"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "Tampilkan Buku setelah Disimpan"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "Buat Rak"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "Memuat..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
 msgstr "Apakah Anda yakin ingin merubah peran untuk pengguna yang dipilih?"
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "Gagal membuat jalur untuk sampul"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr "Apakah Anda yakin ingin merubah peran untuk pengguna yang dipilih?"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "Buat Rak"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "Gagal membuat jalur untuk sampul"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "Instans Calibre-Web belum diatur, harap hubungi administrator Anda"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Buat Isu"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Kembali ke Beranda"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "Keluar Pengguna"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "Edit Rak"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show this shelf in your sidebar"
 msgstr "Sinkronkan rak ini dengan perangkat Kobo"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "Tampilkan semua"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "Rak Publik"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Tambah ke rak"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Beranda"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Alihkan Navigasi"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Cari di Pustaka"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Katalog eBook Calibre-Web"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Keluar"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "Pengaturan"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "Cari di Pustaka"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Tidak ada informasi rilis yang tersedia"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Katalog eBook Calibre-Web"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Hapus"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Harap jangan segarkan halaman"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Buat Rak"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Sebelumnya"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Detail Buku"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Apa Anda yakin untuk mematikan layanan?"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Gabungkan buku terpiih"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Format Unggahan"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Hapus format:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Hapus"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Tidak ada hasil yang ditemukan"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Skala ke Terbaik"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "Hingga:"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "Pengaturan"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Tambah ke rak"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Gabungkan buku terpiih"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Tandai sebagai Belum dibaca"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Hapus"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Hapus"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Buat Rak"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Kesalahan koneksi"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr ""
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "Terjadi Kesalahan"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "Kata Sandi SMTP"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Ingat saya"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Lupa Kata Sandi?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Masuk dengan Magic Link"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 #, fuzzy
 msgid "Log in with SSO"
 msgstr "Masuk dengan Magic Link"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Tampilkan Log Caliber-Web:"
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Calibre-Web Log: "
 msgstr "Tampilkan Log Caliber-Web:"
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Output aliran, tidak dapat ditampilkan"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Tampilkan Log Akses:"
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Unduh Calibre-Web Log"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "Unduh Log Akses"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "Bagikan dengan Semua Orang"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Pilih Tag yang Diizinkan/Ditolak"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Pilih Nilai Kolom Kustom yang Diizinkan/Ditolak"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Pilih Tag Pengguna yang Diizinkan/Ditolak"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr "Pilih Nilai Kolom Pengguna yang Diizinkan/Ditolak"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Masukkan Tag"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Tambahkan Batasan Tampilan"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "Format buku ini akan dihapus secara permanen dari database"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Buku ini akan dihapus secara permanen dari basis data"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "dan harddisk"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Catatan Penting Kobo: buku yang dihapus akan tetap ada di perangkat Kobo "
 "yang telah dipasangkan."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11044,579 +10862,575 @@ msgstr ""
 "Buku harus diarsipkan terlebih dahulu dan perangkat disinkronkan sebelum "
 "buku dapat dihapus dengan aman."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Pilih Lokasi Berkas"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "tipe"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "nama"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "ukuran"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "Direktori Induk"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "Ok"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Katalog eBook Calibre-Web"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "Pembaca EPUB"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "Tindakan"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "Hitam"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr ""
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Halaman Selanjutnya"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr ""
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 #, fuzzy
 msgid "Default"
 msgstr "Hapus"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr ""
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr ""
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 #, fuzzy
 msgid "KaiTi"
 msgstr "Menunggu"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 #, fuzzy
 msgid "Arial"
 msgstr "Vertical"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 #, fuzzy
 msgid "Spread"
 msgstr "Baca"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 #, fuzzy
 msgid "Two columns"
 msgstr "Kolom Baca Tidak Valid"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 #, fuzzy
 msgid "One column"
 msgstr "Kolom Baca Tidak Valid"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Reflow teks saat sidebar terbuka."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Pembaca Komik"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Pintasan Keyboard"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Halaman Sebelumnya"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Halaman Selanjutnya"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page Display"
 msgstr "Halaman Admin"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Skala ke Terbaik"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Skala ke Lebar"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Skala ke Tinggi"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Skalakan ke Asli"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Putar ke Kanan"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Putar ke Kiri"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Balikkan Gambar"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page"
 msgstr "Halaman Admin"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr ""
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Skala"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Terbaik"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Lebar"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Tinggi"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Asli"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Putar"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Balik"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Horizontal"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Vertical"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Direction"
 msgstr "Deskripsi"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Kiri ke Kanan"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Kanan ke Kiri"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Reset to Top"
 msgstr "Kembali ke Beranda"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Remember Position"
 msgstr "Ingat saya"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "Scrollbar"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "Tampilkan"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "Pembaca DJVU"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "Pembaca PDF"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "Pembaca txt"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Daftar Akun Baru"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Pilih nama pengguna"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Alamat email Anda"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Magic Link - Otorisasi Perangkat Baru"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "Di perangkat lain, masuk dan kunjungi:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr ""
 "Setelah diverifikasi, Anda akan secara otomatis masuk ke perangkat ini."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Tautan verifikasi ini akan kedaluwarsa dalam 10 menit."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "Hasilkan Thumbnail Sampul Seri"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Tidak ada hasil yang ditemukan"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Istilah Penelusuran:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Hasil untuk:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Tanggal Diterbitkan Dari"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Tanggal Diterbitkan Hingga"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr ""
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Kecualikan Tag"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Kecualikan Seri"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "Kecualikan Rak"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Kecualikan Bahasa"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Ekstensi"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Kecualikan Ekstensi"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Peringkat Diatas"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Peringkat Dibawah"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "Dari:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "Hingga:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Hapus rak ini"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "Edit Properti Rak"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Buku Tersembunyi"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "Atur buku secara manual"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "Nonaktifkan Ubah urutan"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "Aktifkan Ubah urutan"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Gabungkan buku terpiih"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Akun"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Token tidak ditemukan"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Hapus rak ini"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Tambah ke rak"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Cari di Pustaka"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Cari di Pustaka"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Bagikan dengan Semua Orang"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "Sinkronkan rak ini dengan perangkat Kobo"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Pengguna tidak ditemukan"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Buku Tersembunyi"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Statistik Pustaka"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Buku dalam Pustaka Ini"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Penulis dalam Pustaka Ini"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Kategori dalam Pustaka Ini"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Seri dalam Pustaka Ini"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Statistik Sistem"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "Pustaka Program"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Versi Terpasang"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Waktu Jalan"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Actions"
 msgstr "Tindakan"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "Putar"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 "Tugas ini akan dibatalkan. Setiap kemajuan yang dibuat oleh tugas ini akan "
 "disimpan."
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
@@ -11624,395 +11438,395 @@ msgstr ""
 "Jika ini adalah tugas terjadwal, ini akan dijalankan ulang selama waktu "
 "terjadwal berikutnya."
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "{} pengguna berhasil dihapus"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Katalog eBook Calibre-Web"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "Alamat email Anda"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "Pengaturan"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Atur ulang kata sandi pengguna"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "Pengaturan Server"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "Alamat E-mail untuk Kirim ke E-Reader"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "Masukkan Bahasa"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Bahasa Buku"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "Tidak Ada Bahasa Buku yang Valid Diberikan"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "Pengaturan OAuth"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Tautan"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Batalkan tautan"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Token Kobo Sync"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Buat/Lihat"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "Paksa sinkronisasi kobo penuh"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "Sinkronkan hanya buku di rak yang dipilih dengan Kobo"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "Sinkronkan hanya buku di rak yang dipilih dengan Kobo"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "Pengaturan OAuth"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Tambahkan Nilai Kolom Kustom yang Diizinkan/Ditolak"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Magic Shelves Order"
 msgstr "Sinkronkan Rak yang dipilih dengan Kob"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "Buku yang baru ditambahkan"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "Edit Rak Publik"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Hapus Pengguna"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12020,158 +11834,158 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Ubah Kata Sandi"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Ubah Kata Sandi"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Buat/Lihat"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Hasilkan URL Autentikasi Kobo"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Pilih..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Hapus Pilihan"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "Edit Pengguna"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "Masukkan Nama Pengguna"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Email"
 msgstr "Email tes"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email"
 msgstr "Alamat E-mail untuk Kirim ke E-Reader"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email"
 msgstr "Email E-Reader"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "Alamat E-mail untuk Kirim ke E-Reader"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "Email E-Reader"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Lokal"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "Bahasa Buku Terlihat"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "Edit Tag yang Diizinkan"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Tag yang Diizinkan"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Edit Tag yang Ditolak"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Tag yang Ditolak"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "Edit Nilai Kolom yang Diizinkan"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "Nilai Kolom yang Diizinkan"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "Edit Nilai Kolom yang Ditolak"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "Nilai Kolom yang Ditolak"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "Ubah Kata Sandi"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "Edit Rak Publik"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "Sinkronkan Rak yang dipilih dengan Kob"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "Sinkronkan Rak yang dipilih dengan Kob"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Read/Unread Section"
 msgstr "Tampilkan pilihan baca/belum dibaca"

--- a/cps/translations/it/LC_MESSAGES/messages.po
+++ b/cps/translations/it/LC_MESSAGES/messages.po
@@ -17,260 +17,258 @@ msgstr ""
 "X-Loco-Parser: loco_parse_po\n"
 "X-Generator: Poedit 3.8\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Statistiche"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 msgid "Server restarted, please reload page."
 msgstr "Server riavviato, ricarica la pagina."
 
-#: cps/admin.py:210
+#: cps/admin.py
 msgid "Performing Server shutdown, please close window."
 msgstr "Esecuzione dell'arresto del server, chiudi la finestra."
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "Tutto OK! Database riconnesso"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Comando sconosciuto"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 "Tutto OK! Libri in coda per il backup dei metadati, controlla le attività "
 "per il risultato"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr ""
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 
-#: cps/admin.py:414
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover ID applied successfully"
 msgstr "{} utenti eliminati correttamente"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr ""
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr ""
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr ""
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr ""
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr ""
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Pagina di amministrazione"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "Hardcover API token"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Configurazione di base"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Configurazione dell'interfaccia utente"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 "La colonna personalizzata no.%(column)d non esiste nel database di Calibre"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Modifica utenti"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Tutti"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Utente non trovato"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} utenti eliminati correttamente"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Mostra tutto"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Richiesta non valida"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "Il nome dell'utente Guest (ospite) non può essere modificato"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "L'utente Guest (ospite) non può avere questo ruolo"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr ""
 "Non rimarrebbe nessun utente amministratore, non è possibile rimuovere il "
 "ruolo di amministratore"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "Il valore deve essere vero o falso"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Ruolo non valido"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "L'utente Guest (ospite) non può visualizzare questa schermata"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "Visualizzazione non valida"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 "Le impostazioni locali dell'utente Guest (ospite) sono determinate "
 "automaticamente e non possono essere configurate"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Nessuna lingua valida specificata"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Nessun libro valido per la lingua specificata"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Parametro non trovato"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "Il DB delle impostazioni non è scrivibile"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Colonna di lettura non valida"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Colonna con restrizioni non valida"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Vuoi veramente eliminare il token di Kobo?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "Vuoi veramente eliminare questo dominio?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "Vuoi veramente eliminare questo utente?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Sei sicuro di voler eliminare questo scaffale?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr ""
 "Sei sicuro di voler cambiare le impostazioni internazionali degli utenti "
 "selezionati?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "Sei sicuro di voler cambiare le lingue visibili del libro per gli utenti "
 "selezionati?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 "Sei sicuro di voler cambiare il ruolo selezionato per gli utenti selezionati?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
@@ -278,7 +276,7 @@ msgstr ""
 "Sei sicuro di voler cambiare le restrizioni selezionate per gli utenti "
 "selezionati?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -286,14 +284,14 @@ msgstr ""
 "Sei sicuro di voler cambiare le restrizioni di visibilità selezionate per "
 "gli utenti selezionati?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "Sei sicuro di voler cambiare il comportamento di sincronizzazione dello "
 "scaffale per gli utenti selezionati?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
@@ -301,128 +299,123 @@ msgstr ""
 "Sei sicuro di voler cambiare il comportamento di sincronizzazione dello "
 "scaffale per gli utenti selezionati?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Sei sicuro di voler cambiare la posizione della biblioteca di Calibre?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Nega"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Consenti"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "{} voci di sincronizzazione eliminate"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Token non trovato"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Etichetta non trovata"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Azione non valida"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json non è configurato per Web Application"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "La posizione del file di log non è valida, per favore indica il percorso "
 "corretto"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "La posizione del file del log di accesso non è valida, indica il percorso "
 "corretto"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 "Inserisci un provider LDAP, una porta, un DN e un identificatore oggetto "
 "utente"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Inserisci un account e una password del servizio LDAP"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "Inserisci un account di servizio LDAP"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Il filtro oggetto gruppo LDAP deve avere un identificatore di formato \"%s\""
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "Il filtro oggetto gruppo LDAP ha parentesi senza corrispondenza"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Il filtro oggetto utente LDAP deve avere un identificatore di formato \"%s\""
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "Il filtro oggetto utente LDAP ha parentesi senza corrispondenza"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Il filtro utente membro LDAP deve avere un identificatore di formato \"%s\""
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "Il filtro utente membro LDAP ha parentesi senza corrispondenza"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -430,29 +423,24 @@ msgstr ""
 "Il certificato CA LDAP, il certificato o la posizione della chiave non sono "
 "validi. Inserisci il percorso corretto"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Aggiungi nuovo utente"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Modifica le impostazioni del server e-mail"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "Tutto OK! Account Gmail verificato."
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Errore nel database: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -460,53 +448,53 @@ msgstr ""
 "L'e-mail di prova è stato accodata correttamente per essere spedita a "
 "%(email)s, controlla il risultato in Attività"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Si è verificato un errore nell'invio dell'e-mail di prova: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Configura prima il tuo indirizzo e-mail..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Le impostazioni del server e-mail sono state aggiornate"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "Modifica utenti"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Configura prima le impostazioni della posta SMTP..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "Configura prima il tuo indirizzo e-mail..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "Seleziona almeno un indirizzo email"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -514,7 +502,7 @@ msgstr ""
 "L'e-mail di prova è stato accodata correttamente per essere spedita a "
 "%(email)s, controlla il risultato in Attività"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -523,564 +511,561 @@ msgstr ""
 "L'e-mail di prova è stato accodata correttamente per essere spedita a "
 "%(email)s, controlla il risultato in Attività"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "Modifica le impostazioni delle attività pianificate"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "Ora di inizio non valida per l'attività specificata"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "Durata non valida per l'attività specificata"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "Impostazioni delle attività pianificate aggiornate"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Si è verificato un errore sconosciuto. Per favore riprova più tardi."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "Titolo"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Modifica utente %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Tutto OK! Password reimpostata per l'utente %(user)s"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Per favore configura le impostazioni della posta SMTP."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Visualizzatore del file di log"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Richiesta del pacchetto di aggiornamento"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Download del pacchetto di aggiornamento"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Decompressione del pacchetto di aggiornamento"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Sostituzione dei file"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Le connessioni al database sono chiuse"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Arresto del server"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Aggiornamento terminato, premi OK e ricarica la pagina"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Aggiornamento non riuscito:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "Errore HTTP"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Errore di connessione"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Tempo scaduto nello stabilire la connessione"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Errore generale"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr ""
 "Il file di aggiornamento non può essere salvato nella cartella temporanea"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "Impossibile sostituire i file durante l'aggiornamento"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "Impossibile estrarre almeno un utente LDAP"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Impossibile creare almeno un utente LDAP"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Errore: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Errore: nessun utente restituito in risposta dal server LDAP"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "Almeno un utente LDAP non è stato trovato nel database"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} utente importato correttamente"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr "Percorso dei libri non valido"
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "La posizione del DB non è valida, per favore indica il percorso corretto"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "Il DB non è scrivibile"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "La posizione del Keyfile non è valida. Inserisci il percorso corretto"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr "La posizione del Certfile non è valida, indica il percorso corretto"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr "La lunghezza della password deve essere compresa tra 1 e 40"
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "Impostazioni del database aggiornate"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "Configurazione del database"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Per favore completa tutti i campi."
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "L'e-mail non proviene da un dominio valido"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Aggiungi nuovo utente"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "L'utente '%(user)s' è stato creato"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "Esiste già un account per questa e-mail o nome."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "L'utente '%(nick)s' è stato eliminato"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "Impossibile eliminare l'utente Guest (ospite)"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr ""
 "Non rimarrebbe nessun utente amministratore, non è possibile eliminare "
 "l'utente"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "L'e-mail non può essere vuota e deve essere un'e-mail valida"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "L'utente '%(nick)s' è stato aggiornato"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 "Connessione fallita: Il server ha restituito il codice di stato %(code)s"
 
-#: cps/admin.py:3276
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr "Connessione fallita: Impossibile connettersi al server."
 
-#: cps/admin.py:3278
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr "Connessione fallita: La richiesta è scaduta."
 
-#: cps/admin.py:3280
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr "Connessione fallita: JSON non valido nella risposta."
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Errore di connessione"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr "I metadati mancano dei campi obbligatori: %(fields)s"
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr "L'URL dei metadati è valido! Trovati %(count)s endpoint."
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "Nessuna informazione disponibile sulla versione"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr "Connessione fallita: Impossibile connettersi al server."
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr "Connessione fallita: La richiesta è scaduta."
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr "Connessione fallita: JSON non valido nella risposta."
 
-#: cps/admin.py:3340
+#: cps/admin.py
 msgid "An unknown error occurred."
 msgstr "Si è verificato un errore sconosciuto."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "Errore di connessione"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Errore di connessione"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "Il file %(file)s è stato caricato"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr "Ceco"
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr "Tedesco"
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr "Greco"
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr "Spagnolo"
 
-#: cps/constants.py:265
+#: cps/constants.py
 msgid "Finnish"
 msgstr "Finlandese"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr "Francese"
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr "Galiziano"
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr "Ungherese"
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr "Indonesiano"
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr "Italiano"
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr "Giapponese"
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr "Khmer"
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr "Coreano"
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr "Olandese"
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr "Norvegese"
 
-#: cps/constants.py:276
+#: cps/constants.py
 msgid "Polish"
 msgstr "Polacco"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr "Portoghese"
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr "Portoghese (Brasiliano)"
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr "Russo"
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr "Slovacco"
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr "Sloveno"
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr "Svedese"
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr "Turco"
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr "Ucraino"
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr "Vietnamita"
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr "Cinese (Semplificato, Cina)"
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr "Cinese (Tradizionale, Taiwan)"
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "non installato"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Mancano i permessi di esecuzione"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, fuzzy, python-format
 msgid "Change cover — %(title)s"
 msgstr "Inverti autore e titolo"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Errore di connessione"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Could not render the e-reader preview."
 msgstr "Impossibile trovare la cartella specificata"
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
@@ -1088,366 +1073,354 @@ msgstr ""
 "Aggiornamento libreria 🔄 Ricerca di eventuali libri che potrebbero essere "
 "stati tralasciati, attendere prego..."
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr "Timestamp"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Book ID"
 msgstr "Book ID"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Titolo del libro"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Book Author"
 msgstr "Autore del libro"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr "Tipo di attivazione"
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Filepath"
 msgstr "Percorso del file"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Filename"
 msgstr "Nome del file"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr "Manuale?"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr "N. Correzioni"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr "Effettuato backup dell'originale?"
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr "Correzioni Applicate"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr "Formato Originale"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "End Format"
 msgstr "Formato Finale"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "Sconosciuto"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr "✅ Tutti i servizi di Monitoring funzionano come previsto!👍"
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 "🔴 Il servizio di Ingest è in esecuzione, ma il servizio di Metadata Change "
 "Detector non lo è"
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 "🔴 Il servizio di Metadata Change Detector è in esecuzione, ma il servizio "
 "di Ingest non lo è"
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 "⛔ Né il servizio di Ingest né il servizio di Metadata Change Detector sono "
 "in esecuzione"
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr "Si è verificato un errore"
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "Book ID non valido."
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "Segna i libri selezionati come non letti"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "Formato %(format)s non trovato sul disco"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB Fixer started for selected book."
 msgstr "Modifica i libri selezionati"
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr "Devi essere un amministratore per accedere a questa pagina."
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr "I campi username ed image data sono obbligatori."
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid image data format."
 msgstr "Formato dell'indirizzo e-mail non valido"
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr "Immagine del profilo aggiornata correttamente."
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Nessuna"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 msgid "Duplicate Books"
 msgstr "Libro duplicato"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "Libro duplicato"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "Libro duplicato"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "Duplicati"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 #, fuzzy
 msgid "Invalid resolution strategy"
 msgstr "Ruolo non valido"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr "ID libro mancante o non valido per il caricamento del formato"
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Caricamento terminato, elaborazione in corso..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 msgid "Failed to queue upload for processing"
 msgstr "Impossibile mettere in coda il caricamento per l'elaborazione"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Manca il formato di origine o di destinazione per la conversione"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "Libro accodato correttamente per essere convertito in %(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Si è verificato un errore durante la conversione del libro: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "Non è consentito caricare questo tipo di file su questo server"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr ""
 "Non è consentito caricare l'estensione del file '%(ext)s' su questo server"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "Il file da caricare deve avere un'estensione"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 "Il libro selezionato non è disponibile. Il file non esiste o non è "
 "accessibile"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "L'utente non ha i permessi per caricare le copertine"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 "Gli identificatori non fanno distinzione tra maiuscole e minuscole e "
 "sovrascrivono il vecchio identificatore"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "%(langname)s non è una lingua valida"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Metadati aggiornati correttamente"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "Errore nella modifica del libro: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1455,96 +1428,96 @@ msgstr ""
 "Probabilmente il libro caricato esiste già nella biblioteca, cambialo prima "
 "di caricarlo di nuovo: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "Il file %(filename)s non può essere salvato nella cartella temporanea"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Impossibile spostare il file della copertina %(file)s: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Il formato del libro è stato eliminato correttamente"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Il libro è stato eliminato correttamente"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "Ti mancano le autorizzazioni per eliminare i libri"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "modifica i metadati"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "Indice serie: %(seriesindex)s non è un numero valido, lo salto"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr "L'utente non ha i permessi per caricare formati di file aggiuntivi"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Impossibile creare il percorso %(path)s (autorizzazione negata)."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Impossibile archiviare il file %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Formato file %(ext)s aggiunto a %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Token non trovato"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "Formato %(format)s non trovato sul disco"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1552,7 +1525,7 @@ msgstr ""
 "Configurazione di Google Drive non completata, prova a disattivare e "
 "attivare nuovamente Google Drive"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1560,87 +1533,86 @@ msgstr ""
 "Il dominio di callback non è stato verificato, segui i passaggi per "
 "verificare il dominio nella console per sviluppatori di Google"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "Formato %(format)s non trovato per l'ID libro: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(format)s non trovato su Google Drive: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s non trovato: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "Invia all'eReader"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "Formato %(format)s non trovato per l'ID libro: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "Formato %(format)s non trovato per l'ID libro: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 msgid "Test Email"
 msgstr "E-mail di prova"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "E-mail di registrazione per l'utente: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Converti %(orig)s in %(format)s e invia all'eReader"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Invia %(format)s all'eReader"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s inviato all'eReader"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "Il file richiesto non può essere letto. I permessi sono corretti?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "Impossibile impostare lo stato di lettura: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
@@ -1648,12 +1620,12 @@ msgstr ""
 "Eliminazione della cartella di libri per il libro %(id)s non riuscita, il "
 "percorso ha sottocartelle: %(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "Eliminazione del libro %(id)s non riuscita: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1662,7 +1634,7 @@ msgstr ""
 "Eliminazione del libro %(id)s solo dal database, percorso del libro nel "
 "database non valido: %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
@@ -1670,66 +1642,66 @@ msgstr ""
 "La modifica dell'autore da '%(src)s' a '%(dest)s' è terminata con l'errore: "
 "%(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Il file %(file)s non è stato trovato su Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "La modifica del titolo da '%(src)s' a '%(dest)s' è terminata con l'errore: "
 "%(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Il percorso del libro %(path)s non è stato trovato su Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr "Trovato un account esistente per questo indirizzo e-mail"
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Questo nome utente è già utilizzato"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr "Formato dell'indirizzo e-mail non valido"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr "La password non è conforme alle regole di convalida della password"
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 "Il modulo Python \"advocate\" non è installato ma è necessario per il "
 "caricamento delle copertine"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Errore nello scaricare la copertina"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr ""
 "Il file della copertina non è in un formato di immagine valido o non può "
 "essere salvato"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Errore nel formato della copertina"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
@@ -1737,119 +1709,119 @@ msgstr ""
 "Non ti è consentito accedere all'host locale o alla rete locale per caricare "
 "le copertine"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Impossibile creare il percorso per la copertina"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr ""
 "Solo i file jpg/jpeg/png/webp/bmp sono supportati come file di copertina"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "Contenuto del file di copertina non valido"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Solo i file jpg/jpeg sono supportati come file di copertina"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr "Copertina"
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "File binario UnRar non trovato"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr "Errore nell'eseguire UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr "Impossibile trovare la cartella specificata"
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr "Specifica una cartella, non un file"
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr "Eseguibili di Calibre non validi"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr "File eseguibili di Calibre mancanti: %(missing)s"
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Permessi di esecuzione mancanti: %(missing)s"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr "Errore durante l'esecuzione di Calibre"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr "Metti in coda tutti i libri per il backup dei metadati"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Configurazione di Kobo"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Registra con %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
@@ -1858,14 +1830,14 @@ msgstr ""
 "Accesso non riuscito: impossibile connettersi all'endpoint delle "
 "informazioni utente."
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "Accesso non riuscito: profilo utente non corretto."
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1873,35 +1845,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "Tutto OK! Ora sei connesso come: %(nickname)s"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Collegamento riuscito a %(oauth)s"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1909,4141 +1881,4073 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr ""
 "Il server e-mail non è configurato, per favore contatta l'amministratore."
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "Scollegamento da %(oauth)s riuscito"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Scollegamento da %(oauth)s non riuscito"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "Non collegato a %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Impossibile accedere con GitHub."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Impossibile recuperare le informazioni dell'utente da GitHub."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Impossibile accedere con Google."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Impossibile recuperare le informazioni dell'utente da Google."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 msgid "Failed to log in with Generic OAuth."
 msgstr "Errore nel collegamento con OAuth generico."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "Errore GitHub Oauth, riprova più tardi."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "Errore GitHub Oauth: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Errore OAuth di Google, riprova più tardi."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Errore OAuth di Google: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr "Errore Oauth: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "Libri in ordine alfabetico"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "Libri ordinati alfabeticamente"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Libri hot"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "Pubblicazioni popolari in questo catalogo in base ai download."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Libri più votati"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Pubblicazioni popolari in questo catalogo in base alle valutazioni."
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "Libri scaricati"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Gli ultimi libri"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Libri casuali"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Mostra Libri casuali"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Libri letti"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Versione attuale"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Libri da leggere"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Autori"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Libri ordinati per autore"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Editori"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Libri ordinati per editore"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Categorie"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Libri ordinati per categoria"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Serie"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Libri ordinati per serie"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Lingue"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Libri ordinati per lingua"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Valutazioni"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Libri ordinati per valutazione"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Formati di file"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Libri ordinati per formato di file"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Scaffali"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "Libri organizzati in scaffali"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Sincronizza gli scaffali selezionati con Kobo"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Libri organizzati in scaffali"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "Descrizione"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} stelle"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Cerca"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Accesso"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Token non trovato"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Il token è scaduto"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Tutto OK! Torna al tuo dispositivo"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Libri"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Mostra Libri recenti"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Mostra Libri hot"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Libri scaricati"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Mostra Libri scaricati"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Mostra Libri più votati"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 msgid "Show Read and Unread"
 msgstr "Mostra Libri letti e Libri da leggere"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Mostra da leggere"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Libri casuali"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Category Section"
 msgstr "Mostra sezione Categorie"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Series Section"
 msgstr "Mostra sezione Serie"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Author Section"
 msgstr "Mostra sezione Autori"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Publisher Section"
 msgstr "Mostra sezione Editori"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Language Section"
 msgstr "Mostra sezione Lingue"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Ratings Section"
 msgstr "Mostra sezione Valutazioni"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show File Formats Section"
 msgstr "Mostra sezione Formati di file"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Libri archiviati"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Archived Books"
 msgstr "Mostra Libri archiviati"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Elenco libri"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Mostra Elenco libri"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr "Duplicati"
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 msgid "Show Duplicate Books"
 msgstr "Mostra Libri duplicati"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Pubblicato dopo il "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Pubblicato prima del "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Valutazione <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Valutazione >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Stato di lettura = '%(status)s'"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 "Errore nella ricerca delle colonne personalizzate. Per favore riavvia "
 "Calibre-Web"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Ricerca avanzata"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Scaffale specificato non valido"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr ""
 "Spiacente, ma non sei autorizzato ad aggiungere libri a questo scaffale"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "Il libro è gia presente nello scaffale: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 "%(book_id)s non è un valido ID libro. Impossibile aggiungerlo allo scaffale"
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "Il libro è stato aggiunto allo scaffale: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "Non sei autorizzato ad aggiungere libri allo scaffale"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "I libri sono già presenti nello scaffale: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "I libri sono stati aggiunti allo scaffale: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Impossibile aggiungere libri allo scaffale: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "Scaffale specificato non valido"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Impossibile aggiungere libri allo scaffale: %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "I libri sono già presenti nello scaffale: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "I libri sono stati aggiunti allo scaffale: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "Il libro è stato rimosso dallo scaffale: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "Spiacente, ma non sei autorizzato a rimuovere libri da questo scaffale"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Crea uno scaffale"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Spiacente, ma non sei autorizzato a modificare questo scaffale"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Modifica uno scaffale"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "Errore nell'eliminare lo scaffale"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "Lo scaffale è stato eliminato correttamente"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Cambia l'ordine dello scaffale: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "Spiacente, ma non sei autorizzato a creare scaffali pubblici"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Lo scaffale %(title)s è stato creato"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Lo scaffale %(title)s è stato modificato"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "C'è stato un errore"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "Esiste già uno scaffale pubblico con il nome '%(title)s'."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "Esiste già uno scaffale privato con il nome '%(title)s'."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Scaffale: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Errore nell'apertura dello scaffale. Lo scaffale non esiste o non è "
 "accessibile"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Escludi scaffali"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Anonimo"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Non autenticato"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr "Seleziona formato"
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Sì"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "No"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Stato di lettura"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Tema"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Chiaro"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Scuro"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "Seppia"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Aggiungi allo scaffale"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Autore"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Naviga"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Chiudi"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr "Converti in"
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Elimina"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Unisci"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Editore"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Letto"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Titolo"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Caricamento"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Account"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Amministratore"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Pubblicato"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Origine"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "Informazioni su"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr "Qualsiasi"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr "Archivio"
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Archiviato"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Annulla"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "Converti"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Descrizione"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Download"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Modifica"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "E-mail"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Abilita la sincronizzazione Kobo"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Crittografia"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "Nascondi"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Identificatori"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Lingua"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr "Contrassegna come letto"
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr "Contrassegna come da leggere"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Password"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Porta"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Avanzamento"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Valutazione"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Salva"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "Seleziona"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr "Invia"
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Stato"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr "Sostieni su Ko-fi →"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Etichette"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Attività"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Attività"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr "Rimuovi dall'archivio"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Utente"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Nome utente"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Visualizza"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Attendi"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Non riuscito"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Avviato"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Finito"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "Terminato"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "Annullato"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Stato sconosciuto"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Dati imprevisti durante la lettura delle informazioni di aggiornamento"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr "Nessun aggiornamento disponibile. Hai già l'ultima versione installata"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6051,17 +5955,17 @@ msgstr ""
 "È disponibile un nuovo aggiornamento. Fai clic sul pulsante in basso per "
 "aggiornare all'ultima versione."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Impossibile recuperare le informazioni sull'aggiornamento"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr ""
 "Fai clic sul pulsante in basso per eseguire l'aggiornamento all'ultima "
 "versione stabile."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6070,268 +5974,266 @@ msgstr ""
 "È disponibile un nuovo aggiornamento. Fai clic sul pulsante in basso per "
 "aggiornare alla versione:%(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Nessuna informazione disponibile sulla versione"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Libri casuali"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Libri hot (i più scaricati)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "Libri scaricati da %(user)s"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Autore: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Editore: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Serie: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "Valutazione: nessuna"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Valutazione: %(rating)s stelle"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Formato file: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Categoria: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Lingua: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Libri hot"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Libro nascosto"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "Errore nell'invio dell'email"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "Formato dell'indirizzo e-mail non valido"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 #, fuzzy
 msgid "Invalid request"
 msgstr "Ruolo non valido"
 
-#: cps/web.py:1470
+#: cps/web.py
 #, fuzzy
 msgid "Name and rules are required"
 msgstr "I campi username ed image data sono obbligatori."
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 #, fuzzy
 msgid "Error creating shelf"
 msgstr "Errore nell'eliminare lo scaffale"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Crea uno scaffale"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 #, fuzzy
 msgid "Shelf name is required"
 msgstr "Questo campo è obbligatorio"
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "Errore nell'eliminare lo scaffale"
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "Modifica uno scaffale"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "Utente non trovato"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "{} utenti eliminati correttamente"
 
-#: cps/web.py:1710
+#: cps/web.py
 #, fuzzy
 msgid "Error duplicating shelf"
 msgstr "Errore nell'eliminare lo scaffale"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 #, fuzzy
 msgid "Error deleting shelf"
 msgstr "Errore nell'eliminare lo scaffale"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "Errore nell'eliminare lo scaffale"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 #, fuzzy
 msgid "Error unhiding shelf"
 msgstr "Errore nell'eliminare lo scaffale"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Scaricati"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Elenco formati di file"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Configura prima le impostazioni della posta SMTP..."
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr "Per favore aggiorna il tuo profilo con un'e-mail eReader valida."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "Tutto OK! Libro in coda per l'invio a %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Si è verificato un errore durante l'invio del libro: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr "Nessun indirizzo email selezionato"
 
-#: cps/web.py:2473
+#: cps/web.py
 #, fuzzy
 msgid "Additional email addresses are disabled for your account."
 msgstr "Scegli gli indirizzi email:"
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "Successo! Libro accodato per l'invio agli indirizzi selezionati"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr "Attendi un minuto per registrare il prossimo utente"
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Registrati"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr ""
 "Il server e-mail non è configurato, per favore contatta l'amministratore"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr ""
 "Il server e-mail non è configurato, per favore contatta l'amministratore."
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "La tua email non è consentita."
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "Tutto OK! L'e-mail di conferma è stata inviata."
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
@@ -6339,7 +6241,7 @@ msgid ""
 msgstr ""
 "L'istanza Calibre-Web non è configurata, per favore contatta l'amministratore"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
@@ -6347,35 +6249,35 @@ msgid ""
 msgstr ""
 "Il server e-mail non è configurato, per favore contatta l'amministratore."
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr "Impossibile attivare l'autenticazione LDAP"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr "Attendi un minuto prima del prossimo accesso"
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "ora sei connesso come: '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "Tutto OK! Ora sei connesso come: %(nickname)s"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
@@ -6383,13 +6285,13 @@ msgid ""
 msgstr ""
 "L'istanza Calibre-Web non è configurata, per favore contatta l'amministratore"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6398,700 +6300,670 @@ msgstr ""
 "Accesso di riserva come: '%(nickname)s', il server LDAP non è raggiungibile "
 "o l'utente è sconosciuto"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr "Impossibile accedere: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 msgid "Wrong Username or Password"
 msgstr "Nome utente o password errati"
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr "La nuova password è stata inviata al tuo indirizzo e-mail"
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr "Si è verificato un errore sconosciuto, riprova più tardi."
 
-#: cps/web.py:2838
+#: cps/web.py
 msgid "Please enter valid username to reset password"
 msgstr "Inserisci un nome utente valido per reimpostare la password"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "Ora sei connesso come: '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 msgid "Success! Profile Updated"
 msgstr "Tutto OK! Profilo aggiornato"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "Esiste già un account per questa e-mail."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr "Book ID non valido."
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr "KOReader Sync Plugin"
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "Nessun file gmail.json valido con informazioni OAuth trovato"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "%(book)s inviato all'eReader"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "Invia all'eReader"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-send completed successfully"
 msgstr "{} utenti eliminati correttamente"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-Send"
 msgstr "Invia"
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr "Elimina contenuto della cartella temporanea"
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s inviato all'E-Reader"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Calibre ebook-convert %(tool)s non trovato"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "Formato %(format)s non trovato sul disco"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "La conversione del libro è terminata con un errore sconosciuto"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Errore con il convertitore Kepubify: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr "File convertito non trovato o più di un file nella cartella %(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Si è verificato un errore con Calibre: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Errore nel convertitore: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Riconnessione al database di Calibre"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "Duplicati"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Seleziona i duplicati"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Decompressione del pacchetto di aggiornamento"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Duplicati"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Abilita Hardcover Sync"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "E-mail"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr "Backup dei metadati"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "Nella biblioteca"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "Sono state generate %(count)s miniature delle copertine"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "Miniature delle copertine"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "Sono state generate {0} miniature delle serie"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "Cancellazione della cache delle miniature delle copertine"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "Libri organizzati in scaffali"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Cambia password"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Seleziona uno scaffale"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "Impostazioni di sicurezza"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Impostazioni"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "seleziona un'opzione"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 msgid "Add to Shelf"
 msgstr "Aggiungi allo scaffale"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Pubblico)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "Scaricati"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Scaricati"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "Ordina secondo la data dei libri, prima i più recenti"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "Ordina secondo la data dei libri, prima i più vecchi"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Autore"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Autore"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Pubblicato prima del "
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Pubblicato prima del "
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Ordina secondo il libro aggiunto allo scaffale, prima il più recente"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "Ordina secondo il libro aggiunto allo scaffale, prima il più vecchio"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr "Utenti&nbsp;&nbsp;👤"
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "Invia all'e-mail dell'eReader"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "Invia all'eReader"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Visualizza libri"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Scaffale pubblico"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr "Gestisci immagini del profilo"
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "Importa utenti LDAP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Impostazioni Server Email&nbsp;&nbsp;📬"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "Nome host SMTP"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "Porta SMTP"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "Accesso SMTP"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Da e-mail"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr "Servizio e-mail"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail via Oauth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr "Impostazioni&nbsp;&nbsp;⚙️"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Cartella del database di Calibre"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Livello di log"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Porta esterna"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Libri per pagina"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Caricamenti"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Navigazione anonima"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Registrazione pubblica"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Accesso remoto Magic Link"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Accesso reverse proxy"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Nome dell'intestazione reverse proxy"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Modifica la configurazione di base"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Modifica la configurazione dell'interfaccia utente"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Modifica la configurazione del database di Calibre"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "Attività pianificate&nbsp;&nbsp;⌛"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "Ora di inizio"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "Durata massima"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "Genera miniature delle copertine delle serie"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Riconnetti il database di Calibre"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr "Genera file di backup dei metadati"
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "Aggiorna la cache delle miniature"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 msgid "Setup KOReader Sync"
 msgstr "Configura KOReader Sync"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Run Hardcover Auto-Fetch"
 msgstr "Hardcover API token"
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Amministrazione&nbsp;&nbsp;🚀"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Scarica il pacchetto di debug"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Visualizza log"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Riavvia Calibre-Web"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Arresta Calibre-Web"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "Informazioni sulla versione&nbsp;&nbsp;📜"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Versione"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Dettagli"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "Aggiornamento non riuscito:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Canale d'aggiornamento"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Versione attuale"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Ricerca aggiornamenti"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Esegui l'aggiornamento"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Sei sicuro di voler riavviare Calibre-Web?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Sei sicuro di voler fermare Calibre-Web?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Aggiornamento in corso, non ricaricare la pagina"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7099,608 +6971,585 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Libri in questa biblioteca"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Caricamento in corso..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "Aggiornamento non riuscito:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Errore di connessione"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Serie: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "via"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "Nella biblioteca"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "riduci"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Altri di"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Elimina libro"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Elimina formati:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Converti formato libro:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Converti da:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr "seleziona un'opzione"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Converti in:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Converti libro"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Errore"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Carica formato"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "ID della serie"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Data di pubblicazione"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Tipo di identificatore"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Valore dell'identificatore"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Aggiungi identificatore"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Recupera la copertina dall'URL (JPEG: l'immagine verrà scaricata e "
 "archiviata nel database)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Carica la copertina dal disco locale"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "Abilita Hardcover Sync"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Visualizza il libro dopo averlo salvato"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Recupera i metadati"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Parola chiave"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "Cerca parola chiave"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Caricamento in corso..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Errore nella ricerca!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "Nessun risultato trovato! Prova con un'altra parola chiave."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "Questo campo è obbligatorio"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr "Inverti autore e titolo"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 msgid "Select all"
 msgstr "Seleziona tutto"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr "Cancella tutto"
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 msgid "Update Title Sort automatically  "
 msgstr "Aggiorna automaticamente l'ordinamento per titolo"
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Aggiorna automaticamente l'ordinamento per autore"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Inserisci titolo"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Inserisci ordinamento per titolo"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Ordina per titolo"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Inserisci ordinamento per autore"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Ordina per autore"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Inserisci autori"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Inserisci categorie"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Inserisci serie"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Inserisci lingue"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Data di pubblicazione"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Inserisci editori"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Inserisci commenti"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Comments"
 msgstr "Commenti"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 msgid "Archived?"
 msgstr "Archiviato?"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 msgid "Read?"
 msgstr "Letto?"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "Inserisci "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Sei veramente sicuro?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "I libri con titolo verranno uniti da:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "Nel libro con il titolo:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr "I libri seguenti verranno eliminati:"
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr "I libri seguenti verranno archiviati:"
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr "I seguenti libri saranno rimossi dall'archivio:"
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr "I libri seguenti verranno segnati come letti:"
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr "I libri seguenti verranno segnati come non letti:"
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Modifica i metadati"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr "Modifica i campi che desideri. I campi vuoti saranno ignorati:"
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 msgid "Select a Shelf"
 msgstr "Seleziona uno scaffale"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr "Seleziona uno scaffale a cui aggiungere i libri selezionati:"
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr "-- Crea uno scaffale --"
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Aggiungi"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr ""
 "Il server e-mail non è configurato, per favore contatta l'amministratore."
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr "Messaggio"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Seleziona almeno un indirizzo email"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Invia all'eReader"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Indietro"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Posizione del database di Calibre (metadata.db file)"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7716,13 +7565,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7733,7 +7582,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7750,11 +7599,11 @@ msgstr ""
 "campo che appare sotto dopo aver selezionato l'opzione <b>Separa i file dei "
 "libri dalla libreria</b>."
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr "Funzionalità Split Library"
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
@@ -7764,32 +7613,32 @@ msgstr ""
 "code> dovrebbe rimanere in <code>/calibre-library</code>, tuttavia, i file "
 "della libreria possono essere salvati dove preferisci"
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Utilizzare Google Drive?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Autentica Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Cartella Calibre di Google Drive"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "ID del canale di visualizzazione dei metadati"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Revoca"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Riconnetti il database di Calibre"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7799,101 +7648,101 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "Sei sicuro di voler fermare Calibre-Web?"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Riconnetti il database di Calibre"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr ""
 "La nuova posizione del database non è valida, inserisci un percorso valido"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Usa autenticazione standard"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Usa l'autenticazione LDAP"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Usa OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Configurazione del server"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Porta del server"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Posizione del file del certificato SSL (lascia vuoto per una configurazione "
 "del server senza SSL)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Posizione del file della chiave SSL (lascia vuoto per una configurazione del "
 "server senza SSL)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Canale d'aggiornamento"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Stabile"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Notturno"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "Host attendibili (separati da virgole)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Configurazione del file di log"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr ""
 "Posizione e nome del file di log degli accessi (se non specificato sarà "
 "access.log)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Abilita il log degli accessi"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr ""
 "Posizione e nome del file di log degli accessi (se non specificato sarà "
 "access.log)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 msgid "Feature Configuration"
 msgstr "Configurazione delle funzionalità"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 "Converti caratteri non inglesi nel titolo e nell'autore durante il "
 "salvataggio su disco"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
@@ -7901,41 +7750,41 @@ msgstr ""
 "Incorpora metadati nel file del libro al momento del download e della "
 "conversione per e-mail (sono necessari gli eseguibili Calibre/Kepubify)"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Abilita il caricamento"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr ""
 "(assicurati che gli utenti dispongano anche delle autorizzazioni di "
 "caricamento)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Formati di file autorizzati ad essere caricati"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Abilita la navigazione anonima"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Abilita la registrazione pubblica"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "Usa l'e-mail come nome utente"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Abilita l'accesso remoto con Magic Link"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7943,156 +7792,156 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Inoltra richieste sconosciute al Kobo Store"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Porta esterna del server (per chiamate API con port forwarding)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 "Sincronizza i progressi di lettura di Kobo con Hardcover (richiede una "
 "chiave API per ogni utente)"
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Usa Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Chiave API Goodreads"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 msgid "Enable Hardcover Sync"
 msgstr "Abilita Hardcover Sync"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr "Hardcover API Key"
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "Il token è scaduto"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Chiave API Goodreads"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8100,182 +7949,182 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Consenti autenticazione con reverse proxy"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Tipo di accesso"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "Nome host o indirizzo IP del server LDAP"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "Porta del server LDAP"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "Crittografia LDAP"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Percorso certificato CA LDAP (necessario solo per l'autenticazione del "
 "certificato client)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Percorso certificato LDAP (necessario solo per l'autenticazione del "
 "certificato client)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Percorso del file di chiavi LDAP (necessario solo per l'autenticazione del "
 "certificato client)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "Autenticazione LDAP"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Semplice"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "Nome utente amministratore LDAP"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "Password amministratore LDAP"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "Nome distinto LDAP (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "Filtro oggetto utente LDAP"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "Il server LDAP è OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr ""
 "Per l'importazione degli utenti sono necessarie le seguenti impostazioni"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "Filtro oggetto gruppo LDAP"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "Nome gruppo LDAP"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "Campo membri del gruppo LDAP"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "Rilevamento filtro utente membro LDAP"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "Trova automaticamente"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "Filtro personalizzato"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "Filtro utente membro LDAP"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr "Provider OAuth generico"
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr "URL dei metadati OAuth (per il rilevamento automatico)"
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 msgid "Test Metadata"
 msgstr "Metadati di prova"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr "Lascia vuoti per usare la configurazione manuale sotto"
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 "Utilizza gli URL degli endpoint manuali (sovrascrivi il rilevamento "
 "automatico)"
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
@@ -8283,230 +8132,230 @@ msgstr ""
 "Selezionare questa opzione per configurare manualmente i singoli endpoint "
 "OAuth invece di utilizzare il rilevamento automatico"
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 msgid "Manual Endpoint Configuration"
 msgstr "Modifica la configurazione dell'Endpoint"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr "URL di base di OAuth"
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr "Endpoint di autorizzazione"
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 msgid "Token Endpoint"
 msgstr "Token dell'Endpoint"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr "Endpoint Userinfo"
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 msgid "Test Connection"
 msgstr "Prova la connessione"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 msgid "OAuth Scopes"
 msgstr "Ambito OAuth"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr "Lista separata da spazi di ambiti OAuth"
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 msgid "OAuth Client Id"
 msgstr "ID client di OAuth"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 msgid "OAuth Client Secret"
 msgstr "OAuth Client Secret"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 msgid "Field Mapping Configuration"
 msgstr "Mappatura dei campi di configurazione"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 msgid "Username Field"
 msgstr "Campo della Username"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr "Campo JWT per estrarre la Username"
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 msgid "Email Field"
 msgstr "Campo Email"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr "Campo JWT per estrarre la Email"
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "Gruppo OAuth per Admin"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr "Gruppo OAuth per Admin"
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Impostazioni predefinite per i nuovi utenti"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Consenti download"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Consenti visualizzatore eBook"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Consenti caricamenti"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Consenti modifiche"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Consenti eliminazione libri"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Consenti modifica password"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Consenti modifica scaffali pubblici"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr "Testo del bottone login"
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Ottieni le credenziali OAuth di %(provider)s"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "%(provider)s ID client OAuth"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "%(provider)s Secret OAuth Client"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "File eseguibili esterni"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr "Percorso dei file eseguibili di Calibre"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 msgid "Calibre E-Book Converter Settings"
 msgstr "Impostazioni del convertitore di libri di Calibre"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Percorso del convertitore di libri Kepubify"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 msgid "Location of Unrar binary"
 msgstr "Posizione del file binario di UnRar"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 msgid "Security Settings"
 msgstr "Impostazioni di sicurezza"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8514,339 +8363,334 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr "Limita tentativi di accesso non riusciti"
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr "Configura il backend per il limitatore"
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr "Opzioni per il limitatore del Backend"
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 "Controlla se le estensioni dei file corrispondono al contenuto del file al "
 "momento del caricamento"
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 msgid "Session protection"
 msgstr "Protezione della sessione"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr "Base"
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr "Forte"
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 msgid "User Password policy"
 msgstr "Politica password utente"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr "Lunghezza minima password"
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr "Obbliga numero"
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr "Obbliga caratteri minuscoli"
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr "Obbliga caratteri maiuscoli"
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 "Obbliga caratteri (necessario per caratteri cinesi, giapponesi e coreani)"
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr "Obbliga caratteri speciali"
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Visualizza configurazione"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Numero di libri casuali da mostrare"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr ""
 "Numero di autori da mostrare prima di nascondere (0=disabilita nascondere)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "Predefinito"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "Tema caliBlur! scuro"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Espressione regolare per ignorare le colonne"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Collega lo stato letto/da leggere nella colonna di Calibre"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "Collega lo stato letto/da leggere nella colonna di Calibre"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Visualizza le restrizioni basate sulla colonna di Calibre"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Espressione regolare per l'ordinamento dei titoli"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Visualizza configurazione"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Custom CSS"
 msgstr "Filtro personalizzato"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Impostazioni predefinite per i nuovi utenti"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "Versione"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Utente amministratore"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "Visualizzazione a pagina singola"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "Lingua predefinita"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "Impostazioni predefinite per i nuovi utenti"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "Lingua predefinita di presentazione dei libri"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "Visibilità predefinita per i nuovi utenti"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Visibilità predefinita per i nuovi utenti"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Mostra Libri casuali nella visualizzazione dettagliata"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Aggiungi etichetta consentiti/negati"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Aggiungi valori di colonna personalizzati consentiti/negati"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Caricamento"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run Archive"
 msgstr "Esegui archiviazione"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 msgid "Download Log"
 msgstr "Scarica i log"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Avvio"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8855,14 +8699,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8870,96 +8714,95 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "Modifica i libri selezionati"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "{} utenti eliminati correttamente"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "Errore nell'invio dell'email"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "Nessun risultato trovato"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "Inserisci nome utente"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "Cerca nella biblioteca"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "Seleziona uno scaffale"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "Modifica i libri selezionati"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "Errore nell'invio dell'email"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Abilita/disabilita i servizi Calibre-Web Automated"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8967,11 +8810,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -8982,11 +8825,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -8996,163 +8839,163 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "Libri archiviati"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr "Abilita servizio CWA Automatic Cover & Metadata Enforcement"
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9160,11 +9003,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9172,65 +9015,63 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "Metadati aggiornati correttamente"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identificatori"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "Copertina"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 1-200 MB (default: 15)"
 msgstr "Intervallo: 5-120 minuti (impostazione predefinita: 15)"
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr "Timeout di elaborazione per il servizio di Ingest"
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
@@ -9241,49 +9082,49 @@ msgstr ""
 "spostati nella cartella di backup dei file con errori per consentirne "
 "l'analisi."
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr "Timeout (minuti):"
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr "Intervallo: 5-120 minuti (impostazione predefinita: 15)"
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Stale temp age (minutes):"
 msgstr "Timeout (minuti):"
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr "Intervallo: 5-120 minuti (impostazione predefinita: 15)"
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr "Intervallo: 5-120 minuti (impostazione predefinita: 15)"
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9291,162 +9132,162 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Delay (minutes):"
 msgstr "Timeout (minuti):"
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr "Intervallo: 5-120 minuti (impostazione predefinita: 15)"
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Hardcover API token"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Token Required"
 msgstr "Hardcover API token"
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr "Intervallo: 5-120 minuti (impostazione predefinita: 15)"
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr "Intervallo: 5-120 minuti (impostazione predefinita: 15)"
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr "Intervallo: 5-120 minuti (impostazione predefinita: 15)"
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 msgid "Web UI Settings"
 msgstr "Impostazioni Interfaccia Utente WEB"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "Impostazioni backup automatico"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9454,36 +9295,35 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr "Abilita le notifiche di contributo alla traduzione"
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -9493,22 +9333,22 @@ msgstr ""
 "utilizzi una lingua diversa dall'inglese qualora le traduzioni per la lingua "
 "selezionata non siano complete."
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Sincronizza gli scaffali selezionati con Kobo"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Abilita la sfocatura degli sfondi sui dispositivi mobile (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -9517,15 +9357,15 @@ msgstr ""
 "applicato anche sugli schermi di piccole dimensioni. Disabilitare in caso si "
 "riscontrino rallentamenti nello scorrimento o nelle animazioni."
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 msgid "Automatic Backup Settings"
 msgstr "Impostazioni backup automatico"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -9533,11 +9373,11 @@ msgstr ""
 "Se attivo, una copia di tutti i file importati verrà salvata in <i>/config/"
 "processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -9545,21 +9385,21 @@ msgstr ""
 "Se attivo, le versioni originali dei file aggiunti e convertiti mediante il "
 "servizio di Ingest verranno salvate in /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9572,11 +9412,11 @@ msgstr ""
 "Ciò aiuta a mantenere le sottocartelle di /config/processed_books "
 "organizzate e a minimizzare l'utilizzo di spazio su disco."
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -9587,32 +9427,32 @@ msgstr ""
 "formato qui selezionato (ad eccezione dei formati selezionati nell'elenco di "
 "esclusione di seguito)"
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 msgid "Choose a target format:"
 msgstr "Scegli il formato di destinazione:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9620,21 +9460,21 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "Calibre è in grado di individuare eventuali titoli di libri duplicati "
 "durante l'importazione e, agendo sulle"
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr "impostazioni"
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -9642,583 +9482,571 @@ msgstr ""
 "di merge automatico, può essere impostato per cancellare una delle due "
 "istanze o per conservarle entrambe (impostazione predefinita)."
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Annulla l'importazione del duplicato, conserva la copia della libreria"
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr "Sovrascrive la copia della libreria con il file di nuova importazione"
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Crea una voce duplicata, mantenendo così entrambe le copie"
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Abilita la registrazione pubblica"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Impostazioni backup automatico"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Manual only"
 msgstr "Manuale?"
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Abilita le notifiche di aggiornamento di CWA"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Abilita la registrazione pubblica"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Formato Originale"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Metadati di prova"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Valutazione"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr "Clicca per vedere altro"
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Successivo"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Contrassegna come da leggere"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Contrassegna come letto"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "Contrassegna come letto"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "Contrassegna come da leggere"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Aggiungi all'archivio"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Ripristina dall'archivio"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Ripristina dall'archivio"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Aggiungi all'archivio"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "Ripristina dall'archivio"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "Cerca nella biblioteca"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "Impostazioni del database aggiornate"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "Valutazione superiore a"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "Libro %(index)s di %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 #, fuzzy
 msgid "File sizes"
 msgstr "Dimensioni caratteri"
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Descrizione:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 msgid "Select eReader Email Addresses"
 msgstr "Seleziona gli indirizzi email dell'eReader"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 msgid "Choose email addresses:"
 msgstr "Scegli gli indirizzi email:"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 msgid "Select All"
 msgstr "Seleziona tutto"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Additional email addresses:"
 msgstr "Scegli gli indirizzi email:"
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Enter additional email addresses (separated by commas):"
 msgstr "Scegli gli indirizzi email:"
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 msgid "Select format:"
 msgstr "Seleziona formato:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "Impossibile creare il percorso per la copertina"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "Impossibile creare il percorso per la copertina"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
@@ -10227,147 +10055,147 @@ msgstr ""
 "Libri con titolo e autore corrispondenti. Si raccomanda l'ispezione visiva "
 "per individuare gli effettivi duplicati."
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Duplicati"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "Mostra Libri duplicati"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr "Seleziona i duplicati"
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 msgid "Select None"
 msgstr "Non selezionare nulla"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 msgid "Delete Selected"
 msgstr "Elimina selezionati"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Duplicati"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Auto-Resolve Duplicates"
 msgstr "Seleziona i duplicati"
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "Precedente"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "Unisci i libri selezionati"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "Dettagli del libro"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "modifica i metadati"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "Archivia i libri selezionati"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 msgid "No Duplicate Books Found"
 msgstr "Nessun libro duplicato trovato"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 "La tua libreria non contiene libri con combinazione di titolo e autore "
 "duplicati."
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
@@ -10375,123 +10203,123 @@ msgstr ""
 "Questo strumento ricerca i libri con titolo E autore identici al fine di "
 "evitare falsi positivi."
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Seleziona formato:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr "Questa funzione non può essere annullata!"
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 msgid "The following books will be permanently deleted:"
 msgstr "I libri seguenti verranno eliminati in modo permanente:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "Libri da leggere"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "I libri seguenti verranno eliminati:"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "I libri seguenti verranno eliminati in modo permanente:"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr "Fatto"
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr "I libri duplicati selezionati sono stati eliminati!"
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr "Si è verificato un errore."
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "Tipo di account e-mail"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr "Account e-mail standard"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr "Account Gmail"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr "Configura l'account Gmail"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Revoca l'accesso a Gmail"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "Password SMTP"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Limite dimensione allegato"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 msgid "Save and Send Test Email"
 msgstr "Salva e invia e-mail di prova"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Domini consentiti (lista bianca)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Aggiungi dominio"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Inserisci nome del dominio"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Domini non consentiti (lista nera)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10499,119 +10327,113 @@ msgstr ""
 "Apri il file .kobo/Kobo/Kobo eReader.conf in un editor di testo e aggiungi "
 "(o modifica):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Token di Kobo:"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "Elenco"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "Seleziona tutto"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "Termine di ricerca:"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "Visualizza il libro dopo averlo salvato"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "Seleziona tutto"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "Caricamento in corso..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
@@ -10619,44 +10441,41 @@ msgid ""
 msgstr ""
 "Sei sicuro di voler cambiare il ruolo selezionato per gli utenti selezionati?"
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "Impossibile creare il percorso per la copertina"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr ""
 "Sei sicuro di voler cambiare il ruolo selezionato per gli utenti selezionati?"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "Seleziona tutto"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "Impossibile creare il percorso per la copertina"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
@@ -10664,419 +10483,418 @@ msgid ""
 msgstr ""
 "L'istanza Calibre-Web non è configurata, per favore contatta l'amministratore"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Segnala problema"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Ritorna alla pagina principale"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "Disconnetti utente"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "Modifica uno scaffale"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show this shelf in your sidebar"
 msgstr "Sincronizza questo scaffale con il lettore Kobo"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "Mostra tutto"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "Scaffale pubblico"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Aggiungi allo scaffale"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 #, fuzzy
 msgid "KOReader Sync is disabled."
 msgstr "KOReader Sync Plugin"
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Home"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Attiva/disattiva navigazione"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Cerca nella biblioteca"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Catalogo eBook Calibre-Web"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Disconnetti"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 msgid "Refresh Library"
 msgstr "Aggiorna la libreria"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Nessuna informazione disponibile sulla versione"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Catalogo eBook Calibre-Web"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr "Vedi Changelog"
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Duplicati"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr "Clicca per contribuire!"
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Per favore non aggiornare la pagina"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Crea uno scaffale"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Precedente"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Dettagli del libro"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Questa funzione non può essere annullata!"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Elimina selezionati"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Formato Finale"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Elimina formati:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Libro duplicato"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nessun libro duplicato trovato"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "Seleziona i duplicati"
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Adatta al meglio"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "A:"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "Configurazione"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Aggiungi allo scaffale"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Segna i libri selezionati come letti"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Contrassegna come da leggere"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Elimina libro"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Elimina libro"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Seleziona uno scaffale"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Errore di connessione"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr "Filtra per iniziale"
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "Griglia"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "Password SMTP"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Ricordami"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Password dimenticata?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Accedi con Magic Link"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 msgid "Log in with SSO"
 msgstr "Accedi con SSO"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Mostra log di Calibre-Web: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Calibre-Web Log: "
 msgstr "Mostra log di Calibre-Web: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Flusso in uscita, non può essere visualizzato"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Mostra log di accesso: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Scarica il log di Calibre-Web"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "Scarica il log di accesso"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "Condividi con tutti"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Seleziona le etichette consentite/negate"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Seleziona i valori personali consentiti/negati per le colonne"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Seleziona le categorie consentite/negate per l'utente"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr ""
 "Seleziona i valori personali consentiti/negati per le colonne dell'utente"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Inserisci etichetta"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Aggiungi restrizioni di visualizzazione"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "Questo formato di libro verrà definitivamente cancellato dal database"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Questo libro verrà definitivamente cancellato dal database"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "e dal disco rigido"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Nota importante su Kobo: i libri eliminati rimarranno su qualsiasi "
 "dispositivo Kobo associato."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11084,566 +10902,562 @@ msgstr ""
 "I libri devono essere prima archiviati e il dispositivo sincronizzato prima "
 "che un libro possa essere eliminato in sicurezza."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Scegli la posizione del file"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "tipo"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "nome"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "dimensione"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "Cartella superiore"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "OK"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Catalogo eBook Calibre-Web"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "Lettore epub"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "Azioni"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "Nero"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "Dimensioni caratteri"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Pagina successiva"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr "Carattere"
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 msgid "Default"
 msgstr "Predefinito"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr "Yahei"
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr "SimSun"
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 msgid "KaiTi"
 msgstr "KaiTi"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 msgid "Arial"
 msgstr "Arial"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 msgid "Spread"
 msgstr "Doppia pagina"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr "Due colonne"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr "Una colonna"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Adatta il testo quando le barre laterali sono aperte."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Lettore di fumetti"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Scorciatoie della tastiera"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Pagina precedente"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Pagina successiva"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 msgid "Single Page Display"
 msgstr "Visualizzazione a pagina singola"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr "Visualizzazione a striscia lunga"
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Adatta al meglio"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Adatta alla larghezza"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Adatta all'altezza"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Adatta all'originale"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Ruota a destra"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Ruota a sinistra"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Capovolgi immagine"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "Visualizzazione"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 msgid "Single Page"
 msgstr "Pagina singola"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr "Striscia lunga"
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Scala"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Migliore"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Larghezza"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Altezza"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Originale"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Ruota"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Capovolgi"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Orizzontale"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Verticale"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 msgid "Direction"
 msgstr "Orientamento"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Da sinistra a destra"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Da destra a sinistra"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr "Reimposta in alto"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 msgid "Remember Position"
 msgstr "Ricorda la posizione"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "Barra di scorrimento"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "Mostra"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "Lettore DJVU"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "Lettore PDF"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "Lettore txt"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Registra un nuovo account"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Scegli un nome utente"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "La tua e-mail"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Magic Link: autorizza nuovo dispositivo"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "Su un altro dispositivo, accedi e visita:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "Una volta verificato, accederai automaticamente a questo dispositivo."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Questo link di verifica scadrà tra 10 minuti."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "Genera miniature delle copertine delle serie"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Nessun risultato trovato"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Termine di ricerca:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Risultati per:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Data di pubblicazione dal"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Data di pubblicazione fino al"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr "Vuoto"
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Escludi etichette"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Escludi serie"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "Escludi scaffali"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Escludi lingue"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Estensioni"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Escludi estensioni"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Valutazione superiore a"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Valutazione inferiore a"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "Da:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "A:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Elimina questo scaffale"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "Modifica le caratteristiche dello scaffale"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Libro nascosto"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "Disponi libri manualmente"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "Disabilita la modifica della disposizione"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "Abilita la modifica della disposizione"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Modifica i libri selezionati"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Account"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Token non trovato"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Elimina questo scaffale"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Aggiungi allo scaffale"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Cerca nella biblioteca"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Cerca nella biblioteca"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Condividi con tutti"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "Sincronizza questo scaffale con il lettore Kobo"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Utente non trovato"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Libro nascosto"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Statistiche della biblioteca"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Libri in questa biblioteca"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Autori in questa biblioteca"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Categorie in questa biblioteca"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Serie in questa biblioteca"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Statistiche del sistema"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "Programma"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Versione installata"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Tempo d'esecuzione"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr "Azioni"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "Ruota"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 "Questa attività verrà annullata. Tutti i progressi compiuti da questa "
 "attività verranno salvati."
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
@@ -11651,396 +11465,396 @@ msgstr ""
 "Se si tratta di un'attività pianificata, verrà eseguita nuovamente "
 "all'orario pianificato successivo."
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "I libri duplicati selezionati sono stati eliminati!"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Catalogo eBook Calibre-Web"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "La tua e-mail"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "Impostazioni"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Reimposta la password dell'utente"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "Configurazione del server"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "Seleziona gli indirizzi email dell'eReader"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "Inserisci lingue"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Lingua dei libri"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "Nessun libro valido per la lingua specificata"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "Impostazioni OAuth"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Collega"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Scollega"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Hardcover API Token"
 msgstr "Hardcover API token"
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Token di sincronizzazione Kobo"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Crea/Visualizza"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "Forza sincronizzazione kobo completa"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "Sincronizza con Kobo unicamente i libri negli scaffali selezionati"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "Sincronizza con Kobo unicamente i libri negli scaffali selezionati"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "Impostazioni di sicurezza"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Aggiungi valori personali consentiti/negati nelle colonne"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Magic Shelves Order"
 msgstr "Sincronizza gli scaffali selezionati con Kobo"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "Libri aggiunti di recente"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "Modifica gli scaffali pubblici"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Elimina utente"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12048,155 +11862,155 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Cambia password"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Cambia password"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Crea/Visualizza"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Genera URL di autenticazione per Kobo"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Seleziona..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Rimuovi le selezioni"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "Modifica utente"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "Inserisci nome utente"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 msgid "Enter Email"
 msgstr "Inserisci e-mail"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "Enter eReader Email"
 msgstr "Inserisci e-mail dell'eReader"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "eReader Email"
 msgstr "E-mail dell'eReader"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "Inserisci e-mail dell'eReader"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "E-mail dell'eReader"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Locale"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "Lingue dei libri visibili"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "Modifica le etichette consentite"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Etichette consentite"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Modifica le etichette non consentite"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Etichette non consentite"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "Modifica i valori delle colonne consentite"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "Valori delle colonne consentiti"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "Modifica i valori per le colonne non consentite"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "Valori per le colonne non consentite"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "Cambia password"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "Modifica gli scaffali pubblici"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "Sincronizza gli scaffali selezionati con Kobo"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "Sincronizza gli scaffali selezionati con Kobo"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 msgid "Show Read/Unread Section"
 msgstr "Mostra sezione Libri letti e Libri da leggere"
 

--- a/cps/translations/ja/LC_MESSAGES/messages.po
+++ b/cps/translations/ja/LC_MESSAGES/messages.po
@@ -19,45 +19,45 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "統計"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 "Calibreデータベースが利用できません。ライブラリパスを再設定してください。"
 
-#: cps/admin.py:208
+#: cps/admin.py
 msgid "Server restarted, please reload page."
 msgstr "サーバーを再起動しました。ページを再読み込みしてください。"
 
-#: cps/admin.py:210
+#: cps/admin.py
 msgid "Performing Server shutdown, please close window."
 msgstr "サーバーをシャットダウンしています。ウィンドウを閉じてください。"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "成功！データベースに再接続しました"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "不明なコマンド"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 "成功！書籍がメタデータバックアップのキューに追加されました。結果はタスクを確"
 "認してください"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
@@ -65,346 +65,339 @@ msgstr ""
 "エラー：Hardcoverトークンがありません。HARDCOVER_TOKEN環境変数を設定するか、"
 "基本設定で構成してください。"
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 "成功！Hardcover自動取得タスクを開始しました。進捗はタスクパネルを確認してくだ"
 "さい。"
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr "Hardcover自動取得タスクの開始エラー：%(error)s"
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr "Hardcoverマッチング結果をレビュー"
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr "レビューキューの読み込みエラー：%(error)s"
 
-#: cps/admin.py:414
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover ID applied successfully"
 msgstr "Hardcover IDの適用に成功しました"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr "マッチング結果を%(action)s"
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr "拒否対象の保留中マッチング結果はありません"
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr "%(count)s件のマッチング結果を拒否しました"
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 "{}冊のサムネイルキャッシュ更新を開始しました。数分かかる場合があります。"
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr "処理対象の表紙付き書籍が見つかりません。"
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr "サムネイル更新の開始に失敗しました：{}"
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "管理者ページ"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "Hardcoverトークンが必要"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "基本設定"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "UI設定"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr "カスタムカラムの%(column)d列目がcalibreのDBに存在しません"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "ユーザーを編集"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "全て"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "ユーザーが見つかりません"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{}人のユーザーが削除されました"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "全て表示"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "不正なリクエスト"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "ゲストユーザーの名前は変更できません"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "ゲストユーザーはこのロールを持つことができません"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr "管理者ユーザーが残っておらず、管理者ロールを削除できません"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "値はtrueかfalseのどちらかでなければなりません"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "無効なロール"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "ゲストユーザーはこの画面を表示できません"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "無効な表示"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 "ゲストユーザーの言語設定は自動的に決定されるため、固定することはできません"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "有効な言語設定がありません"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "有効な本の言語がありません"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "パラメータが見つかりません"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "設定DBが書き込みできません"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "無効な読み取り列"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "無効な制限列"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Koboのトークンを削除してもよろしいですか？"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "このドメインを削除してもよろしいですか？"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "このユーザーを削除してもよろしいですか？"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "この本棚を削除してもよろしいですか？"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr "選択したユーザーの言語設定を変更してもよろしいですか？"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr "選択したユーザーが表示できる本の言語を変更してもよろしいですか？"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr "選択したユーザーの選択したロールを変更してもよろしいですか？"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
 msgstr "選択したユーザーの選択した制限を変更してもよろしいですか？"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
 msgstr "選択したユーザーの選択した表示制限を変更してもよろしいですか？"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr "選択したユーザーの本棚同期の動作を変更してもよろしいですか？"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
 msgstr "選択したユーザーの本棚同期の動作を変更してもよろしいですか？"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Calibreライブラリのパスを変更してもよろしいですか？"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "拒否"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "許可"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "{}件の同期項目を削除しました"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "トークンが見つかりません"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "タグが見つかりません"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "無効なアクションです"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.jsonがWebアプリケーション用に設定されていません"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "ログファイルの場所が無効です。正しいパスを入力してください"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "アクセスログファイルの場所が無効です。正しいパスを入力してください"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr "LDAPのプロバイダ、ポート番号、DN、ユーザーIDを入力してください"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "LDAPのサービスアカウント名とパスワードを入力してください"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "LDAPのサービスアカウント名を入力してください"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr "LDAPのグループフィルタには \"%s\" というフォーマットのIDが一つ必要です"
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "LDAPのグループフィルタ内の括弧が一致しません"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr "LDAPのユーザーフィルタには \"%s\" というフォーマットのIDが一つ必要です"
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "LDAPのユーザーフィルタ内の括弧が一致しません"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr "LDAPのメンバーフィルタには \"%s\" というフォーマットのIDが一つ必要です"
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "LDAPのメンバーフィルタ内の括弧が一致しません"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -412,29 +405,24 @@ msgstr ""
 "LDAP CA証明書、証明書、またはキーの場所が無効です。正しいパスを入力してくださ"
 "いLDAPのCA証明書、証明書、キーの場所が無効です。正しいパスを入力してください"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "新規ユーザーを追加"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "メールサーバー設定を編集"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "成功！Gmailアカウントが確認されました。"
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "DBエラー: %(error)s"
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -442,53 +430,53 @@ msgstr ""
 "%(email)s 宛のテストメールを送信キューに追加しました。結果はタスクを確認して"
 "ください"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "%(res)s へのテストメール送信中にエラーが発生しました"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "初めにメールアドレスを設定してください"
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "メールサーバーの設定を更新しました"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "ユーザーを編集"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "まずSMTPメール設定を行ってください..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "初めにメールアドレスを設定してください"
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "新しいパスワードがあなたのメールアドレスに送信されました"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -496,7 +484,7 @@ msgstr ""
 "%(email)s 宛のテストメールを送信キューに追加しました。結果はタスクを確認して"
 "ください"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -505,170 +493,168 @@ msgstr ""
 "%(email)s 宛のテストメールを送信キューに追加しました。結果はタスクを確認して"
 "ください"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "スケジュールタスク設定を編集"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "指定したタスクの開始時刻が無効です"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "指定したタスクの期間が無効です"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "スケジュールタスクの設定を更新しました"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "不明なエラーが発生しました。あとで再試行してください。"
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "タイトル"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "ユーザー %(nick)s を編集"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "成功！ユーザー %(user)s のパスワードをリセットしました"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "SMTPメール設定を行ってください。"
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "ログファイルビューア"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "更新データを要求中"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "更新データをダウンロード中"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "更新データを展開中"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "ファイルを置換中"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "DB接続を切断"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "サーバー停止中"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "アップデート完了、OKを押してページを再読み込みしてください"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "アップデート失敗:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "HTTPエラー"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "接続エラー"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "接続確立中にタイムアウトしました"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "エラー発生"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr "更新データを一時フォルダに保存できませんでした"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "更新中にファイルを置換できませんでした"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "少なくとも1人のLDAPユーザーの抽出に失敗しました"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "少なくとも1人のLDAPユーザーの作成に失敗しました"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "エラー: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "エラー: LDAPサーバーのレスポンスでユーザーが返されません"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "DB内にLDAPユーザーが1人も見つかりません"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{}人のユーザーをインポートしました"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr "書籍パスが無効です"
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "DBの場所が無効です。正しいパスを入力してください"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "DBへの書き込みができません"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "キーファイルの場所が無効です。正しいパスを入力してください"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr "証明書ファイルの場所が無効です。正しいパスを入力してください"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 "リバースプロキシ認証を有効にしないと、ユーザー自動作成は有効にできません"
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr "ユーザー自動作成には有効なリバースプロキシヘッダー名が必要です"
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
@@ -676,7 +662,7 @@ msgstr ""
 "OAuthリダイレクトホストの形式が無効です。プロトコルを含む完全なURLを入力して"
 "ください（例：https://your-domain.com）"
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
@@ -684,76 +670,76 @@ msgstr ""
 "OAuthリダイレクトホストにはパスを含めないでください。ベースURLのみを使用して"
 "ください（例：https://your-domain.com）"
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr "パスワードの長さは1〜40文字である必要があります"
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "DB設定を更新しました"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "DB設定"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "全ての項目を入力してください"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "このメールは有効なドメインからのものではありません"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "新規ユーザー追加"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "ユーザー '%(user)s' を作成しました"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr ""
 "このメールアドレスかニックネームで登録されたアカウントがすでに存在します。"
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "ユーザー '%(nick)s' を削除しました"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "ゲストユーザーは削除できません"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "管理者ユーザーが残っておらず、ユーザーを削除できません"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "メールアドレスは空欄にできず、有効なメールアドレスである必要があります"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "ユーザー '%(nick)s' を更新しました"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 "接続成功！OIDCディスカバリーエンドポイントにアクセスできます。%(endpoints)s"
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
@@ -761,12 +747,12 @@ msgstr ""
 "接続失敗：OIDCディスカバリーエンドポイントが見つかりません（404）。ベースURL"
 "が正しいか確認してください。"
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr "接続失敗：サーバーがステータスコード %(code)s を返しました"
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
@@ -774,13 +760,13 @@ msgstr ""
 "接続失敗：サーバーに接続できませんでした。URLとネットワーク接続を確認してくだ"
 "さい。"
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 "接続失敗：リクエストがタイムアウトしました。サーバーが遅いか到達不能です。"
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
@@ -788,12 +774,12 @@ msgstr ""
 "接続失敗：サーバーが無効なJSONを返しました。OIDCエンドポイントではない可能性"
 "があります。"
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "接続失敗：%(error)s"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
@@ -802,29 +788,29 @@ msgstr ""
 "メタデータに必要なOIDCフィールドがありません：%(fields)s。有効なOIDCメタデー"
 "タエンドポイントではない可能性があります。"
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 "メタデータURLは有効です！%(count)s個のOAuthエンドポイントが見つかりました。"
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "リリース情報がありません"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 " 注意：ユーザー情報エンドポイントが見つかりません。認証で問題が発生する可能性"
 "があります。"
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr "メタデータURLが見つかりません（404）。URLが正しいか確認してください。"
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
@@ -832,48 +818,48 @@ msgstr ""
 "接続失敗：メタデータURLに接続できませんでした。URLとネットワーク接続を確認し"
 "てください。"
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr "接続失敗：リクエストがタイムアウトしました。"
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr "接続失敗：レスポンスに無効なJSONが含まれています。"
 
-#: cps/admin.py:3340
+#: cps/admin.py
 msgid "An unknown error occurred."
 msgstr "不明なエラーが発生しました。"
 
-#: cps/admin.py:3352
+#: cps/admin.py
 msgid "Restore already in progress."
 msgstr "復元は既に進行中です。"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr "復元失敗：Calibreライブラリパスが設定されていません。"
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr "復元失敗：metadata.dbが%(path)sに見つかりません"
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr "復元失敗：app.dbが%(path)sに見つかりません"
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: %(err)s"
 msgstr "復元失敗：%(err)s"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 "復元は完了しましたが、app.dbのクリーンアップに失敗しました。詳細はログを確認"
 "してください。"
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
@@ -882,467 +868,457 @@ msgstr ""
 "復元完了。バックアップと復元ログを%(dir)sに保存しました。書籍に紐づくすべての"
 "データがリセットされました。"
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "ファイル %(file)s をアップロードしました"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr "チェコ語"
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr "ドイツ語"
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr "ギリシャ語"
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr "スペイン語"
 
-#: cps/constants.py:265
+#: cps/constants.py
 msgid "Finnish"
 msgstr "フィンランド語"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr "フランス語"
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr "ガリシア語"
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr "ハンガリー語"
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr "インドネシア語"
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr "イタリア語"
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr "日本語"
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr "クメール語"
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr "韓国語"
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr "オランダ語"
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr "ノルウェー語"
 
-#: cps/constants.py:276
+#: cps/constants.py
 msgid "Polish"
 msgstr "ポーランド語"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr "ポルトガル語"
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr "ポルトガル語（ブラジル）"
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr "ロシア語"
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr "スロバキア語"
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr "スロベニア語"
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr "スウェーデン語"
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr "トルコ語"
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr "ウクライナ語"
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr "ベトナム語"
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr "中国語（簡体字、中国）"
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr "中国語（繁体字、台湾）"
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "インストールされていません"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "実行権限がありません"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, fuzzy, python-format
 msgid "Change cover — %(title)s"
 msgstr "著者とタイトルを入れ替え"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "接続エラー"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Could not render the e-reader preview."
 msgstr "指定されたディレクトリが見つかりませんでした"
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr "テーマ切り替えはv5.0.0まで一時的に無効化されています"
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 "ライブラリ更新 🔄 見落とされた可能性のある書籍を確認中です、お待ちください..."
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr "重複スキャンのcron式が無効です。変更は保存されませんでした。"
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr "タイムスタンプ"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Book ID"
 msgstr "書籍ID"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "本のタイトル"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Book Author"
 msgstr "著者"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr "トリガータイプ"
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Filepath"
 msgstr "ファイルパス"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Filename"
 msgstr "ファイル名"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr "手動？"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr "修正数"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr "元ファイルをバックアップ済み？"
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr "適用された修正"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr "元の形式"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "End Format"
 msgstr "変換後の形式"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 msgid "Unknown User"
 msgstr "不明"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr "✅ すべての監視サービスが正常に稼働しています！👍"
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr "🔴 取り込みサービスは稼働中ですが、メタデータ変更検出は停止しています"
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr "🔴 メタデータ変更検出は稼働中ですが、取り込みサービスは停止しています"
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr "⛔ 取り込みサービスとメタデータ変更検出の両方が停止しています"
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr "エラーが発生しました"
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 "単一書籍のEPUB修復ツールはGoogle Driveライブラリでサポートされていません。"
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "無効な書籍IDです。"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "選択した本を統合"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "EPUBファイルがディスク上に見つかりません。"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 msgid "EPUB Fixer started for selected book."
 msgstr "選択した書籍のEPUB修復ツールを開始しました。"
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr "選択した書籍のEPUB修復ツール開始に失敗しました。"
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr "このページにアクセスするには管理者権限が必要です。"
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr "ユーザー名と画像データの両方が必要です。"
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr "画像データの形式が無効です。有効な画像である必要があります。"
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr "サポートされていない画像形式です。PNGとJPEGのみ使用できます。"
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr "画像が大きすぎます。500KB未満の画像を使用してください。"
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr "無効なBase64画像データです。"
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 msgid "Invalid image data format."
 msgstr "無効な画像データ形式です。"
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr "画像データの検証エラー。"
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr "プロフィール画像を更新しました。"
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "なし"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 msgid "Duplicate Books"
 msgstr "重複する書籍"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr "重複グループは既に解除済みです"
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "本を削除"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "本を削除"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr "重複グループは解除されませんでした"
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "結果が見つかりません"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr "重複スキャンが完了しました（フォールバック）"
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 #, fuzzy
 msgid "Invalid resolution strategy"
 msgstr "無効なロール"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
@@ -1350,91 +1326,88 @@ msgstr ""
 "取り込みフォルダーへ書き込めません。/cwa-book-ingestボリュームの権限を確認し"
 "てください。"
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr "フォーマットアップロード用の書籍IDがないか無効です"
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr "フォーマットをアップロードできません：書籍がライブラリに存在しません"
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "アップロード完了。現在処理中ですのでお待ち下さい..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 msgid "Failed to queue upload for processing"
 msgstr "アップロードの処理キューへの追加に失敗しました"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "変換元の形式または変換後の形式が指定されていません"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "本の %(book_format)s への変換がキューに追加されました"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "この本の変換中にエラーが発生しました: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "このファイル形式はこのサーバーへのアップロードが許可されていません"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr ""
 "ファイル拡張子 '%(ext)s' をこのサーバーにアップロードすることは許可されていま"
 "せん"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "アップロードするファイルには拡張子が必要です"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr "選択した本は利用できません。ファイルが存在しないか、アクセスできません"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "ユーザーは表紙をアップロードする権限がありません"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr "IDは大文字小文字を区別しません。元のIDを上書きします"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "'%(langname)s' は有効な言語ではありません"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "メタデータを更新しました"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "本編集中のエラー: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "不明"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1443,97 +1416,97 @@ msgstr ""
 "アップロードする前に変更を検討してください：アップロードした本はすでにライブ"
 "ラリに存在します。新しくアップロードする前に変更を加えてください: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "ファイル %(filename)s は一時フォルダに保存できませんでした"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "表紙ファイル %(file)s の移動に失敗しました: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "本の形式を削除しました"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "本を削除しました"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "本を削除する権限がありません"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "メタデータを編集"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr ""
 "シリーズ番号: %(seriesindex)s は有効な数字ではありません。スキップします"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr "新たなファイル形式をアップロードする権限がありません"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "%(path)s の作成に失敗しました (Permission denied)。"
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "ファイル %(file)s を保存できません。"
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "ファイル形式 %(ext)s が %(book)s に追加されました"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "トークンが見つかりません"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "EPUBファイルがディスク上に見つかりません。"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1542,7 +1515,7 @@ msgstr ""
 "効にしてくださいGoogleドライブの設定が完了していません。Googleドライブを無効"
 "にしてから再度有効にしてみてください"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1551,89 +1524,88 @@ msgstr ""
 "確認する手順に従ってくださいコールバックドメインが認証されていません。Google "
 "Developer Consoleでドメインを認証してください"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "ID: %(book)d の本に %(format)s フォーマットはありません"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "Googleドライブ: %(fn)s に %(format)s はありません"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s がありません: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "E-Readerに送信"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "ID: %(book)d の本に %(format)s フォーマットはありません"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "ID: %(book)d の本に %(format)s フォーマットはありません"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 msgid "Test Email"
 msgstr "テストメール"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "ユーザー: %(name)s の登録メール"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "%(orig)s を %(format)s に変換して電子書籍リーダーに送信"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, python-format
 msgid "Send %(format)s to eReader"
 msgstr "%(format)s を電子書籍リーダーに送信"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s を電子書籍リーダーに送信"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr ""
 "要求されたファイルを読み込めませんでした。権限設定が正しいか確認してくださ"
 "い。"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "読み込みステータスを設定できません: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
@@ -1641,12 +1613,12 @@ msgstr ""
 "書籍 %(id)s のフォルダ削除に失敗しました。パスにサブフォルダがあります："
 "%(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "本 %(id)s の削除に失敗しました: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1655,47 +1627,47 @@ msgstr ""
 "書籍 %(id)s をデータベースからのみ削除します。データベース内の書籍パスが無効"
 "です：%(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "著者名を '%(src)s' から '%(dest)s' に変更できませんでした。エラー：%(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "ファイル %(file)s はGoogleドライブ上にありません"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "エラー: %(error)s により、タイトルを %(src)s から %(dest)s に変更できませんで"
 "した"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "本のパス %(path)s はGoogleドライブ上にありません"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr "このメールアドレスで既存のアカウントが見つかりました"
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "このユーザー名はすでに使われています"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr "メールアドレスの形式が無効です"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr "パスワードがパスワード検証ルールに準拠していません"
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
@@ -1703,24 +1675,24 @@ msgstr ""
 "ドに必要です表紙のアップロードに必要なPythonモジュール 'advocate' がインス"
 "トールされていません"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "表紙のダウンロードに失敗しました"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr "表紙画像が最大サイズ%(size)s MBを超えています"
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr "表紙ファイルが有効な画像ファイルでないか、または保存できませんでした"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "表紙形式エラー"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
@@ -1729,107 +1701,107 @@ msgstr ""
 "とは許可されていません表紙アップロードのためにlocalhostやローカルネットワーク"
 "にアクセスすることは許可されていません"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "表紙ファイルの作成に失敗しました"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "表紙ファイルは jpg/jpeg/png/webp/bmp のみ対応しています"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "表紙ファイルの内容が無効です"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "表紙ファイルは jpg/jpeg のみ対応しています"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr "表紙"
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "UnRarのバイナリファイルが見つかりません"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr "UnRarの実行中にエラーが発生しました"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr "指定されたディレクトリが見つかりませんでした"
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr "ファイルではなくディレクトリを指定してください"
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr "Calibreバイナリが使用できません"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr "Calibreバイナリがありません：%(missing)s"
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "実行権限がありません: %(missing)s"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr "Calibreの実行中にエラーが発生しました"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr "すべての書籍をメタデータバックアップのキューに追加"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Kobo設定"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "%(provider)s で登録"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
@@ -1838,13 +1810,13 @@ msgstr ""
 "ログイン失敗：OAuthトークンの検証エラー。スコープ設定の不一致が原因の可能性が"
 "あります。OAuthスコープ設定を確認するか、管理者にお問い合わせください。"
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 "ログイン失敗：OAuthトークンの有効期限が切れています。再度ログインしてくださ"
 "い。"
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
@@ -1852,14 +1824,14 @@ msgstr ""
 "ログイン失敗：OAuthプロバイダーのユーザー情報エンドポイントに接続できませんで"
 "した。再試行するか、管理者にお問い合わせください。"
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "メールサーバーが設定されていません。管理者に連絡してください"
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1869,37 +1841,37 @@ msgstr ""
 "ログイン失敗：OAuthプロバイダーの応答に必要なフィールドがありません："
 "%(fields)s。OAuth設定を確認するか、管理者にお問い合わせください。"
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr "OAuthアカウントの連携に失敗しました。再試行してください。"
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 "OAuthエラー：プロバイダーが無効なユーザー情報を返しました。再試行してくださ"
 "い。"
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "%(nickname)s としてログイン中"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "%(oauth)s との連携に成功しました"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1910,62 +1882,62 @@ msgstr ""
 "ん。アカウントの作成または既存アカウントの連携については管理者にお問い合わせ"
 "ください。"
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr "OAuth認証に失敗しました。再試行するか、管理者にお問い合わせください。"
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr "メールサーバーが設定されていません。管理者に連絡してください"
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "%(oauth)s との連携解除に成功しました"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "%(oauth)s との連携解除に失敗しました"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "%(oauth)s と連携していません"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "GitHubアカウントでのログインに失敗しました。"
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "GitHubからのユーザー情報取得に失敗しました。"
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Googleアカウントでのログインに失敗しました。"
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Googleからのユーザー情報取得に失敗しました。"
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 msgid "Failed to log in with Generic OAuth."
 msgstr "汎用OAuthでのログインに失敗しました。"
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr "OAuth認証失敗：トークンの検証エラー。再試行してください。"
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 "予期しないエラーによりOAuth認証に失敗しました。管理者にお問い合わせください。"
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
@@ -1974,4085 +1946,4017 @@ msgstr ""
 "OAuthエラー：無効なリダイレクトURIです。このエラーが繰り返し発生する場合は、"
 "管理 > 基本設定 > OAuthで「OAuthリダイレクトホスト」を設定してください。"
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "GitHub OAuth エラー、再度お試しください。"
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "GitHub OAuth エラー: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Google OAuth エラー、再度お試しください。"
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Google OAuth エラー: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr "OAuthエラー: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "五十音順の本"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "五十音順にソートされた本"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "人気の本"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "ダウンロード数に基づいた、この出版社が出している有名な本"
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "高評価の本"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "評価に基づいた、この出版社が出している有名な本"
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "ダウンロードされた本"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "最新の本"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "ランダム"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "ランダムに本を表示"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "既読の本"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "現在のバージョン"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "未読の本"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "著者"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "著者名順"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "出版社"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "出版社順"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "カテゴリ"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "カテゴリ順"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "シリーズ"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "シリーズ順"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "言語"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "言語順"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "評価"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "評価順"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "ファイル形式"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "ファイル形式順"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "本棚"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "本棚に整理された本"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Magic Shelves ✨"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "本棚に整理された本"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "詳細"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "星{}"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "検索"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "ログイン"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "トークンが見つかりません"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "トークンが無効です"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "成功です！端末に戻ってください"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "本"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "最近追加された本を表示"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "人気の本を表示"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "ダウンロードされた本"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "ダウンロードされた本を表示"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "高評価の本を表示"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 msgid "Show Read and Unread"
 msgstr "既読と未読を表示"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "未読の本を表示"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "見つける"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Category Section"
 msgstr "カテゴリセクションを表示"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Series Section"
 msgstr "シリーズセクションを表示"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Author Section"
 msgstr "著者セクションを表示"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Publisher Section"
 msgstr "出版社セクションを表示"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Language Section"
 msgstr "言語セクションを表示"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Ratings Section"
 msgstr "評価セクションを表示"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show File Formats Section"
 msgstr "ファイル形式セクションを表示"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "アーカイブされた本"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Archived Books"
 msgstr "アーカイブされた書籍を表示"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "本の一覧"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "本の一覧を表示"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr "重複"
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 msgid "Show Duplicate Books"
 msgstr "重複する書籍を表示"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "これ以降に出版 "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "これ以前に出版 "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "評価 <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "評価 >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "既読状況 = '%(status)s'"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 "カスタムカラムの検索でエラーが発生しました。Calibre-Webを再起動してください"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "詳細検索"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "指定された本棚は無効です"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr ""
 "申し訳ありませんが、あなたはこの本棚に本を追加することが許可されていません"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "この本は %(shelfname)s にすでに追加されています"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr "%(book_id)s は無効な書籍IDです。本棚に追加できませんでした"
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "本を %(sname)s に追加しました"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "あなたはこの本棚に本を追加することが許可されていません"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "これらの本は %(name)s にすでに追加されています"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "本が %(sname)s に追加されました"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "%(sname)s に本を追加できません"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "指定された本棚は無効です"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "%(sname)s に本を追加できません"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "これらの本は %(name)s にすでに追加されています"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "本が %(sname)s に追加されました"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "本が %(sname)s から削除されました"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr ""
 "申し訳ありませんが、あなたはこの本棚から本を削除することが許可されていません"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "本棚を作成する"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "申し訳ありませんが、あなたはこの本棚を編集することが許可されていません"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "本棚を編集する"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "本棚の削除中にエラーが発生しました"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "本棚を削除しました"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "'%(name)s' 内の本の順番を変更する"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr ""
 "申し訳ありませんが、あなたはみんなの本棚を作成することが許可されていません"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "%(title)s を作成しました"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "%(title)s を変更しました"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "エラーが発生しました"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "'%(title)s' という名前のみんなの本棚はすでに存在します。"
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "'%(title)s' という名前の本棚はすでに存在します。"
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "本棚: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "本棚を開けません。この本棚は存在しないかアクセスできません"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "除外する本棚"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 #, fuzzy
 msgid "Name (A → Z)"
 msgstr "名前（A-Z）"
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 #, fuzzy
 msgid "Name (Z → A)"
 msgstr "名前（Z-A）"
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 #, fuzzy
 msgid "Book count (most → fewest)"
 msgstr "書籍数（多い順）"
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 #, fuzzy
 msgid "Book count (fewest → most)"
 msgstr "書籍数（多い順）"
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 #, fuzzy
 msgid "Created (newest → oldest)"
 msgstr "作成日（新しい順）"
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 #, fuzzy
 msgid "Created (oldest → newest)"
 msgstr "作成日（古い順）"
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 #, fuzzy
 msgid "Manual (drag below)"
 msgstr "手動（ドラッグで並び替え）"
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "匿名"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "認証失敗"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr "タグを追加"
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "既読"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "未読"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "既読/未読"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "テーマ"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "ライト"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "ダーク"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "セピア"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "本棚に追加"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "著者"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "閲覧"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "閉じる"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "削除"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "統合"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "出版社"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "既読"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "タイトル"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "アップロード"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "アカウント"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "管理者"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "発売日"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "ソース"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "このサイトについて"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr "すべて"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr "アーカイブ"
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "アーカイブ済み"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "変換"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr "追加日"
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "詳細"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr "解除"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "ダウンロード"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "編集"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "メールアドレス"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Koboの同期を有効にする"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "暗号化"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "非表示"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "識別子"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "言語"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr "最終更新"
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr "既読にする"
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr "未読にする"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "パスワード"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "ポート番号"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "進捗"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "評価"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "保存"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "選択"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr "送信"
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "ステータス"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr "Ko-fiで支援する →"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "タグ"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "タスク"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "タスク"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr "アーカイブ解除"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "ユーザー"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "ユーザー名"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "閲覧"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "待機中"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "失敗"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "開始"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "終了"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "終了"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "キャンセル"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "不明"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "アップデート情報の読み込み中に予期しないデータが見つかりました"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr ""
 "アップデートはありません。すでに最新バージョンがインストールされています"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6061,16 +5965,16 @@ msgstr ""
 "新してください。アップデートが利用可能です。下のボタンをクリックして最新バー"
 "ジョンにアップデートしてください。"
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "アップデート情報を取得できません"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr ""
 "下のボタンをクリックして最新の安定バージョンにアップデートしてください。"
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6080,163 +5984,163 @@ msgstr ""
 "新してください。アップデートが利用可能です。下のボタンをクリックしてバージョ"
 "ン: %(version)s にアップデートしてください。"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "リリース情報がありません"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "本を見つける (ランダムに表示)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "人気の本 (最もダウンロードされた本)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "%(user)s がダウンロードした本"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "著者: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "出版社: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "シリーズ: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "評価: なし"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "評価: 星%(rating)s"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "ファイル形式: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "カテゴリ: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "言語: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "人気の本"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "非表示の本"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "Magic Shelfの読み込みエラー"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr "ルールが指定されていません"
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "メールアドレスの形式が無効"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr "ルールの処理エラー"
 
-#: cps/web.py:1426
+#: cps/web.py
 #, fuzzy
 msgid "Invalid request"
 msgstr "無効なロール"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr "名前とルールは必須です"
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr "シェルフ名が長すぎます（最大100文字）"
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 #, fuzzy
 msgid "Error creating shelf"
 msgstr "本棚の削除中にエラーが発生しました"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Magic Shelfを作成"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr "公開ステータスを変更する権限がありません"
 
-#: cps/web.py:1587
+#: cps/web.py
 #, fuzzy
 msgid "Shelf name is required"
 msgstr "この項目は必須です"
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "本棚の削除中にエラーが発生しました"
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "Magic Shelfを編集"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "ユーザーが見つかりません"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr "権限がありません"
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "シェルフを複製しました"
 
-#: cps/web.py:1710
+#: cps/web.py
 #, fuzzy
 msgid "Error duplicating shelf"
 msgstr "本棚の削除中にエラーが発生しました"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
@@ -6244,102 +6148,100 @@ msgstr ""
 "システムシェルフは削除できません。ユーザープロフィール設定で非表示にできま"
 "す。"
 
-#: cps/web.py:1755
+#: cps/web.py
 #, fuzzy
 msgid "Error deleting shelf"
 msgstr "本棚の削除中にエラーが発生しました"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr "自分のシェルフは非表示にできません。不要な場合は削除してください。"
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr "シェルフは既に非表示です"
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "本棚の削除中にエラーが発生しました"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr "シェルフは非表示になりませんでした"
 
-#: cps/web.py:1818
+#: cps/web.py
 #, fuzzy
 msgid "Error unhiding shelf"
 msgstr "本棚の削除中にエラーが発生しました"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "ダウンロード数"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "ファイル形式一覧"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr "まずSMTPメール設定を行ってください..."
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 "有効な電子書籍リーダーのメールアドレスをプロフィールに設定してください。"
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "本の %(eReadermail)s への送信がキューに追加されました"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "%(res)s を送信中にエラーが発生しました"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr "メールアドレスが選択されていません"
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr "追加のメールアドレスはあなたのアカウントで無効化されています。"
 
-#: cps/web.py:2500
+#: cps/web.py
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "成功！選択したアドレスへの送信キューに書籍を追加しました"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr "次のユーザー登録まで1分お待ちください"
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "登録"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr "リミッターバックエンドへの接続エラーです。管理者に連絡してください"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr "メールサーバーが設定されていません。管理者に連絡してください"
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "このメールアドレスは登録が許可されていません"
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "確認メールがこのメールアドレスに送信されました。"
 
-#: cps/web.py:2624
+#: cps/web.py
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
@@ -6347,34 +6249,34 @@ msgstr ""
 "認証ループを検出しました。ログインに問題がある場合は、管理者にお問い合わせく"
 "ださい。"
 
-#: cps/web.py:2704
+#: cps/web.py
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "OAuth認証が正しく設定されていません。管理者にお問い合わせください。"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr "LDAP認証を有効にできません"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr "標準ログインは無効化されています。"
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr "次のログインまで1分お待ちください"
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr "ユーザー名を空にできません"
 
-#: cps/web.py:2756
+#: cps/web.py
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "'%(nickname)s' としてログインしました"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
@@ -6383,7 +6285,7 @@ msgstr ""
 "ようこそ！アカウントが自動作成されました。'%(nickname)s'としてログインしまし"
 "た"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
@@ -6391,7 +6293,7 @@ msgstr ""
 "認証は成功しましたが、アカウント作成に失敗しました。管理者にお問い合わせくだ"
 "さい。"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
@@ -6399,7 +6301,7 @@ msgstr ""
 "認証は成功しましたが、ローカルアカウントが見つかりません。アカウント作成につ"
 "いては管理者にお問い合わせください。"
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6408,701 +6310,671 @@ msgstr ""
 "フォールバックログイン：'%(nickname)s'、LDAPサーバーに到達できないか、ユー"
 "ザーが不明です"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr "ログインできませんでした: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 msgid "Wrong Username or Password"
 msgstr "ユーザー名またはパスワードが間違っています"
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr "新しいパスワードをメールアドレスに送信しました"
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr "不明なエラーが発生しました。後でもう一度お試しください。"
 
-#: cps/web.py:2838
+#: cps/web.py
 msgid "Please enter valid username to reset password"
 msgstr "パスワードをリセットするには有効なユーザー名を入力してください"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "'%(nickname)s' としてログインしました"
 
-#: cps/web.py:3158
+#: cps/web.py
 msgid "Success! Profile Updated"
 msgstr "成功！プロフィールを更新しました"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "このメールアドレスで登録されたアカウントがすでに存在します"
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr "無効な書籍IDです。"
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr "KOReader同期プラグイン"
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "OAuth情報を含んだ有効なgmail.jsonファイルが見つかりません"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr "Hardcover IDを自動取得中"
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "eReaderに送信準備中..."
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr "利用可能なフォーマットを確認中..."
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "E-Readerに送信"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-send completed successfully"
 msgstr "自動送信に成功しました"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr "自動送信"
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr "一時フォルダの内容を削除"
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s をE-Readerに送信"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Calibre ebook-convert %(tool)s が見つかりません"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "%(format)s 形式は存在しません"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "Ebook converter が不明なエラーで失敗しました"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Kepubify-converter が失敗しました: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "変換されたファイルが見つからないか、またはフォルダー %(folder)s 内に複数存在"
 "します"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre が失敗しました: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Ebook-converter が失敗しました: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Calibre DBと再接続中"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr "アーカイブ済み書籍の参照をクリーンアップ"
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "本を削除"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan skipped: import in progress"
 msgstr "重複スキャン完了：%(count)sの新規グループ"
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "この重複グループを解除"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "更新データを展開中"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "結果が見つかりません"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr "重複スキャン完了：%(count)sグループ"
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr "重複スキャン完了：%(count)sの新規グループ"
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr "重複スキャン完了：%(count)sグループを自動解決"
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Hardcover同期を有効にする"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "メール"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr "メタデータをバックアップ中"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr "ライブラリ変換 – 全実行"
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "ライブラリ内"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr "EPUB修復ツール – 全実行"
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr "EPUB修復ツール"
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "表紙サムネイルを%(count)s個生成しました"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "表紙サムネイル"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "シリーズのサムネイルを{0}個生成しました"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "表紙サムネイルのキャッシュを消去中"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "本棚に整理された本"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "パスワード変更"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "本棚を選択"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "OAuth設定"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "設定"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "オプションを選択"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 msgid "Add to Shelf"
 msgstr "本棚に追加"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(公開)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "ダウンロード数"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "ダウンロード数"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "作成日（新しい順）"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "作成日（古い順）"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "著者"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "著者"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "作成日（新しい順）"
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "作成日（古い順）"
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "本棚に追加された順でソート（新しい順）"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "本棚に追加された順でソート（古い順）"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr "ユーザー&nbsp;&nbsp;👤"
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "E-Readerメールアドレス"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "E-Readerに送信"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "閲覧"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "みんなの本棚"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr "プロフィール画像の管理"
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "LDAPユーザーをインポート"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "メールサーバー設定&nbsp;&nbsp;📬"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "SMTPホスト名"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "SMTPポート番号"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "SMTPログイン"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Fromメールアドレス"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr "メールサービス"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "OAuth2経由のGmail"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr "設定&nbsp;&nbsp;⚙️"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Calibre DBのディレクトリ"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "ログレベル"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "外部ポート"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "1ページに表示する冊数"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "アップロード"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "匿名での閲覧"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "誰でも登録可能"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "マジックリンクによるリモートログイン"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "リバースプロキシによるログイン"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "リバースプロキシのヘッダー名"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "基本設定を編集"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "UI設定を編集"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Calibre DBの設定を編集"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "スケジュールされたタスク&nbsp;&nbsp;⌛"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "タスクを開始する時間"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "最大タスク継続時間"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr "スケジュール済みサムネイル更新"
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "シリーズの表紙サムネイルを生成"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Calibreライブラリに再接続"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr "メタデータバックアップファイルを生成"
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "表紙サムネイルのキャッシュを更新"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 msgid "Setup KOReader Sync"
 msgstr "KOReader同期を設定"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr "Hardcover自動取得を実行"
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "管理&nbsp;&nbsp;🚀"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "デバッグパッケージをダウンロード"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "ログを表示"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "再起動"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "シャットダウン"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "バージョン情報&nbsp;&nbsp;📜"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "バージョン"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "詳細"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "アップデート失敗:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "アップデートチャンネル"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "現在のバージョン"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "アップデートを確認"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "アップデートを実行"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "再起動してもよろしいですか？"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "シャットダウンしてもよろしいですか？"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "アップデート中です。このページをリロードしないでください"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7110,422 +6982,400 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import"
 msgstr "重要："
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "このライブラリ内の本の冊数"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "アップロード中..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "アップデート失敗:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "接続エラー"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr "メモ："
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "シリーズ: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "経由"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "ライブラリ内"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "減らす"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "同じ著者が書いた本: "
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "本を削除"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "削除する形式:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "変換する形式:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "変換元:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr "オプションを選択"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "変換先:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "本を変換"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "エラー"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "アップロード形式"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "巻数"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "発売日"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "識別子タイプ"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "識別子の値"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "削除"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "識別子を追加"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr "表紙をURLから取得 (JPEG画像がダウンロードされDBに保存されます)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "表紙をアップロード"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "Hardcover同期のブラックリスト"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr "Hardcoverへの注釈同期をブラックリスト化"
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr "Hardcoverへの読書進捗同期をブラックリスト化"
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "保存後に本を表示"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "メタデータを取得"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "キーワード"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "キーワード検索"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr "選択したメタデータフィールドを編集フォームに適用しました。"
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "読み込み中..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "検索エラー"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "検索結果が見つかりません。別のキーワードで検索してみてください。"
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "この項目は必須です"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr "著者とタイトルを入れ替え"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 msgid "Select all"
 msgstr "すべて選択"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr "すべてクリア"
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 msgid "Update Title Sort automatically  "
 msgstr "タイトルソートを自動更新"
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "著者のよみがなを自動で更新"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "タイトルを入力"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "タイトルのよみがなを入力"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "タイトルのよみがな"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "著者名のよみがなを入力"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "著者名のよみがな"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "著者名を入力"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "カテゴリ名を入力"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "シリーズ名を入力"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "言語を入力"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "発売日"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "出版社を入力"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "コメントを入力"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Comments"
 msgstr "コメント"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 msgid "Archived?"
 msgstr "アーカイブ済み？"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 msgid "Read?"
 msgstr "既読？"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "入力: "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "よろしいですか?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "このタイトルの本から"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "このタイトルの本に統合します"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr "以下の書籍が削除されます："
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr "以下の書籍がアーカイブされます："
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr "以下の書籍のアーカイブが解除されます："
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr "以下の書籍が既読としてマークされます："
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr "以下の書籍が未読としてマークされます："
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "メタデータを編集"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 "変更したいフィールドを編集してください。空白のフィールドは無視されます："
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
@@ -7533,186 +7383,185 @@ msgstr ""
 "著者、タグ/カテゴリ、言語、出版社では複数の値がサポートされています。カンマ区"
 "切りで指定してください（例：\"Name1, Name2\"）。"
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 msgid "Select a Shelf"
 msgstr "本棚を選択"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr "選択した書籍を追加する本棚を選択してください："
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr "-- 本棚を選択 --"
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "追加"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr "メールサーバーが設定されていません。管理者に連絡してください"
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr "メッセージ"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "新しいパスワードがあなたのメールアドレスに送信されました"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "E-Readerに送信"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "戻る"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Calibreデータベース（metadata.dbファイル）の場所"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7728,13 +7577,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7745,7 +7594,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7762,11 +7611,11 @@ msgstr ""
 "        チェックした後に表示されるフィールドに<code>/books</code>と入力できま"
 "す。"
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr "分割ライブラリ機能"
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
@@ -7776,32 +7625,32 @@ msgstr ""
 "<code>/calibre-library</code>に残しますが、ライブラリファイルは任意の場所に配"
 "置できます"
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Googleドライブを利用しますか？"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Googleドライブを認証"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Googleドライブ上のCalibreフォルダ"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "メタデータ監視用チャンネルID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "取り消す"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Calibreライブラリに再接続"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7817,90 +7666,90 @@ msgstr ""
 "のデータベースは自動的に/config/backupへバックアップされます。</b>復元ログが"
 "バックアップと共に保存されます。"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "シャットダウンしてもよろしいですか？"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Calibreライブラリに再接続"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr "入力したDBの場所が無効です。有効なパスを入力してください"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "通常の認証を利用"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "LDAP認証を利用"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "OAuthを利用"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "サーバー設定"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "ポート番号"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL証明書の場所 (非SSLサーバーでは空欄にしてください)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL鍵ファイルの場所 (非SSLサーバーでは空欄にしてください)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "アップデートチャンネル"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "安定"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "最新"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "信頼するホスト名 (カンマ区切り)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "ログファイル設定"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "アクセスログのファイル名 (空欄の場合はaccess.log)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "アクセスログを保存する"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "アクセスログのファイル名 (空欄の場合はaccess.log)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 msgid "Feature Configuration"
 msgstr "機能設定"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr "ダウンロード時にタイトルと著者名の中にある2バイト文字を変換する"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
@@ -7908,39 +7757,39 @@ msgstr ""
 "ダウンロード/変換/メール時に電子書籍ファイルにメタデータを埋め込む（Calibre/"
 "Kepubifyバイナリが必要）"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "アップロード機能を有効にする"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr "(ユーザーにアップロード権限を与えることも忘れないでください)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "アップロードを許可するファイル形式"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "匿名での閲覧を許可"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "誰でも登録可能にする"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "メールアドレスをユーザー名として使う"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "マジックリンクによるリモートログインを有効にする"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7948,154 +7797,154 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Koboストアへの不明なリクエストをプロキシ"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr ""
 "サーバーの外部ポート番号 (APIの呼び出しをポートフォワーディングするため)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr "Koboの注釈をHardcoverに同期（ユーザーごとにAPIキーが必要）"
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Goodreadsを利用"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "GoodreadsのAPIキー"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 msgid "Enable Hardcover Sync"
 msgstr "Hardcover同期を有効にする"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr "Hardcover APIキー"
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "トークンが無効です"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "GoodreadsのAPIキー"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8103,11 +7952,11 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "リバースプロキシの認証を許可"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
@@ -8116,11 +7965,11 @@ msgstr ""
 "リバースプロキシからの\"Remote-User\"ヘッダーを認証に信頼します。これは認証方"
 "式であり、下記のHTTPSセキュリティ設定とは別のものです。"
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr "HTTPS経由で使用"
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
@@ -8129,11 +7978,11 @@ msgstr ""
 "バーにアクセスする場合のみ有効にしてください。そうでない場合はログインできな"
 "くなります。"
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr "リバースプロキシからユーザーを自動作成"
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
@@ -8142,73 +7991,73 @@ msgstr ""
 "有効なリバースプロキシヘッダーを受信した際にユーザーアカウントを自動作成しま"
 "す。リバースプロキシ認証が適切に保護されている場合のみ有効にしてください。"
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "ログインの種類"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr "OAuthを使用（HTTPSが必要）"
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "LDAPサーバーのホスト名またはIPアドレス"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "LDAPサーバーのポート番号"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "LDAPの暗号化方式"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr "LDAPのCA証明書のパス (クライアント証明書による認証の場合のみ必要)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr "LDAP証明書のパス (クライアント証明書による認証の場合のみ必要)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr "LDAPのキーファイルのパス (クライアント証明書による認証の場合のみ必要)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "LDAP認証"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "簡単"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "LDAP管理者のユーザー名"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "LDAP管理者のパスワード"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "LDAPの識別名 (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "LDAPユーザーフィルタ"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "LDAPサーバーはOpenLDAPですか？"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr "LDAPからユーザーを自動作成"
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
@@ -8216,43 +8065,43 @@ msgstr ""
 "新規ユーザーのLDAP認証が成功した際にユーザーアカウントを自動作成します。エン"
 "タープライズ環境で推奨されます。"
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr "以下の設定はユーザーのインポートのために必要です"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "LDAPグループフィルタ"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "LDAPグループ名"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "LDAPグループメンバーフィールド"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "LDAPメンバーユーザーフィルタ検出"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "自動検出"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "カスタムフィルタ"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "LDAPメンバーユーザーフィルタ"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr "重要："
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
@@ -8260,27 +8109,27 @@ msgstr ""
 "OAuth認証ではこのサーバーへのHTTPSアクセスが必要です。HTTPを使用している場"
 "合、ログインに失敗します。"
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr "汎用OAuthプロバイダー"
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr "OAuthメタデータURL（自動検出用）"
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 msgid "Test Metadata"
 msgstr "メタデータをテスト"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr "空欄のまま下の手動設定を使用"
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr "手動エンドポイントURLを使用（自動検出を上書き）"
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
@@ -8288,43 +8137,43 @@ msgstr ""
 "自動検出を使用せずにOAuthエンドポイントを個別に手動設定するにはこれをチェック"
 "してください"
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 msgid "Manual Endpoint Configuration"
 msgstr "手動エンドポイント設定"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr "OAuth ベースURL"
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr "認証エンドポイント"
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 msgid "Token Endpoint"
 msgstr "トークンエンドポイント"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr "ユーザー情報エンドポイント"
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 msgid "Test Connection"
 msgstr "接続テスト"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 msgid "OAuth Scopes"
 msgstr "OAuthスコープ"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr "スペース区切りのOAuthスコープリスト"
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr "OAuthリダイレクトホスト"
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
@@ -8334,7 +8183,7 @@ msgstr ""
 "名を設定します。プロトコル（https://）を含めてください。空欄の場合は自動検出"
 "されます。"
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
@@ -8342,70 +8191,70 @@ msgstr ""
 "次の場合に必要：複数のホスト名でアクセス、リバースプロキシ配下、\"invalid "
 "redirect URI\"エラーが発生する場合。"
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 msgid "OAuth Client Id"
 msgstr "OAuthクライアントID"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 msgid "OAuth Client Secret"
 msgstr "OAuthクライアントシークレット"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 msgid "Field Mapping Configuration"
 msgstr "フィールドマッピング設定"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 msgid "Username Field"
 msgstr "ユーザー名フィールド"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr "ユーザー名を抽出するJWTフィールド"
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 msgid "Email Field"
 msgstr "メールフィールド"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr "メールアドレスを抽出するJWTフィールド"
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "管理者用OAuthグループ"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr "管理者用OAuthグループ"
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
@@ -8415,101 +8264,101 @@ msgstr ""
 "理を無効化します。より詳細な制御にはセキュリティ設定のグローバル設定を使用し"
 "てください。"
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "新規ユーザーのデフォルト設定"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "ダウンロードを許可"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "本のビューアを許可"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "アップロードを許可"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "編集を許可"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "本の削除を許可"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "パスワード変更を許可"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "みんなの本棚の編集を許可"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr "ログインボタンのテキスト"
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "%(provider)s OAuth 認証情報を入手"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "%(provider)s OAuth クライアントID"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "%(provider)s OAuth クライアントシークレット"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "外部バイナリ"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr "Calibreバイナリへのパス"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 msgid "Calibre E-Book Converter Settings"
 msgstr "Calibre電子書籍コンバーター設定"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Kepubify E-Book Converterのパス"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 msgid "Location of Unrar binary"
 msgstr "Unrarバイナリの場所"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 msgid "Security Settings"
 msgstr "セキュリティ設定"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr "標準ログイン（ユーザー名/パスワード）を無効化"
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
@@ -8518,11 +8367,11 @@ msgstr ""
 "する必要があります。有効化する前に代替のログイン方法が機能していることを確認"
 "してください。"
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr "OAuthグループベースの管理者ロール管理を有効化"
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8533,87 +8382,87 @@ msgstr ""
 "または取り消されます。無効化すると、ユーザー管理パネルで管理者ロールを手動管"
 "理でき、OAuthログインによるローカルロール割り当ての上書きを防げます。"
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr "ログイン失敗回数を制限"
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr "リミッターのバックエンドを設定"
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr "リミッターバックエンドのオプション"
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr "アップロード時にファイル拡張子がファイル内容と一致するか確認"
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 msgid "Session protection"
 msgstr "セッション保護"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr "基本"
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr "強力"
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 msgid "User Password policy"
 msgstr "ユーザーパスワードポリシー"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr "パスワードの最小長"
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr "数字を必須にする"
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr "小文字を必須にする"
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr "大文字を必須にする"
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr "文字を必須にする（中国語/日本語/韓国語の文字に必要）"
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr "特殊文字を必須にする"
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "表示設定"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr "ブラウザのタブとナビゲーションバーに表示されるタイトル。"
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr "リスト表示でページごとに表示する書籍数（1-200）。"
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "ランダムに表示する本の冊数"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr "ホームページに表示するランダムな書籍数（1-30）。"
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr "非表示にする前に表示する著者数 (0=非表示にしない)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
@@ -8621,16 +8470,16 @@ msgstr ""
 "デフォルトテーマ（ユーザーは好みのテーマを選択できますが、新規ユーザーにはこ"
 "のテーマがデフォルトで適用されます）"
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "削除"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "caliBlur! ダークテーマ"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
@@ -8638,38 +8487,38 @@ msgstr ""
 "ユーザーごとのテーマ切り替えが有効です。このグローバルデフォルトは新規ユー"
 "ザーとゲストにのみ影響します"
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "無視するカラムの正規表現"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr "UIでの表示からカスタムカラムを非表示にする正規表現パターン。"
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "既読/未読をリンクするCalibreのカラム"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "既読/未読をリンクするCalibreのカラム"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "表示制限をリンクするCalibreのカラム"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 "Calibreのテキスト型カスタムカラムの値に基づいて書籍の表示を制限します。"
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "タイトルをソートするための正規表現"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
@@ -8677,201 +8526,196 @@ msgstr ""
 "適切な並び替えのためにタイトルからプレフィックスを除去する正規表現（例："
 "\"The\"、\"A\"、\"An\"）。"
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "表示設定"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Custom CSS"
 msgstr "カスタムフィルタ"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "新規ユーザーのデフォルト設定"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 "これらの設定は、新たに作成されるすべてのユーザーアカウントに適用されます。"
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "バージョン"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "管理者ユーザー"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "管理者ページ"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "言語設定のデフォルト"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "新規ユーザーのデフォルト設定"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "表示する本の言語設定のデフォルト"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "新規ユーザーのデフォルト表示設定"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "新規ユーザーのデフォルト表示設定"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 "新規ユーザーに対してデフォルトで表示するサイドバーセクションを選択します。"
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "詳細画面でランダムに本を表示"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "許可/拒否タグを追加"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "許可/拒否カスタムカラムを追加"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "アップロード"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Candidates"
 msgstr "候補マッチング結果"
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run Archive"
 msgstr "アーカイブを実行"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 msgid "Download Log"
 msgstr "ログをダウンロード"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "開始"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr "5分後に実行"
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr "15分後に実行"
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr "ライブラリ変換のスケジュール設定に成功しました"
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr "ライブラリ変換のスケジュール設定エラー"
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8880,14 +8724,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8895,94 +8739,93 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr "単一の書籍に対して実行"
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr "タイトル/著者で検索"
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "選択した本を統合"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "EPUB修復ツールのスケジュール設定に成功しました"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error scheduling EPUB Fixer"
 msgstr "EPUB修復ツールのスケジュール設定エラー"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "結果が見つかりません"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "ユーザー名を入力してください"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "ライブラリ内を検索"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "本棚を選択"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "選択した書籍のEPUB修復ツールを開始しました"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error starting EPUB Fixer"
 msgstr "EPUB修復ツールの開始エラー"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Calibre-Web Automatedサービスを有効/無効にする"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8990,11 +8833,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -9005,11 +8848,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -9019,28 +8862,28 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 "このツールは<a href=\"https://github.com/innocenat\">innocenat</a>氏が作成し"
-"た<a href=\"https://kindle-epub-fix.netlify.app/\">kindle-epub-fix.netlify."
-"app</a>ツールから移植されました。"
+"た<a href=\"https://kindle-epub-fix.netlify.app/\">kindle-epub-"
+"fix.netlify.app</a>ツールから移植されました。"
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
@@ -9050,11 +8893,11 @@ msgstr ""
 "れ、metadata.dbが一時的にロックされる場合があります。実行中のバックフィルを停"
 "止するには、無効化後にコンテナを再起動してください。"
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr "積極的なEPUB修復ツールモードを有効化（よりリスクが高い）"
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
@@ -9062,12 +8905,12 @@ msgstr ""
 "積極モードはより踏み込んだ修正を適用し、信頼度の低いエンコーディング変換も試"
 "みます。ほとんどのライブラリではセーフモードを推奨します。"
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "アーカイブされた本"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
@@ -9075,116 +8918,116 @@ msgstr ""
 "Calibreライブラリに書籍が存在しない場合に、app.db内の古いアーカイブ書籍参照を"
 "削除します。アーカイブ数を正確に保つのに役立ちます。"
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr "クリーンアップスケジュール："
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr "よく使う間隔"
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr "15分ごと"
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr "30分ごと"
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr "1時間ごと"
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr "2時間ごと"
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr "4時間ごと"
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr "6時間ごと"
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr "12時間ごと"
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr "毎日・毎週・毎月"
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr "毎日指定時刻"
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr "毎週指定曜日"
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr "毎月指定日"
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr "デフォルト：毎日03:00"
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr "曜日："
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr "月曜日"
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr "火曜日"
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr "水曜日"
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr "木曜日"
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr "金曜日"
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr "土曜日"
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr "日曜日"
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr "日："
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr "（1-28）"
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr "時刻："
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr "（サーバータイムゾーン：%(tz)s）"
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr "新規書籍のメタデータ自動取得を有効化"
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9192,11 +9035,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr "スマートメタデータ適用を有効化"
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9207,12 +9050,12 @@ msgstr ""
 "解像度）のみ既存データを置き換えます。無効にすると、優先プロバイダーから取得"
 "したメタデータをそのまま既存データに上書きします。"
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "メタデータを更新しました"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
@@ -9221,27 +9064,25 @@ msgstr ""
 "自動取得時に更新するメタデータフィールドを選択します。チェックを外したフィー"
 "ルドは自動メタデータ取得中に変更されず、既存データが保持されます。"
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr "タグ/ジャンル"
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "識別子"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "見つける"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr "TIP"
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
@@ -9251,15 +9092,15 @@ msgstr ""
 "マートモードでは選択されたフィールドに対して品質基準が追加で適用され、直接"
 "モードでは選択したすべてのフィールドがプロバイダーデータで置き換えられます。"
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr "表紙ファイル最大サイズ（MB）："
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr "範囲：1-200 MB（デフォルト：15）"
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
@@ -9267,11 +9108,11 @@ msgstr ""
 "メタデータプロバイダーまたはURLからダウンロードする表紙画像の最大サイズを制限"
 "し、保存の遅延や停止を防ぎます。"
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr "取り込み処理タイムアウト"
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
@@ -9280,19 +9121,19 @@ msgstr ""
 "単一書籍の処理がタイムアウトするまでの最大時間（分単位）。タイムアウトした"
 "ファイルは調査のため失敗バックアップフォルダーに移動されます。"
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr "タイムアウト（分）："
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr "範囲：5-120分（デフォルト：15）"
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr "古い一時ファイルのクリーンアップ"
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
@@ -9302,27 +9143,27 @@ msgstr ""
 "リーンアップできます。いずれかの値を0にするとクリーンアップが無効化されます。"
 "変更は次のクリーンアップサイクルで適用されます。"
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr "古い一時ファイルの経過時間（分）："
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr "範囲：0-10080分（デフォルト：120）"
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr "古い一時ファイルのクリーンアップ間隔（秒）："
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr "範囲：0-86400秒（デフォルト：600）"
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr "新規書籍の自動送信遅延"
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9333,19 +9174,19 @@ msgstr ""
 "タ取得などの処理が完了する時間を確保します。プロフィールで自動送信を有効にし"
 "ているユーザーにのみ適用されます。"
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr "遅延（分）："
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr "範囲：1-60分（デフォルト：5）"
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr "メタデータ自動取得プロバイダー階層"
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
@@ -9355,25 +9196,25 @@ msgstr ""
 "ラッグ＆ドロップで並び替えできます。有効化されたプロバイダーのみが使用されま"
 "す。"
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 "プロバイダーは上から下の順に試行されます。ドラッグで並び替えてください。"
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr "有効化されたメタデータプロバイダー"
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr "チェックを外したプロバイダーはグローバルに無効化されます。"
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Hardcover自動取得設定"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
@@ -9383,11 +9224,11 @@ msgstr ""
 "り、互換性のあるeReader使用時にHardcover.appとの読書進捗同期と注釈同期が可能"
 "になります。"
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr "Hardcoverトークンが必要"
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
@@ -9397,18 +9238,18 @@ msgstr ""
 "HARDCOVER_TOKENを設定するか、基本設定でグローバルトークンを構成する必要があり"
 "ます。有効なトークンがない場合、この機能は無効のままになります。"
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
@@ -9418,23 +9259,23 @@ msgstr ""
 "ング結果は自動適用され、信頼度の低いマッチング結果は手動レビュー用にキューイ"
 "ングされます。"
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr "実行スケジュール："
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr "Hardcover ID取得タスクを自動実行する頻度"
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr "最小信頼度しきい値："
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr "範囲：0.50-1.00（デフォルト：0.85）"
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
@@ -9444,15 +9285,15 @@ msgstr ""
 "低い場合は手動レビュー用にキューイングされます。高い値 = 自動マッチング数は減"
 "るが精度は向上します。"
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr "バッチサイズ："
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr "範囲：1回の実行あたり10-200冊（デフォルト：50）"
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
@@ -9460,15 +9301,15 @@ msgstr ""
 "スケジュール実行ごとに処理する書籍数。バッチが小さいとAPI負荷が減り、大きいと"
 "ライブラリの処理が早くなります。"
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr "レート制限の遅延（秒）："
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr "範囲：0-60秒（デフォルト：5.0）"
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
@@ -9476,33 +9317,33 @@ msgstr ""
 "HardcoverへのAPIリクエスト間の遅延。レート制限を防止しAPIキーを保護します。エ"
 "ラー時は指数バックオフを使用します。"
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 msgid "Web UI Settings"
 msgstr "Web UI設定"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "自動バックアップ設定"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9510,36 +9351,35 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr "翻訳貢献通知を有効にする"
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -9548,12 +9388,12 @@ msgstr ""
 "無効時、英語以外の言語を使用していて翻訳が完了していない場合、Web UIで通知を"
 "受け取らなくなります。"
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Magic ShelvesをKoboと同期"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
@@ -9561,11 +9401,11 @@ msgstr ""
 "有効にすると、Magic ShelvesがKoboデバイスにコレクションとして同期されます。注"
 "意：基本設定でKobo同期も有効にする必要があります。"
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "モバイルでぼかし背景を有効にする（&lt;768px）"
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -9573,15 +9413,15 @@ msgstr ""
 "有効時、ぼかしカバー背景効果が小さな画面でも表示されます。スクロールやアニ"
 "メーションの遅延が発生する場合は無効にしてください。"
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 msgid "Automatic Backup Settings"
 msgstr "自動バックアップ設定"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -9589,11 +9429,11 @@ msgstr ""
 "有効時、インポートされたすべてのファイルのコピーが<i>/config/processed_books/"
 "imported</i>に保存されます"
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -9601,21 +9441,21 @@ msgstr ""
 "有効時、変換される取り込みファイルの元ファイルが/config/processed_books/"
 "convertedに保存されます"
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9627,11 +9467,11 @@ msgstr ""
 "config/processed_booksのサブディレクトリを整理し、ディスク容量の使用を最小限"
 "に抑えるためです。"
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -9640,32 +9480,32 @@ msgstr ""
 "自動変換機能が有効な場合、すべての取り込まれた書籍がここで選択した形式に自動"
 "的に変換されます（以下の無視リストで選択した形式を除く）"
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 msgid "Choose a target format:"
 msgstr "変換先の形式を選択："
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9673,19 +9513,19 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr "Calibreはインポート時に重複した書籍タイトルを検出でき、"
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr "automerge"
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -9693,34 +9533,34 @@ msgstr ""
 "設定に応じて動作します。重複書籍のいずれかのインスタンスを削除するか、両方を"
 "保持する（デフォルト）よう設定できます。"
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr "重複インポートを破棄し、ライブラリのコピーを保持"
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr "ライブラリのコピーを新しくインポートしたファイルで上書き"
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "重複レコードを作成し、両方のコピーを保持"
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
@@ -9728,31 +9568,31 @@ msgstr ""
 "重複検出システムを有効化または無効化します。無効化すると重複スキャンは実行さ"
 "れず、通知も表示されません。"
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Detection"
 msgstr "重複検出を有効化"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr "重複検出方式"
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr "ハイブリッド（SQL事前フィルタ + Python検証）"
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr "Pythonのみ（最も低速、最も堅牢）"
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr "レガシーSQLのみ（実験的）"
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
@@ -9760,11 +9600,11 @@ msgstr ""
 "ハイブリッドモードは高速なSQL事前フィルタで候補を絞り込み、最終結果に堅牢な"
 "Pythonロジックを適用します。"
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 msgid "Automatic Duplicate Scanning"
 msgstr "自動重複スキャン"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
@@ -9772,27 +9612,27 @@ msgstr ""
 "バックグラウンドの重複スキャンを設定します。UIをブロックせずに自動実行されま"
 "す。"
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr "自動重複スキャンを有効化"
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr "インポート後のスキャン"
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr "各インポート後に実行（デバウンス付き）"
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr "手動のみ"
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr "インポート後の待機時間（秒）"
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
@@ -9800,15 +9640,15 @@ msgstr ""
 "最後のインポートから何秒待機してからバックグラウンドスキャンを開始するかを設"
 "定します。"
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr "スケジュールスキャン（cron式）"
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr "空欄にするとスケジュールスキャンが無効化されます。例："
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
@@ -9817,15 +9657,15 @@ msgstr ""
 "ケジュールを残しつつインポート後スキャンを無効化するには「手動のみ」を使用し"
 "てください。"
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr "次回スケジュールスキャン："
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
@@ -9834,31 +9674,31 @@ msgstr ""
 "書籍が重複かを判定するメタデータフィールドを設定します。重複と見なされるに"
 "は、選択したすべての基準に一致する必要があります。"
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr "重複検出時に書籍タイトルを考慮"
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr "重複検出時に著者を考慮"
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr "重複検出時に言語を考慮"
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr "重複検出時にシリーズを考慮"
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr "重複検出時に出版社を考慮"
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr "重複検出時にファイル形式を考慮"
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
@@ -9866,11 +9706,11 @@ msgstr ""
 "少なくとも1つの基準を選択する必要があります。タイトルと著者を主要な基準として"
 "推奨します。"
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr "重複フォーマットの優先順位"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
@@ -9879,11 +9719,11 @@ msgstr ""
 "\"最高品質フォーマット\"の自動解決戦略を使用する際に優先するファイル形式を設"
 "定します。ドラッグ＆ドロップで優先順位を並び替えてください（上＝優先）。"
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr "TIP："
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
@@ -9892,22 +9732,22 @@ msgstr ""
 "\"最高品質フォーマット\"戦略で重複を解決する際、より上位のフォーマットを持つ"
 "書籍が保持されます。優先順位が低いフォーマットは削除されます。"
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr "重複の通知と自動解決"
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr "重複書籍に関する通知方法を設定し、必要に応じて自動解決を有効化します。"
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "誰でも登録可能にする"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
@@ -9917,16 +9757,16 @@ msgstr ""
 "持つユーザーには重複サイドバーボタンにバッジが表示され、ログイン時に通知ポッ"
 "プアップが表示されます。"
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "誰でも登録可能にする"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr "警告："
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
@@ -9934,81 +9774,81 @@ msgstr ""
 "下記の戦略に基づいて書籍を自動削除します。元のファイルは次の場所にバックアッ"
 "プされます："
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr "自動解決戦略"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr "最新を保持"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr "古いコピーを削除し、最近追加された書籍を保持"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr "最古を保持"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr "新しいコピーを削除し、最初に追加されたものを保持"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "削除する形式:"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr "フォーマットを最新の書籍にマージし、残りを削除"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr "最高品質フォーマットを保持"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr "重複フォーマットの優先順位に基づいてフォーマットを優先"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "メタデータを取得"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr "最も情報が揃っている書籍を保持"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr "最大ファイルサイズを保持"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr "総ファイルサイズが最大の書籍を保持"
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr "重複が自動解決される際に保持する書籍を選択してください。"
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "評価"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr "クールダウン期間（分）"
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 "自動解決間の最小時間（0で無効化）。バッチインポート中の連続削除を防ぎます。"
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -10016,287 +9856,275 @@ msgstr ""
 "自動解決は重複スキャンで新規重複が検出された後に実行されます。解除済みの重複"
 "グループは自動解決されません。"
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr "保留中の%(count)s件のマッチング結果をレビュー"
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr "クリックして詳細を表示"
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "次"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "未読に設定"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "既読に設定"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "未読に設定"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "未読に設定"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "アーカイブに追加"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "アーカイブから復元"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "アーカイブから復元"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "アーカイブに追加"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "アーカイブから復元"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Reloaded metadata from disk"
 msgstr "有効化されたメタデータプロバイダー"
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Unhide from your library"
 msgstr "このシェルフをサイドバーから非表示"
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "このシェルフをサイドバーから非表示"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "DB設定を更新しました"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "評価(〜以上)"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "%(range)s 第%(index)s巻"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr "ID"
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr "UUID"
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr "UUIDをクリップボードにコピーしました"
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr "UUIDをコピーできませんでした"
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr "UUIDをコピー"
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr "ファイルサイズ"
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "詳細:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "E-Readerメールアドレス"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "E-Readerメールアドレス"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "本棚を作成する"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr "追加のメールアドレス："
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr "追加のメールアドレスを入力してください（カンマ区切り）："
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr "example@domain.com, another@domain.com"
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr "1つ以上のメールアドレスをカンマ区切りで入力してください"
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "削除する形式:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "表紙ファイルの作成に失敗しました"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "表紙ファイルの作成に失敗しました"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
@@ -10304,64 +10132,64 @@ msgstr ""
 "タイトルと著者が一致する書籍。真の重複を特定するために目視確認をお勧めしま"
 "す。"
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "本を削除"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "高評価の本を表示"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr "重複を選択"
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 msgid "Select None"
 msgstr "選択解除"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 msgid "Delete Selected"
 msgstr "選択を削除"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "本を削除"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View Background Tasks"
 msgstr "バックグラウンドタスクの概要"
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr "重複を自動解決"
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
@@ -10369,23 +10197,23 @@ msgstr ""
 "戦略に基づいて1冊を保持し他を削除することで、すべての重複グループを自動解決し"
 "ます。"
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr "戦略："
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr "最新を保持 - 古いコピーを削除し、最近追加されたものを保持"
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr "最古を保持 - 新しいコピーを削除し、最初に追加されたものを保持"
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr "フォーマットをマージ - フォーマットを最新の書籍にマージし、残りを削除"
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
@@ -10393,185 +10221,185 @@ msgstr ""
 "最高品質フォーマットを保持 - 重複フォーマット優先順位に基づいてフォーマットを"
 "優先"
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr "最大メタデータを保持 - 最も情報が揃っている書籍を保持"
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr "最大ファイルサイズを保持 - 総ファイルサイズが最大の書籍を保持"
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "前"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr "解決を実行"
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 "これにより書籍が完全に削除されます。元のファイルは次の場所にバックアップされ"
 "ます："
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "選択した本を統合"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr "この重複グループを解除"
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "本の詳細"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "メタデータを編集"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "選択した本を統合"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 msgid "No Duplicate Books Found"
 msgstr "重複する書籍は見つかりませんでした"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr "ライブラリにタイトルと著者の組み合わせが重複する書籍はありません。"
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr "この検索は誤検出を避けるため、タイトルと著者が同一の書籍を探します。"
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Execute Auto-Resolution"
 msgstr "解決を実行"
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "削除する形式:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr "この操作は元に戻せません！"
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 msgid "The following books will be permanently deleted:"
 msgstr "以下の書籍は完全に削除されます："
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "未読の本"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "この本はDBと"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "この本はDBと"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr "注意：ソース書籍のファイル形式がターゲット書籍に追加されます。"
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr "解決プレビュー"
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr "成功"
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr "選択した重複書籍が正常に削除されました！"
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr "リクエストの処理中にエラーが発生しました。"
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "サーバーの種類を選択"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr "標準メールアカウント"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr "Gmailアカウント"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr "Gmailアカウントを設定"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Gmailへのアクセスを失効"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "SMTPのパスワード"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "添付ファイルのサイズ制限"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 msgid "Save and Send Test Email"
 msgstr "保存してテストメールを送信"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "許可するドメイン名 (ホワイトリスト)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "ドメインを追加"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "ドメイン名を入力"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "拒否するドメイン名 (ブラックリスト)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr "(Magic)"
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10580,23 +10408,23 @@ msgstr ""
 "たは編集）してください：.kobo/Kobo/Kobo eReader.confファイルをテキストエディ"
 "タで開いて追加(編集)してください:"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Koboトークン:"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "一覧"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr "Hardcoverマッチング結果レビュー 🔖"
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr "すべて処理済み！"
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
@@ -10604,15 +10432,15 @@ msgstr ""
 "レビューが必要な保留中のHardcoverマッチング結果はありません。新しいマッチング"
 "結果は自動取得タスクの実行時にここに表示されます。"
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr "管理パネルに戻る"
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr "レビューが必要"
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
@@ -10622,11 +10450,11 @@ msgstr ""
 "結果をレビューして正しい結果を選択するか、適切なマッチング結果がない場合はス"
 "キップ/拒否してください。"
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr "保留中のマッチング結果"
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
@@ -10635,114 +10463,105 @@ msgstr ""
 "書籍のあいまいなHardcover IDマッチング結果をレビューして承認します。信頼度の"
 "高いマッチング結果は自動適用されますが、これらは手動検証が必要です。"
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "保留中をすべて拒否"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "検索する単語:"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr "候補マッチング結果"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr "上位%(count)s件"
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr "信頼度"
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr "マッチング理由"
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "Hardcoverで表示"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr "このマッチング結果を選択"
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "本棚を作成する"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr "今はスキップ"
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "読み込み中..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr "✓ このマッチング結果を選択"
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr "マッチング結果の適用に失敗しました"
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
 msgstr "選択したユーザーの選択したロールを変更してもよろしいですか？"
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr "✗ すべてのマッチング結果を拒否"
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "表紙ファイルの作成に失敗しました"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr "選択したユーザーの選択したロールを変更してもよろしいですか？"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "✗ 保留中をすべて拒否"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "表紙ファイルの作成に失敗しました"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr "→ 今はスキップ"
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr "マッチング結果のスキップに失敗しました"
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
@@ -10751,278 +10570,277 @@ msgstr ""
 "Calibre-Web Automatedインスタンスが設定されていません。管理者に連絡してくださ"
 "い。"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Issueを作成"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "ホームに戻る"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "ユーザーをログアウト"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr "モバイルに関する注意"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 "Magic Shelfの編集はデスクトップまたはタブレットデバイスで最適に動作します。"
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr "シェルフを再読み込みして最新状態にする"
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "本棚を編集する"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr "このシェルフをサイドバーから非表示"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show this shelf in your sidebar"
 msgstr "この本棚をKobo端末と同期"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "全て表示"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "みんなの本棚"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "本棚に追加"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 #, fuzzy
 msgid "KOReader Sync is disabled."
 msgstr "KOReader同期プラグイン"
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "ホーム"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "ナビゲーションを実行"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "ライブラリ内を検索"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Calibre-Web Automated 電子書籍カタログ"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "ログアウト"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 msgid "Settings"
 msgstr "設定"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 msgid "Refresh Library"
 msgstr "ライブラリを更新"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "リリース情報がありません"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Calibre-Web Automated 電子書籍カタログ"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr "変更履歴を見る"
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "重複"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr "ここで貢献！"
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "ページを更新しないでください"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "本棚を作成する"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr "Magic Shelves ✨"
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "前"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "本の詳細"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "この操作は元に戻せません！"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "選択を削除"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "アップロード形式"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "削除する形式:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "本を削除"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr "ライブラリに未解決の重複書籍があります"
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "結果が見つかりません"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr "あとで通知"
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr "重複を表示・解決"
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "最適なサイズにする"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "TIP"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "設定"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "本棚に追加"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "未読に設定"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "未読に設定"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "本を削除"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "本を削除"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -11031,93 +10849,93 @@ msgstr ""
 "これにより書籍が完全に削除されます。元のファイルは次の場所にバックアップされ"
 "ます："
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "本棚を選択"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "復元失敗：%(err)s"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr "頭文字でフィルター"
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "表"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "SMTPのパスワード"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "アカウント情報を記憶する"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "パスワードを忘れた場合"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "マジックリンクでログイン"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 msgid "Log in with SSO"
 msgstr "SSOでログイン"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 "標準ログインは無効化されています。代替のログイン方法を使用してください。"
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Calibre-Webのログを表示: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Calibre-Web Log: "
 msgstr "Calibre-Webログ："
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "ストリームの出力を表示できません"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "アクセスログを表示: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Calibre-Webのログをダウンロード"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "アクセスログをダウンロード"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr "システムテンプレート"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 "これはあらかじめ設定済みのテンプレートシェルフです。自由に編集できます。"
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "みんなと共有"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
@@ -11125,43 +10943,43 @@ msgstr ""
 "他のユーザーがこのシェルフを表示できます。\"パブリックシェルフの編集\"権限を"
 "持つユーザーは編集/削除できます。"
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "許可/拒否タグを選択"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "許可/拒否カスタムカラムを選択"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "ユーザーの許可/拒否タグを選択"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr "ユーザーの許可/拒否カスタムカラムを選択"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "タグを入力"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "表示制限を追加"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "このファイル形式はDBから完全に削除されます"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "この本はDBと"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "ローカルから完全に削除されます"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
@@ -11169,7 +10987,7 @@ msgstr ""
 "す。Koboに関する重要な注意: 削除された本はどの連携されたKobo端末にも残りま"
 "す。"
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11178,283 +10996,283 @@ msgstr ""
 "ります。本を安全に削除するためには、初めに本をアーカイブした上で端末と同期す"
 "る必要があります"
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "ファイルの場所を選択"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "種類"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "名前"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "サイズ"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "親ディレクトリ"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "OK"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Calibre-Web Automated 電子書籍カタログ"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "EPUBリーダー"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "アクション"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "ブラック"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "フォントサイズ"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "次のページ"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr "フォント"
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 msgid "Default"
 msgstr "デフォルト"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr "ヤヘイ"
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr "宋体"
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 msgid "KaiTi"
 msgstr "楷体"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 msgid "Arial"
 msgstr "Arial"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 msgid "Spread"
 msgstr "見開き"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr "2カラム"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr "1カラム"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "サイドバーが開いているとき、テキストを再度流し込みます。"
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 #, fuzzy
 msgid "Note"
 msgstr "メモ："
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "コミックリーダー"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "キーボードショートカット"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "前のページ"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "次のページ"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 msgid "Single Page Display"
 msgstr "単一ページ表示"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr "縦スクロール表示"
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "最適なサイズにする"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "横に合わせる"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "縦に合わせる"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "オリジナルのサイズにする"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "右に回転する"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "左に回転する"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "画像を反転する"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "表示"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 msgid "Single Page"
 msgstr "単一ページ"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr "縦スクロール"
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "スケール"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "最適"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "横に合わせる"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "縦に合わせる"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "オリジナル"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "回転"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "反転"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "水平方向"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "垂直方向"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 msgid "Direction"
 msgstr "方向"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "左から右"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "右から左"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr "先頭に戻る"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 msgid "Remember Position"
 msgstr "位置を記憶"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "スクロールバー"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "表示"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "DJVUリーダー"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "PDFリーダー"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "テキストリーダー"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "新規アカウントを登録"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "ユーザー名を入力してください"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "メールアドレス"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "マジックリンク - 新規端末を認証する"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "他の端末でログインしてアクセスしてください:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "一度承認されると、自動的にこの端末でログインされます。"
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "この確認リンクの有効期限は10分です。"
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
@@ -11462,260 +11280,256 @@ msgstr ""
 "スケジュールメンテナンス中にすべてのサムネイルを自動更新します。この設定に関"
 "わらず、サムネイルは常にオンデマンドで生成されます。"
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "シリーズの表紙サムネイルを生成"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "結果が見つかりません"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "検索する単語:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "結果:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "発売日(〜から)"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "発売日(〜まで)"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr "空"
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "除外するタグ"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "除外するシリーズ"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "除外する本棚"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "除外する言語"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "拡張子"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "除外する拡張子"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "評価(〜以上)"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "評価(〜以下)"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "〜から:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "〜まで:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "この本棚を削除"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "本棚のプロパティを編集"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "非表示の本"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "手動で本を並び替える"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "並び順の変更を無効にする"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "並び順の変更を有効にする"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "選択した本を統合"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "上位%(count)s件"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "トークンが見つかりません"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "この本棚を削除"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Could not add the books. Please try again."
 msgstr "OAuthアカウントの連携に失敗しました。再試行してください。"
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "本棚に追加"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "ライブラリ内を検索"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "ライブラリ内を検索"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "みんなと共有"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "この本棚をKobo端末と同期"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Order saved"
 msgstr "並び替えモード"
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "ユーザーが見つかりません"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "非表示の本"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "ライブラリの統計"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "このライブラリ内の本の冊数"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "このライブラリ内の著者数"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "このライブラリ内のカテゴリ数"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "このライブラリ内のシリーズ数"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "システムの統計"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "プログラム"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "インストールされたバージョン"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr "バックグラウンドタスクの概要"
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "稼働時間"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr "アクション"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr "予定されている送信"
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr "スケジュール時刻"
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "回転"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
@@ -11723,15 +11537,15 @@ msgstr ""
 "予定送信は永続化され、スケジュール時刻にタスクとしてキューに追加されます。実"
 "行前であれば保留中の送信をキャンセルできます。"
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr "予定されている操作"
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr "種別"
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
@@ -11739,14 +11553,14 @@ msgstr ""
 "ここでスケジュールされたライブラリ変換とEPUB Fixerの実行は再起動後も維持され"
 "ます。実行を防ぐにはキャンセルしてください。"
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 "このタスクはキャンセルされます。このタスクで行われた進捗は保存されます。この"
 "タスクはキャンセルされます。このタスクによる進捗はすべて保存されます。"
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
@@ -11755,166 +11569,166 @@ msgstr ""
 "これがスケジュールタスクの場合、次のスケジュールの時刻にはもう一度実行されま"
 "す。"
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "スケジュール項目をキャンセルしました"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr "スケジュール項目のキャンセルエラー"
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Calibre-Web Automated 電子書籍カタログ"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Portainer:"
 msgstr "重要："
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Set up automatic updates"
 msgstr "自動重複スキャンを有効化"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "メールアドレス"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "設定"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr "アカウント情報"
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 "メールアドレスまたはパスワードを変更する必要がある場合は、ここで変更できま"
 "す。"
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "パスワードをリセット"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "サーバー設定"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "E-Readerメールアドレス"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 "電子書籍リーダーのメールアドレスに送信。複数のリーダーには、カンマで区切って"
 "ください"
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 "eReaderデバイス用のメールアドレス。複数のアドレスはカンマで区切ってください。"
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr "eReaderへ送信ポップアップモーダルを有効化"
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
@@ -11923,7 +11737,7 @@ msgstr ""
 "eReader送信時に追加のメールアドレスを入力したり、保存済みアドレスから選択して"
 "送信できるeReaderへ送信ポップアップモーダルを有効化または無効化します。"
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
@@ -11931,11 +11745,11 @@ msgstr ""
 "無効化すると、メールは確認なしで設定済みのすべてのeReaderアドレスに送信されま"
 "す。"
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr "新規書籍を自分のeReaderに自動送信"
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
@@ -11943,109 +11757,109 @@ msgstr ""
 "有効化すると、新規取り込み書籍が上記で設定したすべてのeReaderメールアドレスに"
 "自動送信されます。"
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr "言語とテーマの設定"
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "言語を入力"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "本の言語"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr "特定の言語の書籍のみを表示するようライブラリをフィルタします。"
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "有効な本の言語がありません"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr "OAuthとAPI連携"
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "OAuth設定"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "リンク"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "リンク解除"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr "Hardcover APIトークン"
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr "Hardcoverメタデータプロバイダー連携用のAPIトークン。"
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Kobo同期トークン"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "作成/表示"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "強制的にKoboと完全同期"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "選択した本棚内の本のみKoboと同期"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "選択した本棚内の本のみKoboと同期"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "OAuth設定"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr "サイドバーナビゲーションに表示するセクションを選択します。"
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "許可/拒否カスタムカラムを追加"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr "OPDSカタログの並び順"
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
@@ -12053,7 +11867,7 @@ msgstr ""
 "エントリIDを希望の順序で並べてOPDSルートカタログを並び替えます。不明なIDは無"
 "視され、欠落したエントリは自動的に末尾に追加されます。"
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
@@ -12061,73 +11875,73 @@ msgstr ""
 "ドラッグでOPDSルートエントリを並び替えます。欠落したエントリは自動的に末尾に"
 "追加されます。"
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr "ユーザー権限"
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr "このユーザーに許可するアクションを設定します。"
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Magic Shelves Order"
 msgstr "Magic Shelvesの並び替え"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr "サイドバーでのMagic Shelvesの並び順を選択します。"
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr "並び替えモード"
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr "手動（ドラッグで並び替え）"
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr "名前（A-Z）"
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr "名前（Z-A）"
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr "書籍数（多い順）"
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr "書籍数（少ない順）"
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr "作成日（新しい順）"
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr "作成日（古い順）"
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "最近追加された本"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr "更新が最も古い順"
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr "手動順序は並び順モードが「手動」に設定されている場合のみ使用されます。"
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr "Magic Shelvesの表示"
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
@@ -12136,34 +11950,34 @@ msgstr ""
 "ルフは削除できず、非表示のみ可能です。他のユーザーのパブリックシェルフも非表"
 "示にできます。"
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr "デフォルトのシステムシェルフ："
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "みんなの本棚を編集"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr "%(total)s件中%(visible)s件のデフォルトシェルフを表示中"
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr "%(total)s件中%(visible)s件のパブリックシェルフを表示中"
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "ユーザーを削除"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12171,156 +11985,156 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "パスワード変更"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "パスワード変更"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "作成/表示"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Last used"
 msgstr "最終更新"
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Koboの認証URLを生成"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr "表示中"
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "選択..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "選択した本を削除"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "ユーザーを編集"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "ユーザー名を入力してください"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 msgid "Enter Email"
 msgstr "メールアドレスを入力"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "Enter eReader Email"
 msgstr "電子書籍リーダーのメールアドレスを入力"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "eReader Email"
 msgstr "電子書籍リーダーのメールアドレス"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "E-Readerメールアドレス"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "E-Readerメール"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "地域"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "表示する本の言語"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "許可タグを編集"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "許可タグ"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "拒否タグを編集"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "拒否タグ"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "許可カスタムカラムを編集"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "許可カスタムカラム"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "拒否カスタムカラムを編集"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "拒否カスタムカラム"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "パスワード変更"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "みんなの本棚を編集"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "選択した本棚をKoboと同期"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "選択した本棚をKoboと同期"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 msgid "Show Read/Unread Section"
 msgstr "既読/未読セクションを表示"
 

--- a/cps/translations/km/LC_MESSAGES/messages.po
+++ b/cps/translations/km/LC_MESSAGES/messages.po
@@ -20,1488 +20,1461 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "ស្ថិតិ"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 #, fuzzy
 msgid "Server restarted, please reload page."
 msgstr "ម៉ាស៊ីន server បានដំណើរការម្តងទៀត សូមបើកទំព័រជាថ្មី"
 
-#: cps/admin.py:210
+#: cps/admin.py
 #, fuzzy
 msgid "Performing Server shutdown, please close window."
 msgstr "កំពុងបិទម៉ាស៊ីន server សូមបិទផ្ទាំងនេះ"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr ""
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr ""
 
-#: cps/admin.py:232
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr "សៀវភៅបានចូលជួរសម្រាប់ផ្ញើទៅ %(eReadermail)s ដោយជោគជ័យ"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr ""
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 
-#: cps/admin.py:414
+#: cps/admin.py
 msgid "Hardcover ID applied successfully"
 msgstr ""
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr ""
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr ""
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr ""
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr ""
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr ""
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "ទំព័ររដ្ឋបាល"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "ការកំណត់"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "ការកំណត់សាមញ្ញ"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "ការកំណត់ផ្ទាំងប្រើប្រាស់"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Edit Users"
 msgstr "អ្នកប្រើប្រាស់រដ្ឋបាល"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr ""
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr ""
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr ""
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "បង្ហាញទាំងអស់"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr ""
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr ""
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr ""
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr ""
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr ""
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr ""
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr ""
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr ""
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr ""
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr ""
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr ""
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr ""
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr ""
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr ""
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr ""
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr ""
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr ""
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "តើអ្នកពិតជាចង់លុបធ្នើនេះមែនទេ?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 #, fuzzy
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr "តើអ្នកពិតជាចង់លុបធ្នើនេះមែនទេ?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1095
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
 msgstr "តើអ្នកពិតជាចង់លុបធ្នើនេះមែនទេ?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1100
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr "តើអ្នកពិតជាចង់លុបធ្នើនេះមែនទេ?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
 msgstr "តើអ្នកពិតជាចង់លុបធ្នើនេះមែនទេ?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 #, fuzzy
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "តើអ្នកពិតជាចង់លុបធ្នើនេះមែនទេ?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr ""
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr ""
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr ""
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "រកមិនឃើញវត្ថុតាង"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr ""
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr ""
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr ""
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr ""
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr ""
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
 msgstr ""
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr ""
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "ប្តូរការកំណត់ SMTP"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr ""
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr ""
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
 msgstr ""
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr ""
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr ""
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr ""
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "អ្នកប្រើប្រាស់រដ្ឋបាល"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "សូមកំណត់អ៊ីមែល SMTP ជាមុនសិន"
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 msgid "Please set an email address on your own account first..."
 msgstr ""
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "បង្កើតធ្នើ"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
 msgstr ""
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
 "delivery."
 msgstr ""
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr ""
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr ""
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr ""
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr ""
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr ""
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "ចំណងជើង"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "កែប្រែអ្នកប្រើប្រាស់ %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr ""
 
-#: cps/admin.py:2296
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "សូមកំណត់អ៊ីមែល SMTP ជាមុនសិន"
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr ""
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "កំពុងស្នើសុំឯកសារបច្ចុប្បន្នភាព"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "កំពុងទាញយកឯកសារបច្ចុប្បន្នភាព"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "កំពុងពន្លាឯកសារបច្ចុប្បន្នភាព"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr ""
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "ទំនាក់ទំនងទៅមូលដ្ឋានទិន្នន័យត្រូវបានផ្តាច់"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr ""
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "ការធ្វើបច្ចុប្បន្នភាពបានបញ្ចប់ សូមចុច okay រួចបើកទំព័រជាថ្មី"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr ""
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr ""
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr ""
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr ""
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr ""
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr ""
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr ""
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr ""
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr ""
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr ""
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr ""
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr ""
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr ""
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr ""
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr ""
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr ""
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 #, fuzzy
 msgid "Database Settings updated"
 msgstr "ទំនាក់ទំនងទៅមូលដ្ឋានទិន្នន័យត្រូវបានផ្តាច់"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 #, fuzzy
 msgid "Database Configuration"
 msgstr "ការកំណត់មុខងារ"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "សូមបំពេញចន្លោះទាំងអស់!"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr ""
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "បន្ថែមអ្នកប្រើប្រាស់ថ្មី"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "បានបង្កើតអ្នកប្រើប្រាស់ ‘%(user)s’"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr ""
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "អ្នកប្រើប្រាស់ ‘%(nick)s’ ត្រូវបានលុប"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr ""
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr ""
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr ""
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "អ្នកប្រើប្រាស់ ‘%(nick)s’ ត្រូវបានកែប្រែ"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr ""
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr ""
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Ebook-converter បានបរាជ័យ៖ %(error)s"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr ""
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 
-#: cps/admin.py:3322
+#: cps/admin.py
 msgid " User info endpoint is available."
 msgstr ""
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr ""
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr ""
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr ""
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "មិនដឹង"
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "Ebook-converter បានបរាជ័យ៖ %(error)s"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Ebook-converter បានបរាជ័យ៖ %(error)s"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 msgid "No file uploaded."
 msgstr ""
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr ""
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr ""
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr ""
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr ""
 
-#: cps/constants.py:265
+#: cps/constants.py
 #, fuzzy
 msgid "Finnish"
 msgstr "បានបញ្ចប់"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr ""
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr ""
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr ""
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr ""
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr ""
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr ""
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr ""
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr ""
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr ""
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr ""
 
-#: cps/constants.py:276
+#: cps/constants.py
 #, fuzzy
 msgid "Polish"
 msgstr "អ្នកបោះពុម្ភ"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr ""
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr ""
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr ""
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr ""
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr ""
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr ""
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr ""
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr ""
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr ""
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr ""
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "មិនបានតម្លើង"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr ""
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, python-format
 msgid "Change cover — %(title)s"
 msgstr ""
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "មិនដឹង"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr ""
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Book ID"
 msgstr "ព័ត៌មានលម្អិតរបស់សៀវភៅ"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "ចំណងជើងសៀវភៅ"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "អ្នកនិពន្ធ"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr ""
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Filepath"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filename"
 msgstr "ឈ្មោះហៅក្រៅ"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr ""
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr ""
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "ទម្រង់អាប់ឡូដ"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "មិនដឹង"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr ""
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 msgid "Invalid book selection."
 msgstr ""
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 msgid "Selected book has no EPUB format."
 msgstr ""
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 msgid "EPUB file not found on disk."
 msgstr ""
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 msgid "EPUB Fixer started for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr ""
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr ""
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 msgid "Invalid image data format."
 msgstr ""
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr ""
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "គ្មាន"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "លុបសៀវភៅ"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "លុបសៀវភៅ"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "លុបសៀវភៅ"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "លទ្ធផលសម្រាប់៖"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 msgid "Invalid resolution strategy"
 msgstr ""
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr ""
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 msgid "Failed to queue upload for processing"
 msgstr ""
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr ""
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr ""
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr ""
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 #, fuzzy
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "ឯកសារប្រភេទ '%(ext)s' មិនត្រូវបានអនុញ្ញាតឲអាប់ឡូដទៅម៉ាស៊ីន server នេះទេ"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr "ឯកសារប្រភេទ '%(ext)s' មិនត្រូវបានអនុញ្ញាតឲអាប់ឡូដទៅម៉ាស៊ីន server នេះទេ"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "ឯកសារដែលត្រូវអាប់ឡូដត្រូវមានកន្ទុយឯកសារ"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr ""
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr ""
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr ""
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr ""
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "មិនដឹង"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
 msgstr ""
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr ""
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr ""
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr ""
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr ""
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "កែប្រែទិន្នន័យមេតា"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr ""
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr ""
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "មិនអាចបង្កើតទីតាំង %(path)s (ពុំមានសិទ្ធិ)។"
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "មិនអាចរក្សាទុកឯកសារ %(file)s ។"
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "ឯកសារទម្រង់ %(ext)s ត្រូវបានបន្ថែមទៅ %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "រកមិនឃើញវត្ថុតាង"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr ""
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
 msgstr ""
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1509,296 +1482,295 @@ msgstr ""
 "Callback domain មិនទាន់បានផ្ទៀងផ្ទាត់ឲប្រើទេ សូមធ្វើតាមជំហានដើម្បីផ្ទៀងផ្ទាត់ domain នៅក្នុង "
 "Google Developer Console"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr ""
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr ""
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr ""
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 #, fuzzy
 msgid "Send to eReader"
 msgstr "ផ្ញើទៅ Kindle"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr ""
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr ""
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 #, fuzzy
 msgid "Test Email"
 msgstr "ឧបករណ៍ Kindle"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr ""
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr ""
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Send %(format)s to eReader"
 msgstr "ផ្ញើទៅ Kindle"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "%(book)s send to eReader"
 msgstr "ផ្ញើទៅ Kindle"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "ឯកសារដែលបានស្នើសុំមិនអាចបើកបានទេ។ អាចនឹងខុសសិទ្ធិប្រើប្រាស់ទេដឹង?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr ""
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
 msgstr ""
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr ""
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
 "%(path)s"
 msgstr ""
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, fuzzy, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr "ប្តូរចំណងជើងពី “%(src)s” ទៅជា “%(dest)s” បរាជ័យដោយបញ្ហា: %(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "ឯកសារ %(file)s រកមិនឃើញក្នុង Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr "ប្តូរចំណងជើងពី “%(src)s” ទៅជា “%(dest)s” បរាជ័យដោយបញ្ហា: %(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "ទីតាំងសៀវភៅ %(path)s រកមិនឃើញក្នុង Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr ""
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr ""
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr ""
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr ""
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr ""
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr ""
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr ""
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
 msgstr ""
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr ""
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr ""
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr ""
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr ""
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr ""
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr ""
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr ""
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr ""
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr ""
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr ""
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr ""
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr ""
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr ""
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr ""
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "ទីតាំង database Calibre"
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1806,35 +1778,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "ឥឡូវអ្នកបានចូលដោយមានឈ្មោះថា៖ ‘%(nickname)s’"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr ""
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1842,5187 +1814,5087 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 msgid "OAuth system error. Please contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr ""
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr ""
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr ""
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr ""
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr ""
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr ""
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr ""
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 msgid "Failed to log in with Generic OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr ""
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr ""
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr ""
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr ""
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr ""
 
-#: cps/opds.py:164
+#: cps/opds.py
 #, fuzzy
 msgid "Alphabetical Books"
 msgstr "លុបសៀវភៅ"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr ""
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "សៀវភៅដែលមានប្រជាប្រិយភាព"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr ""
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "សៀវភៅដែលមានការវាយតម្លៃល្អជាងគេ"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr ""
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "សៀវភៅដែលបានអានរួច"
 
-#: cps/opds.py:183
+#: cps/opds.py
 #, fuzzy
 msgid "The latest Books"
 msgstr "សៀវភៅដែលមានការវាយតម្លៃល្អជាងគេ"
 
-#: cps/opds.py:188
+#: cps/opds.py
 #, fuzzy
 msgid "Random Books"
 msgstr "បង្ហាញសៀវភៅចៃដន្យ"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "បង្ហាញសៀវភៅចៃដន្យ"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "សៀវភៅដែលបានអានរួច"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "លេខ version ដែលបានតម្លើង"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "សៀវភៅដែលមិនទាន់បានអាន"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "អ្នកនិពន្ធ"
 
-#: cps/opds.py:213
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by Author"
 msgstr "អ្នកនិពន្ធ"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr ""
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr ""
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "ប្រភេទនានា"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr ""
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "ស៊េរី"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr ""
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "ភាសានានា"
 
-#: cps/opds.py:237
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by Languages"
 msgstr "ចំនួនសៀវភៅក្នុងមួយទំព័រ"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr ""
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr ""
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr ""
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr ""
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr ""
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr ""
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "កែប្រែធ្នើ"
 
-#: cps/opds.py:261
+#: cps/opds.py
 msgid "Books organized in magic shelves"
 msgstr ""
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "ពិពណ៌នា"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr ""
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "ស្វែងរក"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "ចូលប្រើប្រាស់"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "រកមិនឃើញវត្ថុតាង"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "វត្ថុតាងហួសពេលកំណត់"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "ជោគជ័យ! សូមវិលមកឧបករណ៍អ្នកវិញ"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr ""
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "បង្ហាញសៀវភៅមកថ្មី"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "បង្ហាញសៀវភៅដែលមានប្រជាប្រិយភាព"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr ""
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr ""
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "បង្ហាញសៀវភៅដែលមានការវាយតម្លៃល្អជាងគេ"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Read and Unread"
 msgstr "បង្ហាញអានរួច និងមិនទាន់អាន"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr ""
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "ស្រាវជ្រាវ"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Category Section"
 msgstr "បង្ហាញជម្រើសប្រភេទ"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Series Section"
 msgstr "បង្ហាញជម្រើសស៊េរី"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Author Section"
 msgstr "បង្ហាញជម្រើសអ្នកនិពន្ធ"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Publisher Section"
 msgstr "បង្ហាញជម្រើសស៊េរី"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Language Section"
 msgstr "បង្ហាញផ្នែកភាសា"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Ratings Section"
 msgstr "បង្ហាញជម្រើសស៊េរី"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show File Formats Section"
 msgstr "បង្ហាញជម្រើសស៊េរី"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr ""
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Archived Books"
 msgstr "បង្ហាញសៀវភៅមកថ្មី"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr ""
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr ""
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr ""
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "បង្ហាញសៀវភៅដែលមានការវាយតម្លៃល្អជាងគេ"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "បានបោះពុម្ភក្រោយ  "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "បានបោះពុម្ភមុន  "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "ការវាយតម្លៃ <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "ការវាយតម្លៃ >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr ""
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "ស្វែងរកកម្រិតខ្ពស់"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr ""
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 #, fuzzy
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "សូមអភ័យទោស អ្នកមិនមានសិទ្ធិដកសៀវភៅចេញពីធ្នើនេះទេ៖ %(sname)s"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr ""
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "សៀវភៅត្រូវបានបន្ថែមទៅធ្នើ៖ %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr ""
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr ""
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr ""
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr ""
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 msgid "Invalid series specified"
 msgstr ""
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr ""
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "សៀវភៅត្រូវបានបន្ថែមទៅធ្នើ៖ %(sname)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "សៀវភៅត្រូវបានបន្ថែមទៅធ្នើ៖ %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "សៀវភៅត្រូវបានដកចេញពីធ្នើ៖ %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr ""
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 #, fuzzy
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "សូមអភ័យទោស អ្នកមិនមានសិទ្ធិដកសៀវភៅចេញពីធ្នើនេះទេ៖ %(sname)s"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "កែប្រែធ្នើ"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr ""
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr ""
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "ប្តូរលំដាប់ធ្នើ៖ ‘%(name)s’"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr ""
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "ធ្នើឈ្មោះ %(title)s ត្រូវបានបង្កើត"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "ធ្នើឈ្មោះ %(title)s ត្រូវបានប្តូរ"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "មានបញ្ហា"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr ""
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr ""
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "ធ្នើ៖ ‘%(name)s’"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "មានបញ្ហាពេលបើកធ្នើ។ ពុំមានធ្នើ ឬមិនអាចបើកបាន"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "លើកលែងស៊េរី"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr ""
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr ""
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr ""
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr ""
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "បាទ/ចាស"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "ទេ"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr ""
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "ការតុបតែង"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr ""
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr ""
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr ""
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "បន្ថែមទៅធ្នើ"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "អ្នកនិពន្ធ"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "រុករក"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "បិទ"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "លុប"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr ""
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "អ្នកបោះពុម្ភ"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "អាន"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "ចំណងជើង"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "អាប់ឡូដ"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr ""
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "រដ្ឋបាល"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr ""
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "ប្រភព"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "អំពី"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "ពិពណ៌នា"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "ទាញយក"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "កែប្រែ"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr ""
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "ភាសា"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "លេខសម្ងាត់"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "លេខ port"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "ដំណើរការ"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "ការវាយតម្លៃ"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr ""
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "ស្ថានភាព"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Tag"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "ការងារ"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "កិច្ចការនានា"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "អ្នកប្រើប្រាស់"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "ឈ្មោះហៅក្រៅ"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr ""
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "កំពុងរង់ចាំ"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "បានបរាជ័យ"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "បានចាប់ផ្តើម"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "បានបញ្ចប់"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr ""
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr ""
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr ""
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr ""
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr ""
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
 msgstr ""
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr ""
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr ""
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
 "%(version)s"
 msgstr ""
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr ""
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "ស្រាវជ្រាវ (សៀវភៅចៃដន្យ)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "សៀវភៅដែលត្រូវបានទាញយកច្រើនជាងគេ"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr ""
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr ""
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr ""
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "ស៊េរី៖ %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr ""
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr ""
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr ""
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "ប្រភេទ៖ %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "ភាសា៖ %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "សៀវភៅដែលមានប្រជាប្រិយភាព"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "សៀវភៅដែលមានប្រជាប្រិយភាព"
 
-#: cps/web.py:1193
+#: cps/web.py
 msgid "Error loading magic shelf"
 msgstr ""
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 msgid "Invalid rules format"
 msgstr ""
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 msgid "Invalid request"
 msgstr ""
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr ""
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 msgid "Error creating shelf"
 msgstr ""
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 msgid "Shelf name is required"
 msgstr ""
 
-#: cps/web.py:1647
+#: cps/web.py
 msgid "Error updating shelf"
 msgstr ""
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "កែប្រែធ្នើ"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "រកមិនឃើញវត្ថុតាង"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 msgid "Shelf duplicated successfully"
 msgstr ""
 
-#: cps/web.py:1710
+#: cps/web.py
 msgid "Error duplicating shelf"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 msgid "Error deleting shelf"
 msgstr ""
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "កែប្រែធ្នើ"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 msgid "Error unhiding shelf"
 msgstr ""
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "ឯកសារ DLS"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr ""
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 #, fuzzy
 msgid "Please configure the SMTP mail settings first..."
 msgstr "សូមកំណត់អ៊ីមែល SMTP ជាមុនសិន"
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "សៀវភៅបានចូលជួរសម្រាប់ផ្ញើទៅ %(eReadermail)s ដោយជោគជ័យ"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "មានបញ្ហានៅពេលផ្ញើសៀវភៅនេះ៖ %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "សៀវភៅបានចូលជួរសម្រាប់ផ្ញើទៅ %(eReadermail)s ដោយជោគជ័យ"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "ចុះឈ្មោះ"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr ""
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr ""
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr ""
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr ""
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
 msgstr "ទីតាំង database Calibre"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "ទីតាំង database Calibre"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr ""
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr ""
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, fuzzy, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "ឥឡូវអ្នកបានចូលដោយមានឈ្មោះថា៖ ‘%(nickname)s’"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "ឥឡូវអ្នកបានចូលដោយមានឈ្មោះថា៖ ‘%(nickname)s’"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
 msgstr "ទីតាំង database Calibre"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
 "known"
 msgstr ""
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr ""
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 #, fuzzy
 msgid "Wrong Username or Password"
 msgstr "ខុសឈ្មោះអ្នកប្រើប្រាស់ ឬលេខសម្ងាត់"
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr ""
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr ""
 
-#: cps/web.py:2838
+#: cps/web.py
 #, fuzzy
 msgid "Please enter valid username to reset password"
 msgstr "ខុសឈ្មោះអ្នកប្រើប្រាស់ ឬលេខសម្ងាត់"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, fuzzy, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "ឥឡូវអ្នកបានចូលដោយមានឈ្មោះថា៖ ‘%(nickname)s’"
 
-#: cps/web.py:3158
+#: cps/web.py
 #, fuzzy
 msgid "Success! Profile Updated"
 msgstr "ព័ត៌មានសង្ខេបបានកែប្រែ"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr ""
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr ""
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr ""
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "ផ្ញើទៅ Kindle"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "ផ្ញើទៅ Kindle"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 msgid "Auto-send completed successfully"
 msgstr ""
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr ""
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr ""
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, fuzzy, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "ផ្ញើទៅ Kindle"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr ""
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr ""
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 #, fuzzy
 msgid "Ebook converter failed with unknown error"
 msgstr "Ebook-converter បានបរាជ័យ៖ %(error)s"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, fuzzy, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Ebook-converter បានបរាជ័យ៖ %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre បានបរាជ័យដោយបញ្ហា៖ %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Ebook-converter បានបរាជ័យ៖ %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 #, fuzzy
 msgid "Reconnecting Calibre database"
 msgstr "ទីតាំង database របស់ Calibre"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "លុបសៀវភៅ"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "លុបសៀវភៅ"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "កំពុងពន្លាឯកសារបច្ចុប្បន្នភាព"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "លទ្ធផលសម្រាប់៖"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 msgid "Hardcover Sync"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 #, fuzzy
 msgid "E-mail"
 msgstr "ពីអ៊ីមែល"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 #, fuzzy
 msgid "Backing up Metadata"
 msgstr "កែប្រែទិន្នន័យមេតា"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "នៅក្នុងបណ្ណាល័យ"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 msgid "Book organizer"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "អនុញ្ញាតឲប្តូរលេខសម្ងាត់"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "ការកំណត់"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "ការកំណត់"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "បន្ថែមទៅធ្នើ"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 msgid "Downloads, fewest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "ទាញយក"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 msgid "Date added, newest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 msgid "Date added, oldest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "អ្នកនិពន្ធ"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "អ្នកនិពន្ធ"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "បានបោះពុម្ភមុន  "
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "បានបោះពុម្ភមុន  "
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "បន្ថែមទៅធ្នើ"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "បន្ថែមទៅធ្នើ"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Send to eReader Email"
 msgstr "ឧបករណ៍ Kindle"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "ផ្ញើទៅ Kindle"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 #, fuzzy
 msgid "View Books"
 msgstr "សៀវភៅដែលបានអានរួច"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Public Shelf"
 msgstr "កែប្រែធ្នើ"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr ""
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr ""
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "ប្តូរការកំណត់ SMTP"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "ឈ្មោះម៉ាស៊ីន SMTP"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "លេខ port SMTP"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "អ្នកចូលប្រើ SMTP"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "ពីអ៊ីមែល"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr ""
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr ""
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "ទីតាំង database Calibre"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr ""
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr ""
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "ចំនួនសៀវភៅក្នុងមួយទំព័រ"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "កំពុងអាប់ឡូដ"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Anonymous Browsing"
 msgstr "អនុញ្ញាតការរុករកដោយអនាមិក"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "ការចុះឈ្មាះសាធារណៈ"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "ការចូលប្រើប្រាស់ពីចម្ងាយ"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr ""
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr ""
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Edit Basic Configuration"
 msgstr "ការកំណត់សាមញ្ញ"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Edit UI Configuration"
 msgstr "ការកំណត់ផ្ទាំងប្រើប្រាស់"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Edit Calibre Database Configuration"
 msgstr "ការកំណត់មុខងារ"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr ""
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Start Time"
 msgstr "បានចាប់ផ្តើម"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr ""
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr ""
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 #, fuzzy
 msgid "Reconnect Calibre Database"
 msgstr "ទីតាំង database របស់ Calibre"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr ""
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr ""
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 msgid "Setup KOReader Sync"
 msgstr ""
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr ""
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "កិច្ចការរដ្ឋបាល"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Download Debug Package"
 msgstr "កំពុងទាញយកឯកសារបច្ចុប្បន្នភាព"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr ""
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Restart"
 msgstr "ចាប់ផ្តើម"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr ""
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr ""
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr ""
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Details"
 msgstr "ព័ត៌មានលម្អិតរបស់សៀវភៅ"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 msgid "Update available"
 msgstr ""
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 msgid "Update now"
 msgstr ""
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Current Version"
 msgstr "លេខ version ដែលបានតម្លើង"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "រកមើលបច្ចុប្បន្នភាព"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "ធ្វើបច្ចុប្បន្នភាព"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Are you sure you want to restart?"
 msgstr "តើអ្នកពិតជាចង់លុបធ្នើនេះមែនទេ?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "បាទ/ចាស"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Are you sure you want to shutdown?"
 msgstr "តើអ្នកពិតជាចង់លុបធ្នើនេះមែនទេ?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "កំពុងធ្វើបច្ចុប្បន្នភាព សូមកុំបើកទំព័រជាថ្មី"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7030,621 +6902,598 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "សៀវភៅនានាក្នុងបណ្ណាល័យនេះ"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "កំពុងអាប់ឡូត..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 msgid "Import failed."
 msgstr ""
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 msgid "Network error."
 msgstr ""
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "ស៊េរី៖ %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "តាមរយៈ"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "នៅក្នុងបណ្ណាល័យ"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr ""
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "បន្ថែមទៀតដោយ"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "លុបឯកសារទម្រង់៖"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr ""
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr ""
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr ""
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr ""
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr ""
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr ""
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "ទម្រង់អាប់ឡូដ"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "លេខសម្គាល់ស៊េរី"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "ថ្ងៃបោះពុម្ភ"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr ""
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr ""
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr ""
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr ""
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "URL របស់ក្របមុខ (ឯកសារ JPG ក្របមុខត្រូវបានទាញយក និងរក្សាទុកក្នុង database "
 "ក្រោយមកចន្លោះនេះទទេម្តងទៀត)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr ""
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 msgid "Hardcover Sync Blacklist"
 msgstr ""
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "មើលសៀវភៅក្រោយពីកែប្រែ"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "មើលទិន្នន័យមេតា"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "ពាក្យគន្លឹះ"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Search keyword"
 msgstr "ស្វែងរកពាក្យគន្លឹះ"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "កំពុងដំណើរការ..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "ការស្វែងរកមានកំហុស!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr ""
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr ""
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr ""
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr ""
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 msgid "Update Title Sort automatically  "
 msgstr ""
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr ""
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Title"
 msgstr "ឧបករណ៍ Kindle"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr ""
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Title Sort"
 msgstr "ចំណងជើង"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr ""
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Author Sort"
 msgstr "អ្នកនិពន្ធ"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Authors"
 msgstr "អ្នកនិពន្ធ"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Categories"
 msgstr "ប្រភេទនានា"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Series"
 msgstr "លើកលែងស៊េរី"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Languages"
 msgstr "លើកលែងភាសា"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Publishing Date"
 msgstr "ថ្ងៃបោះពុម្ភ"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Publishers"
 msgstr "អ្នកបោះពុម្ភ"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter comments"
 msgstr "ចុះឈ្មោះ"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Comments"
 msgstr ""
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Archived?"
 msgstr "ស្វែងរក"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Read?"
 msgstr "អាន"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter "
 msgstr "ចុះឈ្មោះ"
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr ""
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr ""
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Into Book with Title:"
 msgstr "ចំណងជើងសៀវភៅ"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr ""
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr ""
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr ""
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr ""
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr ""
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "កែប្រែទិន្នន័យមេតា"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr ""
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "ឧបករណ៍ Kindle"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "ផ្ញើទៅ Kindle"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "មកក្រោយ"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "ទីតាំង database របស់ Calibre"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7660,13 +7509,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7677,7 +7526,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7688,43 +7537,43 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr ""
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
 "can be wherever you desire"
 msgstr ""
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "ប្រើ Google Drive ឬ?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "វាយបញ្ចូលគណនី Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Folder របស់ Google Drive Calibre"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "Metadata Watch Channel ID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "ដកសិទ្ធិ"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "ទីតាំង database របស់ Calibre"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7734,133 +7583,133 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "តើអ្នកពិតជាចង់លុបធ្នើនេះមែនទេ?"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "ទីតាំង database របស់ Calibre"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr ""
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr ""
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "ការកំណត់ម៉ាស៊ីន server"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "លេខ port របស់ម៉ាស៊ីន server"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "ទីតាំង SSL certfile (ទុកទទេសម្រាប់ម៉ាស៊ីន server ដែលមិនប្រើ SSL)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "ទីតាំង SSL keyfile (ទុកទទេសម្រាប់ម៉ាស៊ីន server ដែលមិនប្រើ SSL)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr ""
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr ""
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr ""
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr ""
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "ការកំណត់ logfile"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "ទីតាំង និងឈ្មោះ logfile (calibre-web.log ប្រសិនបើទទេ)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr ""
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "ទីតាំង និងឈ្មោះ logfile (calibre-web.log ប្រសិនបើទទេ)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "ការកំណត់ម៉ាស៊ីន server"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Uploads"
 msgstr "អនុញ្ញាតឲអាប់ឡូត"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr ""
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Allowed Upload Fileformats"
 msgstr "ទម្រង់អាប់ឡូដ"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "អនុញ្ញាតការរុករកដោយអនាមិក"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "អនុញ្ញាតការចុះឈ្មោះសាធារណៈ"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Use Email as Username"
 msgstr "ជ្រើសរើសឈ្មោះអ្នកប្រើប្រាស់"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "អនុញ្ញាតការ login ពីចម្ងាយ (ឬ “magic link”)"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7868,154 +7717,154 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr ""
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr ""
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Use Goodreads"
 msgstr "Goodreads API key"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Goodreads API key"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 msgid "Enable Hardcover Sync"
 msgstr ""
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "វត្ថុតាងហួសពេលកំណត់"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Goodreads API key"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8023,415 +7872,415 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Login type"
 msgstr "ចូលប្រើប្រាស់"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr ""
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Server Port"
 msgstr "លេខ port របស់ម៉ាស៊ីន server"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Encryption"
 msgstr "SSL"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr ""
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Administrator Username"
 msgstr "កិច្ចការរដ្ឋបាល"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr ""
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr ""
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr ""
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr ""
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr ""
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr ""
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr ""
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr ""
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "មើលទិន្នន័យមេតា"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
 msgstr ""
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "ការកំណត់ផ្ទាំងប្រើប្រាស់"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "រកមិនឃើញវត្ថុតាង"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 msgid "Test Connection"
 msgstr ""
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "ការកំណត់"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 msgid "OAuth Client Id"
 msgstr ""
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 msgid "OAuth Client Secret"
 msgstr ""
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "មើលការកំណត់"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "ឈ្មោះហៅក្រៅ"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr ""
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "ពីអ៊ីមែល"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr ""
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 msgid "OAuth Group Claim"
 msgstr ""
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr ""
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "ការកំណត់មកស្រាប់សម្រាប់អ្នកប្រើប្រាស់ថ្មី"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "អនុញ្ញាតឲទាញយក"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Allow eBook Viewer"
 msgstr "អនុញ្ញាតឲលុបសៀវភៅ"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "អនុញ្ញាតឲអាប់ឡូត"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "អនុញ្ញាតឲកែប្រែ"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "អនុញ្ញាតឲលុបសៀវភៅ"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "អនុញ្ញាតឲប្តូរលេខសម្ងាត់"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "អនុញ្ញាតឲកែប្រែធ្នើសាធារណៈ"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr ""
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr ""
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr ""
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr ""
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr ""
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr ""
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 msgid "Calibre E-Book Converter Settings"
 msgstr ""
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr ""
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "ទីតាំង database របស់ Calibre"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Security Settings"
 msgstr "ការកំណត់"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8439,337 +8288,332 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr ""
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr ""
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr ""
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 msgid "Session protection"
 msgstr ""
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr ""
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr ""
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 msgid "User Password policy"
 msgstr ""
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr ""
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr ""
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "មើលការកំណត់"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "ចំនួនសៀវភៅចៃដន្យដើម្បីបង្ហាញ"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "លុប"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "ការតុបតែងពណ៌ងងឹត caliBlur!"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Regular expression សម្រាប់រំលងជួរឈរ"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "ភ្ជាប់ស្ថានភាពបានអាន/មិនទាន់បានអានទៅជួរឈររបស់ Calibre"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "ភ្ជាប់ស្ថានភាពបានអាន/មិនទាន់បានអានទៅជួរឈររបស់ Calibre"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Regular expression ដើម្បីរៀបចំណងជើងតាមលំដាប់"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "មើលការកំណត់"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 msgid "Custom CSS"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "ការកំណត់មកស្រាប់សម្រាប់អ្នកប្រើប្រាស់ថ្មី"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 msgid "Permissions"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "អ្នកប្រើប្រាស់រដ្ឋបាល"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "ទំព័ររដ្ឋបាល"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Language"
 msgstr "លើកលែងភាសា"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "ការកំណត់មកស្រាប់សម្រាប់អ្នកប្រើប្រាស់ថ្មី"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Visible Language of Books"
 msgstr "បង្ហាញសៀវភៅដែលមានភាសា"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "ភាពមើលឃើញដែលមកស្រាប់សម្រាប់អ្នកប្រើប្រាស់ថ្មី"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "ភាពមើលឃើញដែលមកស្រាប់សម្រាប់អ្នកប្រើប្រាស់ថ្មី"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "បង្ហាញសៀវភៅចៃដន្យក្នុងការបង្ហាញជាពិស្តារ"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr ""
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "អាប់ឡូដ"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "ស្វែងរក"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "ទាញយក"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "ចាប់ផ្តើម"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8778,14 +8622,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8793,91 +8637,90 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on selected book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error scheduling EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "លទ្ធផលសម្រាប់៖"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "ជ្រើសរើសឈ្មោះអ្នកប្រើប្រាស់"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "នៅក្នុងបណ្ណាល័យ"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer started for selected book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error starting EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "រក្សាទុកការកំណត់រួចផ្ញើអ៊ីមែលសាកល្បង"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8885,11 +8728,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -8900,11 +8743,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -8914,161 +8757,161 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 msgid "Enable Archived Book Cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9076,11 +8919,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9088,108 +8931,106 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 msgid "Metadata Fields to Update"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 msgid "Identifiers (ISBN, etc.)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "ស្រាវជ្រាវ"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
 "investigation."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9197,157 +9038,157 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "ការកំណត់"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "ការកំណត់"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "ការកំណត់"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9355,102 +9196,101 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "ការកំណត់"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9458,44 +9298,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "ជ្រើសរើសឈ្មោះអ្នកប្រើប្រាស់"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9503,2432 +9343,2406 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "អនុញ្ញាតការចុះឈ្មោះសាធារណៈ"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "ការកំណត់"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "អនុញ្ញាតការចុះឈ្មោះសាធារណៈ"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "អនុញ្ញាតការចុះឈ្មោះសាធារណៈ"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "លុបឯកសារទម្រង់៖"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "មើលទិន្នន័យមេតា"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "ការវាយតម្លៃ"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "បន្ទាប់"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr ""
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 msgid "Marked as read"
 msgstr ""
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 msgid "Marked as unread"
 msgstr ""
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "បន្ថែមទៅធ្នើ"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "បន្ថែមទៅធ្នើ"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr ""
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, fuzzy
 msgid "Add to archive"
 msgstr "បន្ថែមទៅធ្នើ"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "បន្ថែមទៅធ្នើ"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "នៅក្នុងបណ្ណាល័យ"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "ទំនាក់ទំនងទៅមូលដ្ឋានទិន្នន័យត្រូវបានផ្តាច់"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "ការវាយតម្លៃលើសពី"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr ""
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr ""
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "ពិពណ៌នា"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "ឧបករណ៍ Kindle"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "ឧបករណ៍ Kindle"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "លុបឯកសារទម្រង់៖"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 msgid "Failed to update tags"
 msgstr ""
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "មិនអាចរក្សាទុកឯកសារ %(file)s ។"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr ""
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "បង្ហាញសៀវភៅដែលមានការវាយតម្លៃល្អជាងគេ"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "មុន"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "ព័ត៌មានលម្អិតរបស់សៀវភៅ"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "កែប្រែទិន្នន័យមេតា"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "បង្ហាញសៀវភៅមកថ្មី"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "លទ្ធផលសម្រាប់៖"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr ""
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "លុបឯកសារទម្រង់៖"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be permanently deleted:"
 msgstr "សៀវភៅនឹងត្រូវលុបចេញពី database របស់ Calibre"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "សៀវភៅដែលមិនទាន់បានអាន"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "សៀវភៅនឹងត្រូវលុបចេញពី database របស់ Calibre"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "សៀវភៅនឹងត្រូវលុបចេញពី database របស់ Calibre"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr ""
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr ""
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr ""
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr ""
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr ""
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr ""
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr ""
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr ""
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "លេខសម្ងាត់ SMTP"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr ""
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Save and Send Test Email"
 msgstr "ឧបករណ៍ Kindle"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr ""
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr ""
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Enter domainname"
 msgstr "ជ្រើសរើសឈ្មោះអ្នកប្រើប្រាស់"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr ""
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr ""
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "ការស្វែងរកមានកំហុស!"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "មើលសៀវភៅក្រោយពីកែប្រែ"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "កំពុងដំណើរការ..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr "តើអ្នកពិតជាចង់លុបធ្នើនេះមែនទេ?"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject all pending matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "ទីតាំង database Calibre"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 #, fuzzy
 msgid "Create Issue"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr ""
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 #, fuzzy
 msgid "Logout User"
 msgstr "ចេញពីការប្រើប្រាស់"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "កែប្រែធ្នើ"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Show this shelf in your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "បង្ហាញទាំងអស់"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "កែប្រែធ្នើ"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "បន្ថែមទៅធ្នើ"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr ""
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "បិទ/បើកការរុករក"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Search Library"
 msgstr "នៅក្នុងបណ្ណាល័យ"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "រក្សាទុកការកំណត់រួចផ្ញើអ៊ីមែលសាកល្បង"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "ចេញពីការប្រើប្រាស់"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "ការកំណត់"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "ស៊េរីនានាក្នុងបណ្ណាល័យនេះ"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 msgid "New interface available"
 msgstr ""
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "រក្សាទុកការកំណត់រួចផ្ញើអ៊ីមែលសាកល្បង"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Please do not refresh the page"
 msgstr "កំពុងធ្វើបច្ចុប្បន្នភាព សូមកុំបើកទំព័រជាថ្មី"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "មុន"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "ព័ត៌មានលម្អិតរបស់សៀវភៅ"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "តើអ្នកពិតជាចង់លុបធ្នើនេះមែនទេ?"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "ទម្រង់អាប់ឡូដ"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "លុបឯកសារទម្រង់៖"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "លទ្ធផលសម្រាប់៖"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 msgid "Scroll to top"
 msgstr ""
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 msgid "Confirm"
 msgstr ""
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "បន្ថែមទៅធ្នើ"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Marked {n} books as read"
 msgstr ""
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr ""
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Ebook-converter បានបរាជ័យ៖ %(error)s"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr ""
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr ""
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "លេខសម្ងាត់ SMTP"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "ចងចាំខ្ញុំ"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 #, fuzzy
 msgid "Forgot Password?"
 msgstr "លេខសម្ងាត់"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "ចូលប្រើប្រាស់ដោយ magic link"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 #, fuzzy
 msgid "Log in with SSO"
 msgstr "ចូលប្រើប្រាស់ដោយ magic link"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr ""
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Calibre-Web Log: "
 msgstr ""
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr ""
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr ""
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr ""
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Download Access Log"
 msgstr "ឯកសារ DLS"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "តើធ្នើនេះគួរជាសាធារណៈទេ?"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Enter Tag"
 msgstr "ចុះឈ្មោះ"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "This book format will be permanently erased from database"
 msgstr "សៀវភៅនឹងត្រូវលុបចេញពី database របស់ Calibre"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "សៀវភៅនឹងត្រូវលុបចេញពី database របស់ Calibre"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "និងពីថាសរឹង"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Choose File Location"
 msgstr "បង្ហាញជម្រើសស៊េរី"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "name"
 msgstr "ឈ្មោះហៅក្រៅ"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Parent Directory"
 msgstr "ទីតាំង database Calibre"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 #, fuzzy
 msgid "Ok"
 msgstr "សៀវភៅ"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "រក្សាទុកការកំណត់រួចផ្ញើអ៊ីមែលសាកល្បង"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 #, fuzzy
 msgid "epub Reader"
 msgstr "កម្មវិធីមើល txt សាមញ្ញ"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 msgid "Annotations"
 msgstr ""
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 #, fuzzy
 msgid "Black"
 msgstr "មកក្រោយ"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr ""
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "បន្ទាប់"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr ""
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 #, fuzzy
 msgid "Default"
 msgstr "លុប"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr ""
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr ""
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 #, fuzzy
 msgid "KaiTi"
 msgstr "កំពុងរង់ចាំ"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 msgid "Arial"
 msgstr ""
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 #, fuzzy
 msgid "Spread"
 msgstr "អាន"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr ""
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr ""
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "សេរេអត្ថបទនៅពេលបើកផ្ទាំងចំហៀង។"
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Comic Reader"
 msgstr "កម្មវិធីមើល txt សាមញ្ញ"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Previous Page"
 msgstr "មុន"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Next Page"
 msgstr "បន្ទាប់"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page Display"
 msgstr "ទំព័ររដ្ឋបាល"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr ""
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr ""
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr ""
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr ""
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr ""
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr ""
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr ""
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page"
 msgstr "ទំព័ររដ្ឋបាល"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr ""
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr ""
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr ""
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr ""
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr ""
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr ""
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr ""
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr ""
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr ""
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr ""
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Direction"
 msgstr "ពិពណ៌នា"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr ""
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr ""
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr ""
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Remember Position"
 msgstr "ចងចាំខ្ញុំ"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr ""
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Show"
 msgstr "បង្ហាញទាំងអស់"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 #, fuzzy
 msgid "DJVU Reader"
 msgstr "កម្មវិធីមើល txt សាមញ្ញ"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 #, fuzzy
 msgid "PDF Reader"
 msgstr "កម្មវិធីមើល txt សាមញ្ញ"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 #, fuzzy
 msgid "txt Reader"
 msgstr "កម្មវិធីមើល txt សាមញ្ញ"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "ចុះឈ្មោះបង្កើតគណនីថ្មី"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "ជ្រើសរើសឈ្មោះអ្នកប្រើប្រាស់"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "អាសយដ្ឋានអ៊ីមែលរបស់អ្នក"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr ""
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr ""
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "ក្រោយពីនេះ អ្នកនឹងត្រូវបានឲចូលប្រើប្រាស់ក្នុងឧបករណ៍នេះដោយស្វ័យប្រវត្តិ។"
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr ""
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 #, fuzzy
 msgid "No Results Found"
 msgstr "លទ្ធផលសម្រាប់៖"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 #, fuzzy
 msgid "Search Term:"
 msgstr "ការស្វែងរកមានកំហុស!"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "លទ្ធផលសម្រាប់៖"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "ថ្ងៃបោះពុម្ភចាប់ពី"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "ថ្ងៃបោះពុម្ភរហូតដល់"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr ""
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "លើកលែង tag"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "លើកលែងស៊េរី"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Exclude Shelves"
 msgstr "លើកលែងស៊េរី"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "លើកលែងភាសា"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr ""
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Exclude Extensions"
 msgstr "លើកលែងស៊េរី"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "ការវាយតម្លៃលើសពី"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "ការវាយតម្លៃតិចជាង"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr ""
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr ""
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "លុបធ្នើនេះ"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr ""
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "សៀវភៅដែលមានប្រជាប្រិយភាព"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr ""
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr ""
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr ""
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, python-format
 msgid "Add %(count)s"
 msgstr ""
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "រកមិនឃើញវត្ថុតាង"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "លុបធ្នើនេះ"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "បន្ថែមទៅធ្នើ"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "នៅក្នុងបណ្ណាល័យ"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "នៅក្នុងបណ្ណាល័យ"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "តើធ្នើនេះគួរជាសាធារណៈទេ?"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr ""
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "រកមិនឃើញវត្ថុតាង"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Hidden Book"
 msgstr "សៀវភៅដែលមានប្រជាប្រិយភាព"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "ស្ថិតិបណ្ណាល័យ Calibre"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "សៀវភៅនានាក្នុងបណ្ណាល័យនេះ"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "អ្នកនិពន្ធនានាក្នុងបណ្ណាល័យនេះ"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "ប្រភេទនានាក្នុងបណ្ណាល័យនេះ"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "ស៊េរីនានាក្នុងបណ្ណាល័យនេះ"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 #, fuzzy
 msgid "System Statistics"
 msgstr "ស្ថិតិ"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 #, fuzzy
 msgid "Program"
 msgstr "ដំណើរការ"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "លេខ version ដែលបានតម្លើង"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "រយៈពេលដែលបានចាប់ផ្តើម"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr ""
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "ស្ថានភាព"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
 msgstr ""
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 msgid "Scheduled item cancelled successfully"
 msgstr ""
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "រក្សាទុកការកំណត់រួចផ្ញើអ៊ីមែលសាកល្បង"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "អាសយដ្ឋានអ៊ីមែលរបស់អ្នក"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "ការកំណត់"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr ""
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "ការកំណត់ម៉ាស៊ីន server"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "ឧបករណ៍ Kindle"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "លើកលែងភាសា"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Language of Books"
 msgstr "ភាសានានា"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 msgid "Book Language Filter"
 msgstr ""
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "OAuth Settings"
 msgstr "ការកំណត់"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr ""
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr ""
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create/View"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 msgid "Expose only books in selected shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "ការកំណត់"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr ""
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Permissions"
 msgstr "ការកំណត់"
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 msgid "Recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Default System Shelves:"
 msgstr "លុប"
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "កែប្រែធ្នើ"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 #, fuzzy
 msgid "Delete User"
 msgstr "លុប"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -11936,165 +11750,165 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "អនុញ្ញាតឲប្តូរលេខសម្ងាត់"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "អនុញ្ញាតឲប្តូរលេខសម្ងាត់"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr ""
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Select..."
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr ""
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit User"
 msgstr "អ្នកប្រើប្រាស់រដ្ឋបាល"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Username"
 msgstr "ឈ្មោះហៅក្រៅ"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Email"
 msgstr "ឧបករណ៍ Kindle"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email"
 msgstr "ឧបករណ៍ Kindle"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email"
 msgstr "ឧបករណ៍ Kindle"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "ផ្ញើទៅ Kindle"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "ផ្ញើទៅ Kindle"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr ""
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Visible Book Languages"
 msgstr "បង្ហាញសៀវភៅដែលមានភាសា"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr ""
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Allowed Tags"
 msgstr "អនុញ្ញាតឲអាប់ឡូត"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr ""
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Denied Tags"
 msgstr "ចុះឈ្មោះ"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Change Password"
 msgstr "អនុញ្ញាតឲប្តូរលេខសម្ងាត់"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Public Shelves"
 msgstr "អនុញ្ញាតឲកែប្រែធ្នើសាធារណៈ"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 msgid "Expose selected Shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Read/Unread Section"
 msgstr "បង្ហាញជម្រើសស៊េរី"

--- a/cps/translations/ko/LC_MESSAGES/messages.po
+++ b/cps/translations/ko/LC_MESSAGES/messages.po
@@ -19,1479 +19,1452 @@ msgstr ""
 "Generated-By: Babel 2.13.1\n"
 "X-Generator: Poedit 3.7\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "통계"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 msgid "Server restarted, please reload page."
 msgstr "서버가 재시작 되었습니다. 페이지를 새로고침 해주세요."
 
-#: cps/admin.py:210
+#: cps/admin.py
 msgid "Performing Server shutdown, please close window."
 msgstr "서버를 종료하고 있습니다. 창을 닫아주세요."
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "성공적으로 데이터베이스를 다시 연결했습니다."
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "알 수 없는 명령입니다."
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr "메타데이터 백업이 작업에 추가되었습니다. 작업 결과를 확인해주세요."
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr ""
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 
-#: cps/admin.py:414
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover ID applied successfully"
 msgstr "{} 사용자를 삭제했습니다."
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr ""
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr ""
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr ""
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr ""
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr ""
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "관리자 페이지"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "Hardcover API 토큰"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "기본 설정"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "UI 설정"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr "사용자 정의 열 번호 %(column)d이(가) calibre 데이터베이스에 없습니다."
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "사용자 관리"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "모두"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "사용자를 찾을 수 없습니다."
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} 사용자를 삭제했습니다."
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "모두 보기"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "잘못된 요청입니다."
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "게스트 이름은 변경할 수 없습니다."
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "게스트는 이 권한을 가질 수 없습니다."
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr "남아있는 관리자가 없어 권한을 삭제할 수 없습니다."
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "true 또는 false여야 합니다."
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "잘못된 권한입니다."
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "게스트는 사용할 수 없습니다."
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "잘못된 설정입니다."
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr "게스트의 언어는 자동으로 설정되며 변경할 수 없습니다."
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "올바른 언어가 아닙니다."
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "제공된 책의 언어가 올바르지 않습니다."
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "매개변수를 찾을 수 없습니다."
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "설정 데이터베이스에 저장할 수 없습니다."
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "읽기 항목이 유효하지 않습니다."
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "제한된 항목이 유효하지 않습니다."
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Kobo 토큰을 삭제하시겠습니까?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "이 도메인을 삭제하시겠습니까?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "이 사용자를 삭제하시겠습니까?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "이 서재를 삭제하시겠습니까?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr "선택한 사용자의 언어를 변경하시겠습니까?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr "선택한 사용자에 대해 표시되는 책 언어를 변경하시겠습니까?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr "선택한 사용자의 권한을 변경하시겠습니까?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
 msgstr "선택한 사용자의 제한을 변경하시겠습니까?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
 msgstr "선택한 사용자의 보기 제한을 변경하시겠습니까?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr "선택한 사용자의 책장 동기화 설정을 변경하시겠습니까?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
 msgstr "선택한 사용자의 책장 동기화 설정을 변경하시겠습니까?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Calibre 라이브러리 경로를 변경하시겠습니까?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "거부"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "허용"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "{} 동기화 항목이 삭제되었습니다."
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "토큰을 찾을 수 없습니다."
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "태그를 찾을 수 없습니다."
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "잘못된 작업입니다."
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json이 설정되지 않았습니다."
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "올바른 로그 파일의 경로를 입력해주세요."
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "올바른 액섹스 로그 파일의 경로를 입력해주세요."
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr "LDAP 공급자, 포트, DN 및 사용자 개체 식별자를 입력해주세요."
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "LDAP 서비스 계정과 비밀번호를 입력해주세요."
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "LDAP 서비스 계정을 입력해주세요."
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP 그룹 개체 필터에는 하나의 \"%s\" 형식 식별자가 필요합니다."
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "LDAP 그룹 개체 필터에 맞지 않는 괄호가 있습니다."
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP 사용자 개체 필터에는 하나의 \"%s\" 형식 식별자가 필요합니다."
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "LDAP 사용자 개체 필터에 맞지 않는 괄호가 있습니다."
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP 구성원 사용자 필터에는 하나의 \"%s\" 형식 식별자가 필요합니다."
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "LDAP 구성원 사용자 필터에 맞지 않는 괄호가 있습니다."
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
 msgstr "LDAP CA인증서, 인증서 또는 키 경로가 유효하지 않습니다."
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "사용자 생성"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "이메일 서버 설정"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "Gmail 계정 인증에 성공했습니다."
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "데이터베이스 오류가 발생했습니다: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
 msgstr "%(email)s로 테스트 이메일을 전송했습니다."
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "테스트 이메일 전송 중 오류가 발생했습니다: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "이메일 주소를 설정해주세요."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "이메일 서버 설정이 업데이트되었습니다."
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "사용자 관리"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "SMTP 메일 설정을 해주세요."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "이메일 주소를 설정해주세요."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "최소 하나 이상의 이메일 주소를 선택하십시오."
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
 msgstr "%(email)s로 테스트 이메일을 전송했습니다."
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
 "delivery."
 msgstr "%(email)s로 테스트 이메일을 전송했습니다."
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "예약 작업 설정"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "작업 시작 시간이 올바르지 않습니다."
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "작업 종료 시간이 올바르지 않습니다."
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "예약 작업 설정이 업데이트되었습니다."
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "제목"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "사용자 %(nick)s 수정"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "사용자 %(user)s의 비밀번호가 재설정되었습니다."
 
-#: cps/admin.py:2296
+#: cps/admin.py
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "SMTP를 설정해주세요."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "로그 파일 보기"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "업데이트 패키지 요청 중"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "업데이트 패키지 다운로드 중"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "업데이트 패키지 압축 해제 중"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "파일 적용 중"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "데이터베이스 연결이 종료됩니다."
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "서버를 중지하고 있습니다."
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "업데이트가 완료되었습니다. 확인을 누르고 페이지를 새로고침해주세요."
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "업데이트 실패: "
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "HTTP 오류가 발생했습니다."
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "연결 오류가 발생했습니다."
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "연결 시도 중 시간이 초과되었습니다."
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "일반 오류가 발생했습니다."
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr "임시 폴더에 업데이트 파일을 저장할 수 없습니다."
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "업데이트 중 파일을 변경할 수 없습니다."
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "최소 한 명의 LDAP 사용자 정보를 가져오지 못했습니다."
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "최소 한 명의 LDAP 사용자 정보를 생성하지 못했습니다."
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "오류: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "오류: LDAP 서버에서 반환된 사용자가 없습니다."
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "데이터베이스에서 찾을 수 없는 LDAP 사용자가 있습니다."
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} 명의 사용자를 가져왔습니다."
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr "책 경로가 유효하지 않습니다."
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "데이터베이스 경로가 유효하지 않습니다."
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "데이터베이스에 쓰기 권한이 없습니다."
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "키 파일 경로가 유효하지 않습니다."
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr "인증서 파일 경로가 유효하지 않습니다."
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr "비밀번호는 1~40자 사이로 입력해주세요."
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "데이터베이스 설정이 업데이트되었습니다."
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "데이터베이스 설정"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "모든 항목을 입력해주세요."
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "이메일 주소가 올바르지 않습니다."
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "새 사용자 생성"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "사용자 '%(user)s'이(가) 생성되었습니다."
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "이미 등록된 이메일 주소 또는 이름입니다."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "사용자 '%(nick)s'이(가) 삭제되었습니다."
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "게스트 사용자는 삭제할 수 없습니다."
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "남은 관리자가 없어 사용자를 삭제할 수 없습니다."
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "이메일 주소는 비워둘 수 없고, 올바른 형식이어야 합니다."
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "사용자 '%(nick)s의 정보를 수정했습니다."
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr "연결 실패: 서버가 %(code)s 오류를 답신했습니다."
 
-#: cps/admin.py:3276
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr "연결 실패: 서버에 연결할 수 없습니다."
 
-#: cps/admin.py:3278
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr "연결 실패: 요청 시간 초과."
 
-#: cps/admin.py:3280
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr "연결 실패: 응답에 잘못된 JSON이 포함되어 있습니다."
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "연결 오류가 발생했습니다."
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr "다음 필드에 메타데이터가 없습니다: %(fields)s"
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr "유효한 메타데이터 URL. %(count)s개의 엔드포인트를 발견했습니다."
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "업데이트 정보가 없습니다."
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr "연결 실패: 서버에 연결할 수 없습니다."
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr "연결 실패: 요청 시간 초과."
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr "연결 실패: 응답에 잘못된 JSON이 포함되어 있습니다."
 
-#: cps/admin.py:3340
+#: cps/admin.py
 msgid "An unknown error occurred."
 msgstr "알 수 없는 오류가 발생했습니다."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "연결 오류가 발생했습니다."
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "연결 오류가 발생했습니다."
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "파일 %(file)s이(가) 업로드되었습니다."
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr "체코어"
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr "독일어"
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr "그리스어"
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr "스페인어"
 
-#: cps/constants.py:265
+#: cps/constants.py
 msgid "Finnish"
 msgstr "핀란드어"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr "프랑스어"
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr "갈리시아어"
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr "헝가리어"
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr "인도네시아어"
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr "이탈리아어"
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr "일본어"
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr "크메르어"
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr "한국어"
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr "네덜란드어"
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr "노르웨이어"
 
-#: cps/constants.py:276
+#: cps/constants.py
 msgid "Polish"
 msgstr "폴란드어"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr "포르투갈어"
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr "포르투갈어 (브라질)"
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr "러시아어"
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr "슬로바키아어"
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr "슬로베니아어"
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr "스웨덴어"
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr "터키어"
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr "우크라이나어"
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr "베트남어"
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr "중국어 (간체, 중국 본토)"
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr "중국어 (번체, 대만)"
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "설치되지 않았습니다."
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "실행 권한이 없습니다."
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, fuzzy, python-format
 msgid "Change cover — %(title)s"
 msgstr "저자와 제목 바꾸기"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "연결 오류가 발생했습니다."
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Could not render the e-reader preview."
 msgstr "지정된 디렉토리를 찾을 수 없습니다."
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr "서재 새로고침 중 🔄 새 책을 찾고 있습니다. 잠시 기다려 주세요…"
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr "타임스탬프"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Book ID"
 msgstr "책 ID"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "책 제목"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Book Author"
 msgstr "저자"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr "트리거 유형"
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Filepath"
 msgstr "파일 위치"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Filename"
 msgstr "파일명"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr "수동?"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr "아니오, 고칩니다."
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr "원본이 백업되었습니까?"
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr "수정사항 적용."
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr "원본 형식"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "End Format"
 msgstr "결과 형식"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "알 수 없음"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr "✅ 모든 모니터링 서비스가 정상 실행중입니다! 👍"
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 "🔴 가져오기 서비스는 실행중이지만, 메타데이터 변경점 감지기가 정지되었습니다."
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 "🔴 메타데이터 변경점 감지기는 실행중이지만, 가져오기 서비스가 정지되었습니다."
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr "⛔ 가져오기 서비스와 메타데이터 변경점 감지기 모두 정지되었습니다."
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr "오류가 발생했습니다."
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "잘못된 "
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "선택한 책 병합"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "%(format)s 형식을 찾을 수 없습니다."
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB Fixer started for selected book."
 msgstr "선택한 책 병합"
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr "이 페이지에 접근하려면 관리자권한이 필요합니다."
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr "사용자명과 사진 데이터가 필요합니다."
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid image data format."
 msgstr "올바른 이메일 주소가 아닙니다."
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr "프로필 사진이 갱신되었습니다."
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "없음"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 msgid "Duplicate Books"
 msgstr "책 복제"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "책 복제"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "책 복제"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "중복인 책"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 #, fuzzy
 msgid "Invalid resolution strategy"
 msgstr "잘못된 권한입니다."
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr "형식 업로드를 위한 책 ID가 없거나 잘못되었습니다."
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "업로드 완료, 처리 중입니다. 잠시만 기다려 주세요."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 msgid "Failed to queue upload for processing"
 msgstr "연산대기열로 업로드에 실패했습니다."
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "변환할 원본 또는 대상 형식이 지정되지 않았습니다."
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "%(book_format)s 형식으로 변환하기 위해 작업에 추가되었습니다."
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "책 변환 중 오류가 발생했습니다: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "업로드할 수 없는 파일 형식입니다."
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr "파일 확장자 '%(ext)s'은(는) 서버에 업로드할 수 없습니다"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "확장자가 없는 파일은 업로드할 수 없습니다."
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr "선택한 책을 사용할 수 없습니다. 파일이 없거나 접근할 수 없습니다."
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "표지 업로드 권한이 없습니다."
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr "식별자는 대소문자 구분 없어 덮어씁니다."
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "'%(langname)s'은(는) 올바른 언어가 아닙니다."
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "메타데이터가 업데이트되었습니다."
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "책 편집 중 오류가 발생했습니다: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "알 수 없음"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
 msgstr "업로드된 책이 이미 존재하는 것 같습니다. 확인이 필요합니다: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "파일 %(filename)s을(를) 임시 폴더에 저장할 수 없습니다."
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "표지 파일 %(file)s을(를) 이동하지 못했습니다 :%(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "책 형식이 삭제되었습니다."
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "책이 삭제되었습니다."
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "책을 삭제할 권한이 없습니다."
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "메타데이터 편집"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "시리즈 순서 %(seriesindex)s은(는) 올바르지 않아 건너뜁니다."
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr "추가 파일 형식을 업로드할 권한이 없습니다."
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "쓰기 권한이 없어 %(path)s 경로 생성에 실패했습니다."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "%(file)s 파일 저장에 실패했습니다."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "파일 형식 %(ext)s이(가) %(book)s에 추가되었습니다"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "토큰을 찾을 수 없습니다."
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "%(format)s 형식을 찾을 수 없습니다."
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1499,7 +1472,7 @@ msgstr ""
 "Google 드라이브 설정이 완료되지 않았습니다. Google 드라이브를 비활성화한 후 "
 "다시 활성화해 주세요."
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1507,98 +1480,97 @@ msgstr ""
 "콜백 도메인이 인증되지 않았습니다. Google 개발자 콘솔에서 도메인 인증 절차를 "
 "진행해 주세요."
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "책 ID %(book)d의 %(format)s 형식을 찾을 수 없습니다."
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "Google 드라이브에서 %(format)s 파일을 찾을 수 없습니다: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s을(를) 찾을 수 없습니다: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "전자책 리더로 보내기"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "책 ID %(book)d의 %(format)s 형식을 찾을 수 없습니다."
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "책 ID %(book)d의 %(format)s 형식을 찾을 수 없습니다."
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 msgid "Test Email"
 msgstr "테스트 이메일"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "사용자 %(name)s의 등록 이메일"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "%(orig)s을(를) %(format)s로 변환하여 전자책 리더로 보내기"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, python-format
 msgid "Send %(format)s to eReader"
 msgstr "%(format)s을 전자책 리더로 보내기"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s을(를) 전자책 리더로 보내기"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "요청한 파일을 읽을 수 없습니다. 파일 접근 권한을 확인해주세요."
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "읽기 상태를 설정할 수 없습니다: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
 msgstr "책 %(id)s의 폴더 삭제에 실패했습니다. %(path)s에 하위 폴더가 있습니다."
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "책 %(id)s 삭제에 실패했습니다: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1607,197 +1579,197 @@ msgstr ""
 "데이터베이스 경로가 올바르지 않아 책 %(id)s을(를) 데이터베이스에서만 삭제합니"
 "다: %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr "저자명 '%(src)s'에서 '%(dest)s'(으)로 변경하지 못했습니다: %(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Google 드라이브에서 %(file)s 파일을 찾을 수 없습니다."
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr "제목을 '%(src)s'에서 '%(dest)s'(으)로 변경하지 못했습니다: %(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Google 드라이브에서 경로 %(path)s을(를) 찾을 수 없습니다."
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr "이미 사용 중인 이메일 주소입니다."
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "이미 사용 중인 사용자 이름입니다."
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr "올바른 이메일 주소가 아닙니다."
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr "비밀번호가 설정된 규칙에 맞지 않습니다."
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr "표지 업로드에 필요한 Python 모듈 'advocate'이 설치되지 않았습니다."
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "표지 다운로드 중 오류가 발생했습니다."
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr "표지 파일이 올바른 이미지 파일이 아니거나 저장할 수 없습니다."
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "표지 형식 오류입니다."
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
 msgstr "표지 업로드를 위해 로컬 호스트나 로컬 네트워크에 접근할 수 없습니다."
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "표지 경로 생성에 실패했습니다."
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "jpg/jpeg/png/webp/bmp 형식만 지원합니다."
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "올바르지 않은 표지 파일입니다."
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "표지 파일은 jpg/jpeg 형식만 지원합니다."
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr "표지"
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "UnRar 바이너리 파일을 찾을 수 없습니다."
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr "UnRar 실행 중 오류가 발생했습니다."
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr "지정된 디렉토리를 찾을 수 없습니다."
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr "파일이 아닌 폴더를 지정하세요."
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr "Calibre 바이너리 파일을 사용할 수 없습니다."
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr "Calibre 바이너리 파일이 누락되었습니다: %(missing)s"
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "실행 권한이 없습니다: %(missing)s"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr "Calibre 실행 오류"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr "메타데이터 백업이 작업에 추가되었습니다."
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Kobo 설정"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "%(provider)s에 등록"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr "로그인 실패: 사용자 정보 엔드포인트에 접속할 수 없습니다."
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "로그인 실패: OAuth 제공자가 잘못된 사용자 정보를 제공했습니다."
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1805,35 +1777,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "%(nickname)s로 로그인했습니다."
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "%(oauth)s에 성공적으로 연결되었습니다."
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1841,4153 +1813,4085 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr "이메일 서버가 설정되지 않았습니다. 관리자에게 문의하세요."
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "%(oauth)s에 연결 해제에 성공했습니다."
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "%(oauth)s에 연결 해제에 실패했습니다."
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "%(oauth)s에 연결되지 않았습니다."
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "GitHub 로그인에 실패했습니다."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "GitHub에서 사용자 정보를 불러오지 못했습니다."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Google 로그인에 실패했습니다."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Google에서 사용자 정보를 불러오지 못했습니다."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 msgid "Failed to log in with Generic OAuth."
 msgstr "일반 OAuth 로그인에 실패했습니다."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "GitHub Oauth 오류입니다. 잠시 후 다시 시도해 주세요."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "GitHub 인증 오류가 발생했습니다: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Google 인증 오류입니다. 잠시 후 다시 시도해 주세요."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Google 인증 오류가 발생했습니다: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr "OAuth 오류: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "책 이름 오름차순 정렬"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "책 이름 오름차순 정렬"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "인기"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "다운로드 기준 인기 책"
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "베스트"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "평점 기준 인기 책"
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "받은 적 있는"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "최신 책"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "랜덤 책"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "무작위 추천 보기"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "읽음"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "현재 버전"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "읽지 않음"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "저자"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "저자별 정렬"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "출판사"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "출판사별 정렬"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "카테고리"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "카테고리별 정렬"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "시리즈"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "시리즈별 정렬"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "언어"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "언어별 정렬"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "평점"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "평점별 정렬"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "파일 형식"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "파일 형식별 정렬"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "서재"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "서재별 정렬"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "선택한 서재 Kobo 동기화"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "서재별 정렬"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "설명"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} Stars"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "검색"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "로그인"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "토큰을 찾을 수 없습니다."
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "토큰이 만료되었습니다."
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "인증되었습니다. 기기로 돌아가 주세요."
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "전체"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "최근 책 보기"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "인기 책 보기"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "받은 적 있는"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "다운로드 받은 적 있는 책 보기"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "평점 높은 책 보기"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 msgid "Show Read and Unread"
 msgstr "읽은 책과 안 읽은 책 보기"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "읽지 않은 책 보기"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "둘러보기"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Category Section"
 msgstr "카테고리 보기"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Series Section"
 msgstr "시리즈 보기"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Author Section"
 msgstr "저자 보기"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Publisher Section"
 msgstr "출판사 보기"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Language Section"
 msgstr "언어 보기"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Ratings Section"
 msgstr "평점 보기"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show File Formats Section"
 msgstr "파일 형식 보기"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "보관함"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Archived Books"
 msgstr "보관된 책 보기"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "책 목록"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "책 목록 보기"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr "중복인 책"
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 msgid "Show Duplicate Books"
 msgstr "중복인 책 보기"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "발행일 이후"
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "발행일 이전"
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "평점 <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "평점 >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "읽은 상태 = %(status)s"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 "사용자 정의 열을 검색하는 동안 오류가 발생했습니다. Calibre-Web을 다시 시작"
 "해 주세요."
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "상세 검색"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "잘못된 서재가 지정되었습니다."
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "추가할 권한이 없습니다."
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "이미 등록된 책입니다: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr "추가할 수 없습니다. %(book_id)s는 잘못된 책 ID입니다."
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "책이 등록되었습니다: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "책을 추가할 권한이 없습니다."
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "이미 등록된 책입니다: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "책들이 등록되었습니다: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "책을 추가할 수 없습니다: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "잘못된 서재가 지정되었습니다."
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "책을 추가할 수 없습니다: %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "이미 등록된 책입니다: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "책들이 등록되었습니다: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "책이 서재에서 삭제되었습니다: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "서재에서 책을 삭제할 권한이 없습니다."
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "서재 생성"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "서재를 수정할 권한이 없습니다."
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "서재 편집"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "서재를 삭제하는 중 오류가 발생했습니다."
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "서재가 삭제되었습니다."
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "서재 순서가 변경되었습니다: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "공개 서재를 생성할 권한이 없습니다."
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "서재 %(title)s가 생성되었습니다."
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "서재 %(title)s가 변경되었습니다."
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "오류가 발생했습니다."
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "'%(title)s' 공개 서재가 이미 존재합니다."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "'%(title)s' 개인 서재가 이미 존재합니다."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "서재: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "서재를 여는 동안 오류가 발생했습니다. 서재가 존재하지 않거나 접근할 수 없습니"
 "다"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "서재 제외"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "익명"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "미인증"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "예"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "아니오"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "읽은 상태"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "테마"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "밝은색"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "어두운색"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "세피아"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "서재에 추가"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "저자"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "탐색"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "닫기"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "삭제"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "병합"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "출판사"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "읽음"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "제목"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "업로드"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "계정"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "관리자"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "발행일"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "출처"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "서재 정보"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr "모두"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr "보관"
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "보관됨"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "취소"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "변환"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "설명"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "다운로드"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "편집"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "이메일 주소"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Kobo sync 사용"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "보안 연결"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "숨기기"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "식별자"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "언어"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr "읽음으로 표시"
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr "읽지 않음으로 표시"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "비밀번호"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "포트"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "진행률"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "평점"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "저장"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "선택"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr "보내기"
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "상태"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "태그"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "작업"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "작업"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr "보관 해제"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "사용자"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "사용자 이름"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "보기"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "대기 중"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "실패"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "시작됨"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "종료됨"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "종료됨"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "취소됨"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "알 수 없는 상태"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "업데이트 정보를 읽는 중 알 수 없는 문제가 발생했습니다."
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr "업데이트가 없습니다. 최신 버전이 설치되어 있습니다."
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
 msgstr ""
 "새로운 업데이트가 있습니다. 아래 버튼을 클릭해 최신 버전으로 업데이트하세요."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "업데이트 정보를 가져올 수 없습니다."
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr "아래 버튼을 클릭해 최신 버전으로 업데이트하세요."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -5996,323 +5900,321 @@ msgstr ""
 "새로운 업데이트가 있습니다. %(version)s으로 업데이트하려면 아래 버튼을 클릭하"
 "세요."
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "업데이트 정보가 없습니다."
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "추천 (무작위)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "인기 책 (가장 많이 다운로드된 책)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "%(user)s이(가) 다운로드한 책"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "저자: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "출판사: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "시리즈: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "평점: 없음"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "평점: %(rating)s"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "파일 형식: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "카테고리: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "언어: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "인기"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "숨긴 책"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "이메일 전송 오류"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "올바른 이메일 주소가 아닙니다."
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 #, fuzzy
 msgid "Invalid request"
 msgstr "잘못된 권한입니다."
 
-#: cps/web.py:1470
+#: cps/web.py
 #, fuzzy
 msgid "Name and rules are required"
 msgstr "사용자명과 사진 데이터가 필요합니다."
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 #, fuzzy
 msgid "Error creating shelf"
 msgstr "서재를 삭제하는 중 오류가 발생했습니다."
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "서재 생성"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 #, fuzzy
 msgid "Shelf name is required"
 msgstr "이 항목은 필수입니다."
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "서재를 삭제하는 중 오류가 발생했습니다."
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "서재 편집"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "사용자를 찾을 수 없습니다."
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "{} 사용자를 삭제했습니다."
 
-#: cps/web.py:1710
+#: cps/web.py
 #, fuzzy
 msgid "Error duplicating shelf"
 msgstr "서재를 삭제하는 중 오류가 발생했습니다."
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 #, fuzzy
 msgid "Error deleting shelf"
 msgstr "서재를 삭제하는 중 오류가 발생했습니다."
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "서재를 삭제하는 중 오류가 발생했습니다."
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 #, fuzzy
 msgid "Error unhiding shelf"
 msgstr "서재를 삭제하는 중 오류가 발생했습니다."
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "다운로드"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "파일 형식 목록"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr "SMTP 메일 설정을 해주세요."
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 "문제가 발생했습니다. 프로필에 유효한 전자책 리더 이메일을 설정해 주세요."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "%(eReadermail)s에 전송 작업이 추가되었습니다."
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "전송 중 오류가 발생했습니다: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 #, fuzzy
 msgid "Additional email addresses are disabled for your account."
 msgstr "이메일 주소 선택:"
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "%(eReadermail)s에 전송 작업이 추가되었습니다."
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr "다음 사용자를 등록은 1분 뒤 가능합니다."
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "등록"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr ""
 "Flask-Limiter 시스템 연결에 문제가 발생했습니다. 관리자에게 문의하세요."
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr "이메일 서버가 설정되지 않았습니다. 관리자에게 문의하세요."
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "사용할 수 없는 이메일입니다."
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "인증 이메일을 발송했습니다."
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
 msgstr "Calibre-Web이 아직 구성되지 않았습니다. 관리자에게 문의하세요."
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "이메일 서버가 설정되지 않았습니다. 관리자에게 문의하세요."
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr "LDAP 인증을 활성화할 수 없습니다."
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr "1분 후 시도해 주세요."
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "'%(nickname)s'로 로그인했습니다."
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "%(nickname)s로 로그인했습니다."
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
 msgstr "Calibre-Web이 아직 구성되지 않았습니다. 관리자에게 문의하세요."
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6321,701 +6223,671 @@ msgstr ""
 "'%(nickname)s'(으)로 대체 로그인했습니다. LDAP 서버에 연결할 수 없거나 존재하"
 "지 않는 사용자입니다."
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr "로그인할 수 없습니다: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 msgid "Wrong Username or Password"
 msgstr "사용자 이름 또는 비밀번호가 올바르지 않습니다."
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr "새 비밀번호가 이메일로 전송되었습니다"
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr "알 수 없는 오류가 발생했습니다. 나중에 다시 시도해 주세요."
 
-#: cps/web.py:2838
+#: cps/web.py
 msgid "Please enter valid username to reset password"
 msgstr "비밀번호를 재설정하려면 올바른 사용자 이름을 입력하세요."
 
-#: cps/web.py:2846
+#: cps/web.py
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "'%(nickname)s'로 로그인했습니다."
 
-#: cps/web.py:3158
+#: cps/web.py
 msgid "Success! Profile Updated"
 msgstr "프로필이 업데이트되었습니다."
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "이미 등록된 이메일 주소입니다."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr "잘못된 "
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr "KOReader Sync 플러그인"
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "인증 정보가 포함된 유요한 gmail.json을 찾을 수 없습니다."
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "%(book)s을(를) 전자책 리더로 보내기"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "전자책 리더로 보내기"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-send completed successfully"
 msgstr "{} 사용자를 삭제했습니다."
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-Send"
 msgstr "보내기"
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr "임시 폴더 비우기"
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s을 전자책 리더로 전송"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Calibre ebook-convert %(tool)s을(를) 찾을 수 없습니다."
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "%(format)s 형식을 찾을 수 없습니다."
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "알 수 없는 오류로 변환에 실패했습니다."
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Kepubify 변환에 실패했습니다: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "변환된 파일을 찾을 수 없거나 %(folder)s 폴더에 하나 이상의 파일이 존재합니다."
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre가 다음 오류로 실패했습니다: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "변환에 실패했습니다: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Calibre 데이터베이스를 다시 연결합니다."
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "중복인 책"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "중복인 책을 선택"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "업데이트 패키지 압축 해제 중"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "중복인 책"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Kobo sync 활성화"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "이메일"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr "메타데이터를 백업하고 있습니다."
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "서재에 있음"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "%(count)s개의 표지 섬네일을 생성했습니다."
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "표지 섬네일"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "{0}개의 시리즈 섬네일을 생성했습니다."
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "표지 섬네일 캐시를 삭제합니다."
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "서재별 정렬"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "비밀번호 변경"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "책장 생성"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "보안 설정"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "설정"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "옵션 선택"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 msgid "Add to Shelf"
 msgstr "책장에 추가"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(공개)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "다운로드"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "다운로드"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "등록 최신순"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "등록 오래된 순"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "저자"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "저자"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "발행일 이전"
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "발행일 이전"
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "추가된 기준으로 최신순"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "추가된 기준으로 오래된 순"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "전자책 리더로 보낼 이메일"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "전자책 리더로 보내기"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "책 보기"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "공개 서재"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr "계정 사진 변경"
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "LDAP 사용자 가져오기"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "이메일 서버 설정&nbsp;&nbsp;📬"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "SMTP 서버명"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "SMTP 포트"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "SMTP 로그인"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "보내는 이메일"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr "이메일 서비스"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail via Oauth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr "설정&nbsp;&nbsp;⚙️"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Calibre 데이터베이스 경로"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "로그 레벨"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "외부 포트"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "페이지당 표시 개수"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "업로드"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "익명 보기"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "공개 등록"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "매직 링크 원격 로그인"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "리버스 프록시 로그인"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "리버스 프록시 헤더 이름"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "기본 설정"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "UI 설정"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Calibre 데이터베이스 설정"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "예약된 작업&nbsp;&nbsp;⌛"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "시작 시간"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "최대 기간"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "시리즈 표지 섬네일 생성"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Calibre 데이터베이스 다시 연결"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr "메타데이터 백업"
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "섬네일 캐시 새로 고침"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 msgid "Setup KOReader Sync"
 msgstr "KOReader Sync 설치"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Run Hardcover Auto-Fetch"
 msgstr "Hardcover API 토큰"
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "관리&nbsp;&nbsp;🚀"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "디버그 패키지 다운로드"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "로그 보기"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "재시작"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "종료"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "버전 정보&nbsp;&nbsp;📜"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "버전"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "세부 정보"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "업데이트 실패: "
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "업데이트 채널"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "현재 버전"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "업데이트 확인"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "업데이트 실행"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "재시작하시겠습니까?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "예"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "종료하시겠습니까?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "업데이트 중입니다. 이 페이지를 새로고침 하지 마세요."
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7023,605 +6895,582 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "이 서재의 책들"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "업로드 중"
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "업데이트 실패: "
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "연결 오류가 발생했습니다."
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "시리즈: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "통해"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "서재에 있음"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "줄이기"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "더보기"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "책 삭제"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "형식 삭제:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "책 형식 변경:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "변환 전 유형:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr "옵션 선택"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "변환 후 유형:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "책 변환"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "오류"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "다른 형식 업로드"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "시리즈 ID"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "발행일"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "식별자 유형"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "식별자 값"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "삭제"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "식별자 추가"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr "URL로 표지 추가 (JPEG 이미지를 다운로드합니다)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "내 컴퓨터에서 표지 업로드"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "Kobo sync 활성화"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "저장 후 상세정보로"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "메타데이터 가져오기"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "키워드"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "키워드 검색"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "불러오는 중"
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "오류가 발생했습니다!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "검색 결과가 없습니다. 다른 검색어로 검색해 보세요."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "이 항목은 필수입니다."
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr "저자와 제목 바꾸기"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 msgid "Select all"
 msgstr "모두 선택"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr "선택 해제"
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 msgid "Update Title Sort automatically  "
 msgstr "자동으로 제목 정렬 업데이트 "
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "자동으로 저자 정렬 업데이트"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "제목 입력"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "제목 정렬 입력"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "제목 정렬"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "저자 정렬 입력"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "저자 정렬"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "저자 입력"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "카테고리 입력"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "시리즈 입력"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "언어 입력"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "발행일"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "출판사 입력"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "설명 입력"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Comments"
 msgstr "설명"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 msgid "Archived?"
 msgstr "보관됨?"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 msgid "Read?"
 msgstr "읽음?"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "입력 "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "정말로 하시겠습니까?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "다음 책들을 병합합니다:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "다음 책으로 병합:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr "다음 책이 삭제됩니다:"
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr "다음 책이 보관됩니다:"
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr "다음 책이 보관해제됩니다:"
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr "다읍 책이 읽음표시됩니다:"
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr "다음 책의 읽음표시가 해제됩니다:"
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "메타데이터 편집"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr "바꾸고자 하는 입력란을 수정하십시오. 빈 입력란은 무시됩니다:"
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 msgid "Select a Shelf"
 msgstr "책장 생성"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr "선택한 책을 추가할 책장을 선택하십시오:"
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr "-- 책장 선택 --"
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "추가"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr "이메일 서버가 설정되지 않았습니다. 관리자에게 문의하세요."
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr "메시지"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "최소 하나 이상의 이메일 주소를 선택하십시오."
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "전자책 리더로 보내기"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "뒤로"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Calibre 데이터베이스 경로 (metadata.db 파일)"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7637,13 +7486,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7654,7 +7503,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7669,11 +7518,11 @@ msgstr ""
 "면 나타나는 입력란에 <code>/books</code>를 입력하여 해당 책 파일들이 들어 있"
 "는 경로를 <code>/books</code> 같은 경로에 연동할 수 있습니다."
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr "서재 기능 분할"
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
@@ -7683,32 +7532,32 @@ msgstr ""
 "calibre-library</code> 내에 유지해야 합니다. 단, 서재 파일은 자유롭게 옮기셔"
 "도 됩니다."
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Google 드라이브 사용"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Google 드라이브 인증"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Google 드라이브 Calibre 폴더"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "Google 드라이브 API ID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "취소"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Calibre 데이터베이스 다시 연결"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7718,90 +7567,90 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "종료하시겠습니까?"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Calibre 데이터베이스 다시 연결"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr "데이터베이스 경로가 올바르지 않습니다. 유효한 경로를 입력해주세요."
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "기본 인증 사용"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "LDAP 인증 사용"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "OAuth 사용"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "서버 설정"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "서버 포트"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL 인증서 파일 경로 (미사용 시 공란)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL 키 파일 경로 (미사용시 공란)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "업데이트 채널"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "안정 버전"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "실험 버전"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "신뢰할 수 있는 호스트 (쉼표로 구분)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "로그 파일 설정"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "액세스 로그 파일 경로 및 파일명 (공란일 경우 access.log로 저장됩니다)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "액세스 로그 사용"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "액세스 로그 파일 경로 및 파일명 (공란일 경우 access.log로 저장됩니다)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 msgid "Feature Configuration"
 msgstr "기능 설정"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr "제목과 저자가 영문이 아닐 경우 영문(발음 그대로)으로 변환하여 저장"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
@@ -7809,39 +7658,39 @@ msgstr ""
 "다운로드/변환/이메일 전송 시 전자책 파일에 메타데이터 포함 (Calibre/Kepubify "
 "필요)"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "업로드 사용"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr "(사용자에게 업로드 권한이 있어야 가능)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "허용할 업로드 파일 형식"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "익명 탐색 사용"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "공개 등록 사용"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "이메일을 사용자 이름으로 사용"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "매직 링크 원격 로그인 사용"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7849,155 +7698,155 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Kobo 스토어에 알 수 없는 요청 프록시 전달"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "서버 외부 포트 (포트 포워딩 API 호출용)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 "Kobo 읽기 진행 상황을 Hardcover와 동기화하기 (사용자별 API 키가 필요합니다)"
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Goodreads 사용"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Goodreads API 키"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 msgid "Enable Hardcover Sync"
 msgstr "Kobo sync 활성화"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr "Hardcover API 키"
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "토큰이 만료되었습니다."
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Goodreads API 키"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8005,173 +7854,173 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "리버스 프록시 인증 허용"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "로그인 방식"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "LDAP 서버 호스트 이름 또는 IP 주소"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "LDAP 서버 포트"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "LDAP 암호화"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr "LDAP CA 인증서 경로 (클라이언트 인증서 인증 시에만 필요)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr "LDAP 인증서 경로 (클라이언트 인증서 인증 시에만 필요)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr "LDAP 키 파일 경로 (클라이언트 인증서 인증 시에만 필요)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "LDAP 인증"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "단순 인증"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "LDAP 관리자 아이디"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "LDAP 관리자 비밀번호"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "LDAP 식별 이름 (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "LDAP 사용자 객체 필터"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "OpenLDAP 서버인 경우 체크"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr "사용자를 가져오기 위해 다음 설정이 필요합니다."
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "LDAP 그룹 객체 필터"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "LDAP 그룹 이름"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "LDAP 그룹 구성원 필드"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "LDAP 사용자 감지 필터"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "자동 감지"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "사용자 지정 필터"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "LDAP 구성원 사용자 필터"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 msgid "Test Metadata"
 msgstr "메타데이터 시험"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr "수동으로 설정하려면 이하를 빈칸으로 두십시오"
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr "수동 엔드포인트 URL 사용 (자동 검색 무시)"
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
@@ -8179,230 +8028,230 @@ msgstr ""
 "자동 검색 대신, 개별 OAuth 엔드포인트를 수동으로 설정하려면 이 항목을 체크하"
 "십시오."
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 msgid "Manual Endpoint Configuration"
 msgstr "수동 엔드포인트 설정"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 msgid "Token Endpoint"
 msgstr "토큰 엔드포인트"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr "UserInfo 엔드포인트"
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 msgid "Test Connection"
 msgstr "연결 확인"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 msgid "OAuth Scopes"
 msgstr "OAuth 범위"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr "공백으로 구분된 OAuth 범위 목록"
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 msgid "OAuth Client Id"
 msgstr "OAuth 클라이언트 ID"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 msgid "OAuth Client Secret"
 msgstr "OAuth 클라이언트 비밀키"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 msgid "Field Mapping Configuration"
 msgstr "필드 매핑 설정"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 msgid "Username Field"
 msgstr "사용자명 필드"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr "JWT에서 사용자 이름을 추출할 필드"
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 msgid "Email Field"
 msgstr "이메일 필드"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr "이메일을 추출할 JWT 필드"
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "관리자용 OAuth 그룹"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr "관리자용 OAuth 그룹"
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "새 사용자 기본 설정"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "다운로드 허용"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "책 보기 허용"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "업로드 허용"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "편집 허용"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "책 삭제 허용"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "비밀번호 변경 허용"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "공개 서재 편집 허용"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr "로그인 버튼 문자"
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "%(provider)s OAuth 인증 정보 받기"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "%(provider)s OAuth 클라이언트 ID"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "%(provider)s OAuth 클라이언트 비밀키"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "외부 바이너리 설정"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr "Calibre 바이너리 경로"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 msgid "Calibre E-Book Converter Settings"
 msgstr "Calibre E-Book 컨버터 설정"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Kepubify 전자책 컨버터 경로"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 msgid "Location of Unrar binary"
 msgstr "UnRar 바이너리 경로"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 msgid "Security Settings"
 msgstr "보안 설정"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8410,335 +8259,330 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr "로그인 실패 횟수 제한"
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr "Flask-Limiter 데이터베이스 주소"
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr "Flask-Limiter 옵션"
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr "업로드 시 파일 형식 일치 검사"
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 msgid "Session protection"
 msgstr "세션 보호"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr "기본"
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr "강력"
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 msgid "User Password policy"
 msgstr "비밀번호 강도 규칙 사용"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr "최소 비밀번호 길이"
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr "숫자 필수"
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr "소문자 필수"
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr "대문자 필수"
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr "한자/일본어/한국어 문자 필수"
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr "특수문자 필수"
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "환경 설정"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "랜덤 보기시 표시할 책 수"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr "숨기기 전 표시할 저자 수 (0=숨기기 비활성화)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "기본값"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "caliBlur! 다크 테마"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "열을 무시하는 정규식"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "읽음/읽지 않음 상태를 Calibre 데이터에 저장"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "읽음/읽지 않음 상태를 Calibre 데이터에 저장"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Calibre 데이터 기반 화면 표시 제한"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "제목 정렬 정규식"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "환경 설정"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Custom CSS"
 msgstr "사용자 지정 필터"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "새 사용자 기본 설정"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "버전"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "관리자"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "한 페이지 보기"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "기본 언어"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "새 사용자 기본 설정"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "책의 기본 표시 언어"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "새 사용자 기본 기능"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "새 사용자 기본 기능"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "목록 보기에서 무작위 추천 표시"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "허용/거부 태그 추가"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "허용/거부 사용자 정의 열 값 추가"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "업로드"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run Archive"
 msgstr "보관 적용"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 msgid "Download Log"
 msgstr "로그 다운로드"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "시작하기"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8747,14 +8591,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8762,96 +8606,95 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "선택한 책 병합"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "{} 사용자를 삭제했습니다."
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "이메일 전송 오류"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "검색 결과가 없습니다."
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "사용자 이름 입력"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "검색"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "책장 생성"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "선택한 책 병합"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "이메일 전송 오류"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Calibre-Web Automated 서비스 활성화/비활성화"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8859,11 +8702,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -8874,11 +8717,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -8888,163 +8731,163 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "보관함"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr "CWA 자동 표지 & 메타데이터 적용 서비스 활성화"
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9052,11 +8895,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9064,65 +8907,63 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "메타데이터가 업데이트되었습니다."
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "식별자"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "표지"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 1-200 MB (default: 15)"
 msgstr "범위: 5-120분 (기본값: 15)"
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr "가져오기 프로세스 시간 초과"
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
@@ -9131,49 +8972,49 @@ msgstr ""
 "개별 책당 최대 연산 시간(단위: 분). 시간 초과한 책은 검사를 위해 실패한 백업 "
 "폴더로 이동됩니다."
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr "시간 초과 (분):"
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr "범위: 5-120분 (기본값: 15)"
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Stale temp age (minutes):"
 msgstr "시간 초과 (분):"
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr "범위: 5-120분 (기본값: 15)"
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr "범위: 5-120분 (기본값: 15)"
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9181,162 +9022,162 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Delay (minutes):"
 msgstr "시간 초과 (분):"
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr "범위: 5-120분 (기본값: 15)"
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Hardcover API 토큰"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Token Required"
 msgstr "Hardcover API 토큰"
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr "범위: 5-120분 (기본값: 15)"
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr "범위: 5-120분 (기본값: 15)"
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr "범위: 5-120분 (기본값: 15)"
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 msgid "Web UI Settings"
 msgstr "Web UI 설정"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "자동 백업 설정"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9344,36 +9185,35 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr "번역 공헌 알림 켜기"
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -9382,22 +9222,22 @@ msgstr ""
 "비활성화된 경우, 사용중인 언어가 번역 미완료인 경우 Web UI에서 알림을 받지 않"
 "습니다. (영어 제외)"
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "선택한 서재 Kobo 동기화"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "모바일에서 흐린 배경 활성화 (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -9405,15 +9245,15 @@ msgstr ""
 "활성화된 경우, 흐림 효과는 작은 창에서도 나타납니다. 스크롤이나 전환 효과가 "
 "느린 경우 비활성화하십시오."
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 msgid "Automatic Backup Settings"
 msgstr "자동 백업 설정"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -9421,11 +9261,11 @@ msgstr ""
 "활성화된 경우, 모든 불러온 파일의 복사본이 <i>/config/processed_books/"
 "imported</i>에 저장됩니다."
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -9433,21 +9273,21 @@ msgstr ""
 "활성화된 경우, 변환 대상인 원본 파일이 /config/processed_books/converted에 저"
 "장됩니다."
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9459,11 +9299,11 @@ msgstr ""
 "포합합니다. /config/processed_books 이하 경로를 정리하고 저장소 사용량을 최소"
 "화합니다."
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -9472,32 +9312,32 @@ msgstr ""
 "자동 변환이 활성화된 경우, 가져오기 한 모든 책이 지정된 형식으로 변환됩니다. "
 "(예외처리된 이하의 형식 목록 제외)"
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 msgid "Choose a target format:"
 msgstr "목표 책 형식 지정:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9505,19 +9345,19 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr "Calibre는 가져오기 중 중복된 책을 감지합니다. 책 제목과 "
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr "자동병합"
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -9525,850 +9365,838 @@ msgstr ""
 "설정. 중복된 책 중 한 쪽을 삭제하거나, 모두 유지(기본값) 중 선택할 수 있습니"
 "다."
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr "중복으로 가져오기 된 책을 삭제하고, 현재 서재에 있는 파일을 유지합니다"
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr "서재에 있는 책을 새로 가져오기한 파일로 덮어씁니다"
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "중복된 항목을 모두 저장합니다."
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "공개 등록 사용"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "자동 백업 설정"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Manual only"
 msgstr "수동?"
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "CWA 업데이트 알림 켜기"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "공개 등록 사용"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "원본 형식"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "메타데이터 시험"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "평점"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr "더보기"
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "다음"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "읽지 않음으로 표시"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "읽음으로 표시"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "읽음으로 표시"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "읽지 않음으로 표시"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "보관함에 추가"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "보관함에서 복원"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "보관함에서 복원"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "보관함에 추가"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "보관함에서 복원"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "검색"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "데이터베이스 설정이 업데이트되었습니다."
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "평점(이상)"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "책 %(index)s / %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 #, fuzzy
 msgid "File sizes"
 msgstr "글자 크기"
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "설명:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 msgid "Select eReader Email Addresses"
 msgstr "eReader 이메일 주소 선택"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 msgid "Choose email addresses:"
 msgstr "이메일 주소 선택:"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 msgid "Select All"
 msgstr "모두 선택"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Additional email addresses:"
 msgstr "이메일 주소 선택:"
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Enter additional email addresses (separated by commas):"
 msgstr "이메일 주소 선택:"
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 msgid "Select format:"
 msgstr "형식 선택:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "표지 경로 생성에 실패했습니다."
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "표지 경로 생성에 실패했습니다."
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr "제목과 저자가 동일한 책. 실제로 중복인지 확인하는 것을 추천드립니다."
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "중복인 책"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "중복인 책 보기"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr "중복인 책을 선택"
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 msgid "Select None"
 msgstr "선택하지 않기"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 msgid "Delete Selected"
 msgstr "선택한 책 삭제"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "중복인 책"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Auto-Resolve Duplicates"
 msgstr "중복인 책을 선택"
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "이전"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "선택한 책 병합"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "책 상세정보"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "메타데이터 편집"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "선택한 책 병합"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 msgid "No Duplicate Books Found"
 msgstr "중복된 책이 없습니다"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr "서재에 중복된 제목과 저자인 조합의 책이 없습니다."
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr "위양성을 피하기 위해, 완전히 동일한 제목과 저자인 책을 검색합니다."
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "형식 선택:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr "되돌릴 수 없습니다!"
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 msgid "The following books will be permanently deleted:"
 msgstr "다음 책이 영구히 삭제됩니다:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "읽지 않음"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "다음 책이 삭제됩니다:"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "다음 책이 영구히 삭제됩니다:"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr "성공"
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr "선택한 중복된 책이 삭제되었습니다!"
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr "요청 실행중 오류가 발생했습니다."
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "이메일 유형 선택"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr "표준 이메일 계정"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr "Gmail 계정"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr "Gmail 계정 설정"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Gmail 접근 권한 해제"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "SMTP 비밀번호"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "첨부파일 최대 크기"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 msgid "Save and Send Test Email"
 msgstr "저장 및 테스트 메일 전송"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "허용하는 도메인 (화이트 리스트)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "도메인 추가"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "도메인 입력"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "차단 도메인 (블랙리스트)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10376,1536 +10204,1522 @@ msgstr ""
 "텍스트 편집기에서 .kobo/Kobo/Kobo eReader.conf 파일을 열고 다음을 추가하거나 "
 "수정하세요:"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Kobo 토큰:"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "목록"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "모두 선택"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "검색어:"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "저장 후 상세정보로"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "모두 선택"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "불러오는 중"
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
 msgstr "선택한 사용자의 권한을 변경하시겠습니까?"
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "표지 경로 생성에 실패했습니다."
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr "선택한 사용자의 권한을 변경하시겠습니까?"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "모두 선택"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "표지 경로 생성에 실패했습니다."
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "Calibre-Web이 아직 구성되지 않았습니다. 관리자에게 문의하세요."
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "이슈 생성"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "홈으로"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "로그아웃"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "서재 편집"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show this shelf in your sidebar"
 msgstr "이 서재를 Kobo 기기와 동기화"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "모두 보기"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "공개 서재"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "책장에 추가"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 #, fuzzy
 msgid "KOReader Sync is disabled."
 msgstr "KOReader Sync 플러그인"
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "홈"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "메뉴 열기/닫기"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "검색"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Calibre-Web Automated 책 목록"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "로그아웃"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 msgid "Settings"
 msgstr "설정"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 msgid "Refresh Library"
 msgstr "서재 새로고침"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "업데이트 정보가 없습니다."
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Calibre-Web Automated 책 목록"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr "변경점 확인"
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "중복인 책"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr "여기에서 기여하세요!"
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "페이지를 새로고침하지 마세요."
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "서재 생성"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "이전"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "책 상세정보"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "되돌릴 수 없습니다!"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "선택한 책 삭제"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "결과 형식"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "형식 삭제:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "책 복제"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "중복된 책이 없습니다"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "중복인 책을 선택"
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "최적 크기"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "종료:"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "설정"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "서재에 추가"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "선택한 책 병합"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "읽지 않음으로 표시"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "책 삭제"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "책 삭제"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "책장 생성"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "연결 오류가 발생했습니다."
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr "초성 필터"
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "격자"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "SMTP 비밀번호"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "로그인 유지"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "비밀번호를 잊으셨나요?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "매직 링크로 로그인"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 msgid "Log in with SSO"
 msgstr "SSO로 로그인"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Calibre-Web 로그 표시: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Calibre-Web Log: "
 msgstr "Calibre-Web 로그:"
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "스트림 출력, 표시할 수 없음"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "액세스 로그 표시: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Calibre-Web 로그 다운로드"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "액세스 로그 다운로드"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "모두와 공유"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "허용/거부 태그 선택"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "허용/거부 사용자 정의 항목 선택"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "사용자의 허용/거부 태그 선택"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr "사용자 정의 항목 허용/거부 선택"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "태그 입력"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "보기 제한 추가"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "이 책의 형식은 데이터베이스에서 삭제됩니다."
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "이 책은 데이터베이스에서 삭제됩니다."
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "그리고 디스크에서도 삭제됩니다."
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr "Kobo 알림: 삭제된 책은 연결된 Kobo 기기에 남아있습니다."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
 msgstr "책을 안전하게 삭제하려면 먼저 보관 처리 후 기기 동기화가 필요합니다."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "파일 위치 선택"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "유형"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "이름"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "크기"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "상위 폴더"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "확인"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Calibre-Web Automated 책 목록"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "epub 리더"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "작업"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "검은색"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "글자 크기"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "다음 페이지"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr "글꼴"
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 msgid "Default"
 msgstr "기본값"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr "Yahei"
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr "SimSun"
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 msgid "KaiTi"
 msgstr "KaiTi"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 msgid "Arial"
 msgstr "Arial"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 msgid "Spread"
 msgstr "페이지 보기"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr "두쪽 보기"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr "한쪽 보기"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "사이드바가 열릴 경우 텍스트를 재정렬합니다."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "만화 리더"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "키보드 단축키"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "이전 페이지"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "다음 페이지"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 msgid "Single Page Display"
 msgstr "한 페이지 보기"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr "연속 보기"
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "최적 크기"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "너비에 맞춤"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "높이에 맞춤"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "원본 크기"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "오른쪽으로 회전"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "왼쪽으로 회전"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "이미지 반전"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "표시 방식"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 msgid "Single Page"
 msgstr "단일 페이지"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr "세로 스크롤"
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "크기 조절"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "최적"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "폭"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "높이"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "원본 크기"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "회전"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "뒤집기"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "수평"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "수직"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 msgid "Direction"
 msgstr "방향"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "왼쪽에서 오른쪽"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "오른쪽에서 왼쪽"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr "맨 위로 이동"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 msgid "Remember Position"
 msgstr "위치 기억하기"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "스크롤바"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "보기"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "DJVU 리더"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "PDF 리더"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "텍스트 리더"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "새 사용자 등록"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "사용자 이름 선택"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "이메일 주소"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "매직 링크 - 새 장치 승인"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "다른 기기에서 로그인하여 방문하세요:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "승인되면 자동으로 로그인 됩니다."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "인증 링크는 10분 후 만료됩니다."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "시리즈 미리보기 표지 생성"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "검색 결과가 없습니다."
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "검색어:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "결과:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "발행일(시작)"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "발행일(종료)"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr "없음"
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "태그 제외"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "시리즈 제외"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "서재 제외"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "언어 제외"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "확장자"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "확장자 제외"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "평점(이상)"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "평점(이하)"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "시작:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "종료:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "이 서재 삭제"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "서재 속성 편집"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "숨긴 책"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "수동으로 책 정렬"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "정렬 변경 비활성화"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "정렬 변경 활성화"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "선택한 책 병합"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "계정"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "토큰을 찾을 수 없습니다."
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "이 서재 삭제"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "서재에 추가"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "검색"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "검색"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "모두와 공유"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "이 서재를 Kobo 기기와 동기화"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "사용자를 찾을 수 없습니다."
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "숨긴 책"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "서재 통계"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "이 서재의 책들"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "이 서재의 저자"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "이 서재의 카테고리"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "이 서재의 시리즈"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "시스템 통계"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "프로그램"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "설치 버전"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "실행 시간"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr "작업"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "회전"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr "작업이 취소됩니다. 진행된 부분은 저장됩니다."
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
 msgstr "예약된 작업일 경우, 다음 예약 시간에 이어서 실행됩니다."
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "선택한 중복된 책이 삭제되었습니다!"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Calibre-Web Automated 책 목록"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "이메일 주소"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "설정"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "사용자 비밀번호 초기화"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "서버 설정"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "eReader 이메일 주소 선택"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "언어 입력"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "책 언어"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "제공된 책의 언어가 올바르지 않습니다."
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "OAuth 설정"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "연결"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "연결 해제"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Hardcover API Token"
 msgstr "Hardcover API 토큰"
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Kobo 동기화 토큰"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "생성/보기"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "강제 Kobo 전체 동기화"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "선택한 서재의 책만 Kobo와 동기화"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "선택한 서재의 책만 Kobo와 동기화"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "보안 설정"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "허용/거부할 사용자 정의 항목 추가"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Magic Shelves Order"
 msgstr "선택한 서재 Kobo 동기화"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "최근 추가된 책"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "공개 서재 편집"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "사용자 삭제"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -11913,155 +11727,155 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "비밀번호 변경"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "비밀번호 변경"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "생성/보기"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Kobo 인증 URL 생성"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "선택…"
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "선택 항목 삭제"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "사용자 편집"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "사용자 이름 입력"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 msgid "Enter Email"
 msgstr "이메일 입력"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "Enter eReader Email"
 msgstr "전자책 리더 이메일 입력"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "eReader Email"
 msgstr "전자책 리더 이메일"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "전자책 리더 이메일 입력"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "전자책 리더 이메일"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "언어"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "표시할 책 언어"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "허용 태그 편집"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "허용 태그"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "제외 태그 편집"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "제외 태그"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "허용 항목 편집"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "허용 항목"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "제외 항목 편집"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "제외 항목"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "비밀번호 변경"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "공개 서재 편집"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "선택한 서재 Kobo 동기화"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "선택한 서재 Kobo 동기화"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 msgid "Show Read/Unread Section"
 msgstr "읽음/읽지 않음 표시"
 
@@ -12255,8 +12069,8 @@ msgstr "읽음/읽지 않음 표시"
 #~ msgstr ""
 #~ "이 경로들은 CWA 내부에서만 사용됩니다. 콜론 왼쪽 경로는 자유롭게 변경가능"
 #~ "하나,\n"
-#~ "        오른쪽 경로는 변경할 이유가 없습니다.<br><br>만약 <code>metadata."
-#~ "db<code> 파일을 나머지 서재와 다른 위치에 두고 싶다면, \n"
+#~ "        오른쪽 경로는 변경할 이유가 없습니다.<br><br>만약 "
+#~ "<code>metadata.db<code> 파일을 나머지 서재와 다른 위치에 두고 싶다면, \n"
 #~ "<b>아래의 ‘책 파일을 서재와 분리하기’ 옵션을 사용하고, 거기에 라이브러리"
 #~ "의 나머지 경로를 입력하십시오.</b>"
 

--- a/cps/translations/nl/LC_MESSAGES/messages.po
+++ b/cps/translations/nl/LC_MESSAGES/messages.po
@@ -12,8 +12,8 @@ msgstr ""
 "Automated\n"
 "POT-Creation-Date: 2026-07-17 21:21-0400\n"
 "PO-Revision-Date: 2026-04-26 13:31+0200\n"
-"Last-Translator: Michiel Cornelissen <michiel.cornelissen+gitbhun at proton."
-"me>\n"
+"Last-Translator: Michiel Cornelissen <michiel.cornelissen+gitbhun at "
+"proton.me>\n"
 "Language-Team: ed.driesen@telenet.be\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
@@ -23,46 +23,46 @@ msgstr ""
 "Generated-By: Babel 2.13.1\n"
 "X-Generator: Poedit 3.9\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Statistieken"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 #, fuzzy
 msgid "Server restarted, please reload page."
 msgstr "De server is opnieuw gestart, vernieuw de pagina"
 
-#: cps/admin.py:210
+#: cps/admin.py
 #, fuzzy
 msgid "Performing Server shutdown, please close window."
 msgstr "Bezig met het afsluiten van de server, sluit het venster"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "Gelukt! Database opnieuw verbonden"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Onbekende opdracht"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 "Gelukt! E-Mail wordt verzonden naar %(email)s, controleer de taken voor het "
 "resultaat"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
@@ -70,48 +70,48 @@ msgstr ""
 "Fout: Geen Hardcover-token beschikbaar. Stel de omgevingsvariabele "
 "HARDCOVER_TOKEN in of configureer deze in de basisconfiguratie."
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 "Succes! De taak voor het automatisch ophalen van hardcoverboeken is gestart. "
 "Controleer het takenpaneel voor de voortgang."
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 "Fout bij het starten van de automatische ophaaltaak voor hardcover: %(error)s"
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Review Hardcover Matches"
 msgstr "Hardcover-overeenkomsten beoordelen"
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr "Fout bij het laden van de beoordelingswachtrij: %(error)s"
 
-#: cps/admin.py:414
+#: cps/admin.py
 msgid "Hardcover ID applied successfully"
 msgstr "Hardcover ID succesvol toegepast"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Match %(action)s"
 msgstr "Vergelijk %(action)s"
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr "Geen openstaande overeenkomsten om af te wijzen"
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr "%(count)s afgewezen overeenkomst(en)"
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
@@ -119,171 +119,169 @@ msgstr ""
 "De cache voor miniaturen wordt vernieuwd voor {} boek(en). Dit kan een paar "
 "minuten duren."
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr "Er zijn geen boeken met omslagen gevonden om te verwerken."
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr "Vernieuwen van de miniatuur is mislukt: {}"
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Systeembeheer"
 
-#: cps/admin.py:653
+#: cps/admin.py
 msgid "Hardcover token expires"
 msgstr "Hardcover-token verloopt"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Basisconfiguratie"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Uiterlijk aanpassen"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr "Aangepaste kolom Nr.%(column)d bestaat niet in de Calibre Database"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Bewerken Gebruikers"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Alles"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Gebruiker niet gevonden"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} gebruikers succesvol verwijderd"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Alle talen"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Misvormd verzoek"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "Gast naam kan niet worden veranderd"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "Gast kan deze rol niet hebben"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr ""
 "Kan systeembeheerder rol niet verwijderen van de laatste systeembeheerder"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "Waarde moet Waar of Onwaar zijn"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Ongeldige rol"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "Gast kan dit niet bekijken"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "Ongeldige waarde"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 "Gasts locale is automatisch bepaald en kan niet handmatig worden ingesteld"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Geen geldige locale is opgegeven"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Geen geldige boek taal is opgegeven"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Parameter is niet gevonden"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "Instellingen database is niet schrijfbaar."
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Ongeldige gelezen kolom"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Ongeldige beperkte kolom"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Wil je je Kobo Token echt verwijderen?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "Wil je dit domein echt verwijderen?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "Wil je deze gebruiker echt verwijderen?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Weet je zeker dat je deze boekenplank wilt verwijderen?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 #, fuzzy
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr ""
 "Weet je zeker dat je de locales van de geselecteerde gebruiker(s) wil "
 "veranderen?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "Weet je zeker dat je de zichtbare talen voor de geselecteerde gebruiker(s) "
 "wil veranderen?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 "Weet je zeker dat je de geselecteerde rol van de geselecteerde gebruiker(s) "
 "wil veranderen?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
@@ -292,7 +290,7 @@ msgstr ""
 "Weet je zeker dat je de geselecteerde beperkingen voor de geselecteerde "
 "gebruikers(s) wil verwijderen?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -300,7 +298,7 @@ msgstr ""
 "Weet je zeker dat je de geselecteerde zichtbaarheidsbeperkingen voor de "
 "geselecteerde gebruiker(s) wil veranderen?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
@@ -308,7 +306,7 @@ msgstr ""
 "Weet je zeker dat je de synchronisatiegedrag van boekenplanken voor de "
 "geselecteerde gebruiker(s) wil veranderen?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
@@ -316,122 +314,117 @@ msgstr ""
 "Weet je zeker dat je de synchronisatiegedrag van boekenplanken voor de "
 "geselecteerde gebruiker(s) wil veranderen?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 #, fuzzy
 msgid "Are you sure you want to change Calibre library location?"
 msgstr ""
 "Weet je zeker dat je de locatie van de Calibre-bibliotheek wil veranderen?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Weigeren"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Toestaan"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "{} synchronisatie objecten verwijderd"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Boek niet gevonden"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Tag niet gevonden"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Ongeldige actie"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json is niet geconfigureerd voor webapplicatie"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "De locatie van het logbestand is onjuist, voer een geldige locatie in"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "De locatie vam het toegangslog is onjuist, voer een geldige locatie in"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 "Voer alsjeblieft een LDAP Provider, Port, DN en User Object Identifier in"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Voer een geldig LDAP Service Account en wachtwoord in"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "Voer een LDAP Service Account in"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP Groep Object Filter Moet Een \"%s\" Formaat Identificiatie hebben"
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "LDAP Groep Object Filter heeft een niet-gebalanceerd haakje"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP Gebruiker Object Filter moet \"%s\" Formaat Identificatie hebben"
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "LDAP Gebruiker Filter heeft een niet-gebalanceerd haakje"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP Lid Gebruiker Filter moet een \"%s\" Formaat Identificatie hebben"
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "LDAP Lid Gebruiker Filter heeft een niet-gebalanceerd haakje"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -439,29 +432,24 @@ msgstr ""
 "LDAP CACertficaat, Certificaat of Sleutel Locatie is ongeldig. Voer "
 "alsjeblieft een geldig pad in."
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Gebruiker toevoegen"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "SMTP-instellingen bewerken"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "Gelukt! Gmail account geverifieerd."
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Database fout: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -469,53 +457,53 @@ msgstr ""
 "Test E-Mail wordt verzonden naar %(email)s, controleer de taken voor het "
 "resultaat"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Fout opgetreden bij het versturen van de test-e-mail: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Gelieve eerst je e-mail adres configureren..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "E-mailserver-instellingen bijgewerkt"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "Bewerken Gebruikers"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Stel eerst SMTP-mail in..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "Gelieve eerst je e-mail adres configureren..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "Een nieuw wachtwoord is verzonden naar je e-mailadres"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -523,7 +511,7 @@ msgstr ""
 "Test E-Mail wordt verzonden naar %(email)s, controleer de taken voor het "
 "resultaat"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -532,263 +520,261 @@ msgstr ""
 "Test E-Mail wordt verzonden naar %(email)s, controleer de taken voor het "
 "resultaat"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "Bewerk instellingen van geplande taken"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "De starttijd van de taak is ongeldig"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "De duur van de taak is ongeldig"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "Instellingen van geplande taken bijgewerkt"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Onbekende fout opgetreden. Probeer het later nog eens."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 msgid "title"
 msgstr "titel"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Gebruiker '%(nick)s' bewerken"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Wachtwoord voor gebruiker %(user)s is hersteld"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Stel eerst SMTP-mail in..."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Logbestand lezer"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Update opvragen"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Update downloaden"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Update uitpakken"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Update toepassen"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Databaseverbindingen zijn gesloten"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Bezig met stoppen van Calibre-Web"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Update voltooid, klik op 'Oké' en vernieuw de pagina"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Update mislukt:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "HTTP-fout"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Verbindingsfout"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Time-out tijdens maken van verbinding"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Algemene fout"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr "Geüpload bestand kon niet opgeslagen worden in de tijdelijke map"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "Bestanden kunnen niet vervangen worden tijdens een update"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 #, fuzzy
 msgid "Failed to extract at least One LDAP User"
 msgstr "Mislukt om minstens een LDAP gebruiker aan te maken"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Het is niet gelukt tenminste een LDAP gebruiker aan te maken"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Fout: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Fout: No user returned in response of LDAP server"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "Minstens een LDAP Gebruiker is niet gevonden in de Database"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} Gebruiker succesvol geïmporteerd"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr "Boekenpad is niet geldig"
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "Database niet gevonden, voer de juiste locatie in"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "Kan niet schrijven naar database"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "SSL-sleutellocatie is niet geldig, voer een geldig pad in"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr "SSL-certificaatlocatie is niet geldig, voer een geldig pad in"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr "Het wachtwoord moet tussen de 1 en 40 tekens lang zijn"
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "Database-instellingen bijgewerkt"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 #, fuzzy
 msgid "Database Configuration"
 msgstr "Databaseconfiguratie"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Vul alle velden in!"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "Het e-mailadres bevat geen geldige domeinnaam"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Gebruiker toevoegen"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Gebruiker '%(user)s' aangemaakt"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! An account already exists for this Email. or name."
 msgstr ""
 "Bestaand account met dit e-mailadres of deze gebruikersnaam aangetroffen."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Gebruiker '%(nick)s' verwijderd"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "Kan Gast gebruiker niet verwijderen"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "Kan laatste systeembeheerder niet verwijderen"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "E-mail kan niet leeg zijn en moet geldig zijn"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Gebruiker '%(nick)s' bijgewerkt"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr "Verbinding mislukt: Server gaf statuscode %(code)s terug"
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
@@ -796,14 +782,14 @@ msgstr ""
 "Verbinding mislukt: Kon geen verbinding maken met de server. Controleer de "
 "URL en de netwerkverbinding"
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 "Verbinding mislukt: De aanvraag duurde te lang. De server kan traag zijn of "
 "onbereikbaar."
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
@@ -811,12 +797,12 @@ msgstr ""
 "Verbinding mislukt: Ongeldige JSON in de respons. Dit mag niet een geldig "
 "OIDC endpoint zijn."
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Verbindingsfout: %(error)s"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
@@ -825,628 +811,615 @@ msgstr ""
 "Metadata mist vereiste velden: %(fields)s. Dit mag niet een geldig OIDC "
 "metadata endpoint zijn."
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr "Metadata URL is geldig! %(count)s endpoints gevonden."
 
-#: cps/admin.py:3322
+#: cps/admin.py
 msgid " User info endpoint is available."
 msgstr "Gebruiker-informatie endoint is beschikbaar"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr "Verbinding mislukt: Kon geen verbinding maken met de server."
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr "Verbinding mislukt: De aanvraag duurde te lang."
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr "Verbinding mislukt: Ongeldige JSON in de respons."
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "Onbekende fout opgetreden. Probeer het later nog eens."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 msgid "Restore already in progress."
 msgstr "Herstel is al bezig."
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr "Herstel mislukt: pad naar Calibre bibliotheek is niet geconfigureerd."
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr "Hertel mislukt: metadata.db niet gevonden in %(path)s"
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr "Hertel mislukt: app.db niet gevonden in %(path)s"
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Hertel mislukt: %(err)s"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "Bestand %(file)s geüpload"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr "Tsjechisch"
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr "Duits"
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr "Grieks"
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr "Spaans"
 
-#: cps/constants.py:265
+#: cps/constants.py
 msgid "Finnish"
 msgstr "Fins"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr "Frans"
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr "Galicisch"
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr "Hongaars"
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr "Indonesisch"
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr "Italiaans"
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr "Japans"
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr "Khmer"
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr "Koreaans"
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr "Nederlands"
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr "Noors"
 
-#: cps/constants.py:276
+#: cps/constants.py
 msgid "Polish"
 msgstr "Pools"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr "Portugees"
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr "Portugees (Brazilië)"
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr "Russisch"
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr "Slowaaks"
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr "Sloveens"
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr "Zweeds"
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr "Turks"
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr "Oekraïens"
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr "Vietnamees"
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr "Chinees (Vereenvoudigd, China)"
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr "Chinees (Traditioneel, Taiwan)"
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "niet geïnstalleerd"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Kan programma niet uitvoeren"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr "Terug naar metagegevens bewerken"
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr "Terug naar boek"
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, fuzzy, python-format
 msgid "Change cover — %(title)s"
 msgstr "Auteur en titel omwisselen"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Verbindingsfout"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Could not render the e-reader preview."
 msgstr "Kon de opgegeven map niet vinden"
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr "Opslaan van omslag mislukt."
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 "Bibliotheek Vernieuwen 🔄 Controleren op gemiste boeken, even geduld..."
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr "Tijdstempel"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Book ID"
 msgstr "Boek ID"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Boektitel"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "Auteur"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr "Trigger Type"
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "Bestandsformaten"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Filename"
 msgstr "Bestandsnaam"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr "Handmatig?"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr "Aantal Fixes"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr "Origineel geback-upt?"
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr "Toegepaste Fixes"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr "Origineel Formaat"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "End Format"
 msgstr "afsluit formaat"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 msgid "Unknown User"
 msgstr "Onbekende gebruiker"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr "✅ Alle controle services draaien zoals bedoeld! 👍"
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr "🔴 De Ingest Service draait maar de Metadata Change Detector niet"
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr "🔴 De Metadata Change Detector draait maar de Ingest Service niet"
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr "⛔ Noch de Ingest Service noch de Metadata Change Detector draait"
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr "Er is een fout opgetreden"
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 msgid "Invalid book selection."
 msgstr "Ongeldige boek selectie"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr "Boek niet gevonden"
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 msgid "Selected book has no EPUB format."
 msgstr "Geselecteerde boek heeft geen EPUB formaat"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 msgid "EPUB file not found on disk."
 msgstr "EPUB bestand is niet gevonden op de schijf"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 msgid "EPUB Fixer started for selected book."
 msgstr "EPUB reparatie is gestart voor geselecteerde boek."
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr "Starten EPUB reparatie is mislukt voor geselecteerde boek."
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr "Je moet een beheerder zijn om deze pagina te bekijken."
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr "Zowel gebruikersnaam als afbeeldingsgegevens zijn vereist."
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid Base64 image data."
 msgstr "Ongeldige Base64 afbeeldinggegevens"
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 msgid "Invalid image data format."
 msgstr "Ongeldig afbeeldingsformaat"
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr "Fout bij validatie van afbeeldinggegevens"
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr "Profielafbeelding succesvol geupdatet."
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Geen"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 msgid "Duplicate Books"
 msgstr "Duplicaat boeken"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 msgid "Duplicate group dismissed"
 msgstr "Groep duplicaten afgewezen"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 msgid "Duplicate group restored"
 msgstr "Groep duplicaten hersteld"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr "Groep duplicaten niet afgewezen"
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 msgid "Duplicate scan queued"
 msgstr "Duplicaten scan in wachtrij"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr "Duplicaten scan voltooid"
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 #, fuzzy
 msgid "Invalid resolution strategy"
 msgstr "Ongeldige rol"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr "Ontbrekend of ongeldig boek-ID voor formaat upload"
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Uploaden voltooid, bezig met verwerken..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 msgid "Failed to queue upload for processing"
 msgstr "Uploaden naar wachtrij voor verwerking mislukt"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Bron- of doelformaat ontbreekt voor conversie"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr ""
 "Het boek is in de wachtrij geplaatst voor conversie naar %(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Er is een fout opgetreden bij het converteren van dit boek: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "Bestandstype niet toegestaan om te uploaden naar deze server"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr "De bestandsextensie '%(ext)s' is niet toegestaan op deze server"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "Het te uploaden bestand moet voorzien zijn van een extensie"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 "Oeps! Geselecteerd boek is niet beschikbaar. Bestand bestaat niet of is niet "
 "toegankelijk"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "Gebruiker mist rechten om de omslag te uploaden"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 "Identificatoren zijn niet hoofdlettergevoelig, overschrijf huidige "
 "identificatoren"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "%(langname)s is geen geldige taal"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "De metagegevens zijn bijgewerkt"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "Fout tijdens bijwerken van boek: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Onbekend"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1454,103 +1427,103 @@ msgstr ""
 "Geüpload boek staat mogelijk al in de bibliotheek, controleer alvorens door "
 "te gaan: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "Bestand %(filename)s kon niet opgeslagen worden in de tijdelijke map"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Omslag %(file)s niet verplaatst: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Het boekformaat is verwijderd"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Het boek is verwijderd"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "U mist rechten om boeken te verwijderen"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "metagegevens bewerken"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "Seriesindex: %(seriesindex)s is geen geldig nummer, sla het over"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr "Gebruiker mist rechten om extra bestandsformaten te uploaden"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Kan de locatie '%(path)s' niet aanmaken (niet gemachtigd)."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Kan %(file)s niet opslaan."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Bestandsformaat %(ext)s toegevoegd aan %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Boek niet gevonden"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "EPUB bestand is niet gevonden op de schijf"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
 msgstr ""
 "Het instellen van Google Drive is niet afgerond, heractiveer Google Drive"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1558,89 +1531,88 @@ msgstr ""
 "Het callback-domein is niet geverifieerd. Volg de stappen in de Google-"
 "ontwikkelaarsconsole om het domein te verifiëren"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr "Deze e-mail is verzonden via Calibre-Web NextGen."
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "%(format)s formaat niet gevonden voor boek met id: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(format)s niet aangetroffen op Google Drive: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s niet gevonden %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "Versturen naar eReader"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "%(format)s formaat niet gevonden voor boek met id: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "%(format)s formaat niet gevonden voor boek met id: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 #, fuzzy
 msgid "Test Email"
 msgstr "Test-e-mail"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Registratie-e-mailadres van gebruiker: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "%(orig)s converteren naar %(format)s en versturen naar eReader"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, python-format
 msgid "Send %(format)s to eReader"
 msgstr "%(format)s versturen naar eReader"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s verzonden naar eReader"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr ""
 "Het opgevraagde bestand kan niet worden gelezen. Ben je hiertoe gemachtigd?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "Gelezen/ongelezen status kan niet aangepast worden: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
@@ -1648,12 +1620,12 @@ msgstr ""
 "Het verwijderen van de boekenmap voor boek %(id)s is mislukt, het pad heeft "
 "submappen: %(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "Verwijderen van boek %(id)s mislukt: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, fuzzy, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1661,68 +1633,68 @@ msgid ""
 msgstr ""
 "Verwijder boek %(id)s alleen uit database, boek pad is ongeldig: %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, fuzzy, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr "Kan de titel '%(src)s' niet wijzigen in '%(dest)s': %(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Bestand '%(file)s' niet aangetroffen op Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr "Kan de titel '%(src)s' niet wijzigen in '%(dest)s': %(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Boeken locatie '%(path)s' niet aangetroffen op Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr "Bestaand account gevondne met dit e-mailadres"
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Deze gebruikersnaam is al in gebruik"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 #, fuzzy
 msgid "Invalid Email address format"
 msgstr "Ongeldig E-Mail adres"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr "Het wachtwoord voldoet niet aan de validatieregels"
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 "Pythonmodule 'advocate' is niet geïnstalleerd maar is nodig omslag uploads"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Fout bij downloaden omslag"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr "Omslag-bestand is geen afbeelding of kon niet opgeslagen worden"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Onjuist omslagformaat"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
@@ -1730,122 +1702,122 @@ msgstr ""
 "Toegang tot localhost of het lokale netwerk niet toegestaant voor omslag "
 "uploaden"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Locatie aanmaken voor omslag mislukt"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "Alleen jpg/jpeg/png/webp/bmp bestanden worden ondersteund als omslag"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "Ongeldig omslagbestand"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Alleen jpg/jpeg bestanden zijn toegestaan als omslag"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr "Omslag"
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "UnRar executable niet gevonden"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing UnRar"
 msgstr "Fout bij het uitvoeren van UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr "Kon de opgegeven map niet vinden"
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr "Geef een map op, geen bestand"
 
-#: cps/helper.py:2125
+#: cps/helper.py
 #, fuzzy
 msgid "Calibre binaries not viable"
 msgstr "Kan niet schrijven naar database"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr "Ontbrekende calibre programmabestanden: %(missing)s"
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Ontbrekende uitvoerende rechten: %(missing)s"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr "Fout bij het uitvoeren van Calibre"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr ""
 "Voeg alle boeken toe aan de wachtrij voor het maken van een metagegevens "
 "backup"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Kobo Instellen"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr "Onlangs toegevoegd"
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr "Hoog beoordeeld"
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr "Nu aan het lezen"
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr "Nog te lezen"
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr "Recente publicaties"
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Aanmelden bij %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
@@ -1853,7 +1825,7 @@ msgid ""
 msgstr ""
 "Inloggen mislukt: Kon geen verbinding maken met het gebruikersinfo eindpunt."
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
@@ -1861,7 +1833,7 @@ msgid ""
 msgstr ""
 "Inloggen mislukt: De OAuth provider gaf een ongeldig gebruikersprofiel terug."
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1869,35 +1841,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "je bent ingelogd als: '%(nickname)s'"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Koppeling gemaakt met %(oauth)s"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1905,784 +1877,775 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 msgid "OAuth system error. Please contact administrator."
 msgstr "Oauth systeem-fout, neem contact op met de beheerder!"
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "Koppeling met %(oauth)s verbroken"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Ontkoppelen van %(oauth)s mislukt"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "Niet gelinkt aan %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Inloggen bij GitHub mislukt."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Opvragen gebruikersinfo bij GitHub mislukt."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Inloggen bij Google mislukt."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Opvragen gebruikersinfo bij Google mislukt."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "Failed to log in with Generic OAuth."
 msgstr "Inloggen mislukt."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "GitHub OAuth fout, probeer het later nog eens."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "Github OAuth foutmelding: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Google OAuth fout, probeer het later nog eens."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Google OAuth foutmelding: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr "OAuth foutmelding: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "Alfabetische Boeken"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "Boeken Alfabetisch gesorteerd"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Populaire boeken"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "Populaire publicaties uit deze catalogus, gebaseerd op Downloads."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Best beoordeelde boeken"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Populaire publicaties uit deze catalogus, gebaseerd op Beoordeling."
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "Gedownloade boeken"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Nieuwe boeken"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Willekeurige boeken"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Willekeurige boeken tonen"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Gelezen boeken"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Huidige versie"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Ongelezen boeken"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Auteurs"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Boeken gesorteerd op auteur"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Uitgevers"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Boeken gesorteerd op uitgever"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Categorieën"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Boeken gesorteerd op categorie"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Boekenreeksen"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Boeken gesorteerd op reeks"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Talen"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Boeken gesorteerd op taal"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Beoordelingen"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Boeken gesorteerd op beoordeling"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Bestandsformaten"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Boeken gesorteerd op bestandsformaat"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Boekenplanken"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "Boeken georganiseerd op boekenplanken"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Synchroniseer geselecteerde boekenplanken met Kobo"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Boeken georganiseerd op boekenplanken"
 
-#: cps/opds.py:317
+#: cps/opds.py
 msgid "description"
 msgstr "omschrijving"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} sterren"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Zoeken"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Inloggen"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Toegangssleutel niet gevonden"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Toegangssleutel is verlopen"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Gelukt! Ga terug naar je apparaat"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Boeken"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Recent toegevoegde boeken tonen"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Populaire boeken tonen"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Gedownloade boeken"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Gedownloade boeken tonen"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Best beoordeelde boeken tonen"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 msgid "Show Read and Unread"
 msgstr "Gelezen/Ongelezen boeken tonen"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Ongelezen boeken tonen"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Willekeurige boeken"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Category Section"
 msgstr "Categoriekeuze tonen"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Series Section"
 msgstr "Boekenreeksenkeuze tonen"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Author Section"
 msgstr "Auteurkeuze tonen"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Publisher Section"
 msgstr "Uitgeverskeuze tonen"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Language Section"
 msgstr "Taalkeuze tonen"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Ratings Section"
 msgstr "Beoordelingen tonen"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show File Formats Section"
 msgstr "Bestandsformaten tonen"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Gearchiveerde boeken"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Archived Books"
 msgstr "Gearchiveerde boeken tonen"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr "Favorieten"
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Boekenlijst"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Boekenlijst tonen"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr "Duplicaten"
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Best beoordeelde boeken tonen"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Gepubliceerd na "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Gepubliceerd vóór "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Beoordeling <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Beoordeling >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, fuzzy, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Lees Status = %(status)s"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 "Fout tijdens het zoeken van aangepaste kolommen, start Calibre-Web opnieuw op"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Geavanceerd zoeken"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Ongeldige boekenplank opgegeven"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "Sorry, je mag geen boeken toevoegen aan de boekenplank"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "Dit boek maakt al deel uit van boekenplank: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 "%(book_id)s is een ongeldig Boek ID. Kon niet worden toegevoegd aan de "
 "boekenplank"
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "Het boek is toegevoegd aan boekenplank: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr ""
 "U heeft niet voldoende rechten om een boek aan deze boekenplank toe te voegen"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Deze boeken maken al deel uit van boekenplank: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "De boeken zijn toegevoegd aan boekenplank: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Kan boeken niet toevoegen aan boekenplank: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "Ongeldige boekenplank opgegeven"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Kan boeken niet toevoegen aan boekenplank: %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Deze boeken maken al deel uit van boekenplank: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "De boeken zijn toegevoegd aan boekenplank: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "Het boek is verwijderd van boekenplank: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr ""
 "U heeft niet voldoende rechten om een boek van deze boekenplank te "
 "verwijderen"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Boekenplank maken"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Je bent niet gemachtigd deze boekenplank aan te passen"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Pas een boekenplank aan"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "Fout bij verwijderen boekenplank"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "Boekenplank is succesvol verwijderd"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Volgorde van boekenplank veranderen: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "Je mist rechten om een openbare boekenplank te maken "
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Boekenplank '%(title)s' aangemaakt"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Boekenplank '%(title)s' is aangepast"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Er is een fout opgetreden"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "Een openbare boekenplank met de naam '%(title)s' bestaat al."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "Een persoonlijke boekenplank met de naam '%(title)s' bestaat al."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Boekenplank: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Kan boekenplank niet openen: de boekenplank bestaat niet of is ontoegankelijk"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Boekenplanken uitsluiten"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr "Nu lezen"
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr "Details openen voor {title}"
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr "{title} lezen"
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr "Standaard (gebruikersnaam / wachtwoord)"
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr "LDAP"
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr "OAuth / OpenID Connect"
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Anoniem"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Niet geverifieerd"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr "Eenvoudig (serviceaccount)"
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr "Reeksvolgorde"
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr "Reeksvolgorde (omgekeerd)"
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr "Label toevoegen"
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr "Nieuw label"
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr "Label verwijderen"
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr "Label {name} verwijderen"
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr "Label {name} hernoemen"
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr "Tagnaam"
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr "Tagnaam mag niet leeg zijn"
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr "Tagnaam opslaan"
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr "Selecteer formaat"
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr "Kan label niet hernoemen"
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr "Label hernoemd naar {name}"
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr "Je moet ingelogd zijn"
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr "Je bent niet gemachtigd metagegevens aan te passen"
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr "Er bestaat al een label met die naam"
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr "Tagnaam moet tekst zijn"
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr "Tagnaam mag geen komma’s bevatten"
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr "Voer een geldige tagnaam in"
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr "Kan deze pagina niet laden"
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr "Pagina niet gevonden"
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr "Beoordeling wissen"
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr "Niet beoordeeld"
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Ja"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Nee"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr "E-mail berichttekst"
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr "Beoordeeld {rating} van de 5"
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr "Meer van {name}"
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
@@ -2691,143 +2654,141 @@ msgstr ""
 "Voeg {n} boeken samen met het eerste geselecteerde boek? De overige worden "
 "verwijderd nadat hun formaten zijn overgenomen."
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr "Toepassen op {n} boeken"
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr "Voorwaarde voor overeenkomst"
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr "Regelveld"
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr "Regeloperator"
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr "Kan regels voor slimme boekenplank niet laden."
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr "Heeft omslag"
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr "Nummer in reeks"
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Lees Status"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr "Heeft Hardcover-ID"
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr "In de afgelopen N dagen"
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr "Niet in de afgelopen N dagen"
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr "is voor / kleiner dan"
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr "is op of voor / hoogstens"
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr "is na / groter dan"
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr "is op of na / minstens"
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr "ligt tussen"
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr "ligt niet tussen"
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr "begint niet met"
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr "eindigt niet op"
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr "is leeg"
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr "is niet leeg"
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr "Uiterlijk"
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Thema"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr "Systeem"
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Licht"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Donker"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "Sepia"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr "Hoog contrast"
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr "Middernacht (AMOLED)"
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr "Volg de lichte of donkere instelling van je apparaat"
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr "Thema opgeslagen."
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr "Kan thema niet opslaan."
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr "Standaardthema voor nieuwe accounts"
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
@@ -2835,169 +2796,159 @@ msgstr ""
 "Geldt voor accounts die vanaf nu worden aangemaakt. Iedereen kiest zelf "
 "onder Account → Thema."
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr "Formaat toevoegen"
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr "Regel toevoegen"
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Toevoegen aan boekenplank"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr "Eigen toevoegen"
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr "App-wachtwoord label"
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr "App-wachtwoorden"
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Auteur"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr "Auteurs (scheid met &)"
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr "Terug naar aanmelden"
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr "Blauw"
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr "Boekinhoud"
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Verkennen"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr "Wachtwoord wijzigen"
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Sluiten"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr "Menu sluiten"
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr "Inhoudsopgave"
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr "Conversie mislukt."
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr "Converteren naar"
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr "Converteren naar formaat"
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr "Kopiëren"
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr "Kan wachtwoord niet wijzigen."
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr "Kan niet aanmaken."
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr "Kan omslag niet ophalen."
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr "Kan metagegevens niet laden."
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr "Kan het boekbestand niet laden ({status})"
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr "Kan je account niet laden."
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr "Kan niet opslaan."
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr "Omslagafbeelding URL"
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr "Bijwerken van omslag mislukt."
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr "Omslag bijgewerkt."
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr "Slimme boekenplank aanmaken"
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr "Maak je account aan"
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr "Donker thema"
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr "Boek verwijderen"
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
@@ -3006,487 +2957,480 @@ msgstr ""
 "Verwijder \"{title}\"? Dit verwijdert het boek en alle bijbehorende "
 "bestanden permanent uit je bibliotheek. Dit kan niet ongedaan worden gemaakt."
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr "Bezig met verwijderen…"
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr "Kan dit boek niet verwijderen."
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 "Het {fmt}-bestand verwijderen? Het boek blijft behouden; alleen dit formaat "
 "wordt verwijderd."
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr "{fmt} verwijderen"
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr "{n} boek(en) verwijderen? Dit kan niet ongedaan worden gemaakt."
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr "Beschrijving bevat"
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr "{title} deselecteren"
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr "Metagegevens bewerken"
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr "{title} bewerken"
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr "Je standaard bibliotheekweergave wordt getoond."
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr "Alle boeken tonen"
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr "Standaardweergave bewerken"
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr "Boeken laden mislukt."
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr "Openen van het boek mislukt."
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr "Genereren"
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr "Groen"
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr "Hulp"
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr "Markeringskleur"
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr "Importeren vanuit Kobo"
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr "Interfacetaal"
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr "Ongeldige gebruikersnaam of wachtwoord."
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr "UI standaardlettertype"
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr "UI weergavelettertype"
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr "Standaard (Optima / Sans-Serif)"
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr "Standaard (Bookish Serif)"
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr "Systeem Sans-Serif"
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr "Bookish Serif"
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr "Monospace"
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr "Label (bijv. KOReader op telefoon)"
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr "Talen (door komma's gescheiden)"
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr "Licht thema"
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr "Inloggen mislukt."
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr "Markeren als gelezen"
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr "Markeren als ongelezen"
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Samenvoegen"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr "Metagegevens toegepast op {n} boek(en)."
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 "Nieuw wachtwoord voor \"{label}\" — kopieer het nu, het wordt niet meer "
 "getoond:"
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr "De nieuwe wachtwoorden komen niet overeen."
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr "Geen boeken hier."
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr "Geen resultaten voor \"{q}\"."
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr "Geen suggesties"
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr "Geen {filter} boeken hier."
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr "Wachtwoord gewijzigd."
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr "URL plakken"
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr "Privéboekenplank"
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr "Profiel"
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr "Profiel opgeslagen."
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr "Openbare boekenplank"
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Uitgever"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr "Uitgevers (komma-gescheiden)"
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Gelezen"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr "Leesvoortgang"
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr "Rood"
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr "Registratie mislukt."
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr "{name} verwijderen"
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr "Aanvraag mislukt."
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr "Resetten"
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr "Je wachtwoord herstellen"
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr "{label} intrekken"
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr "Wijzigingen opslaan"
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr "Opslaan mislukt."
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr "Profiel opslaan"
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr "Opgeslagen."
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr "Opslaan…"
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr "Zoeken mislukt."
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr "Metagegevens zoeken"
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr "Metagegevensproviders"
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr "Providers laden…"
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr "Kan providers niet laden."
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr "Kan provider niet bijwerken."
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr "{provider}: {state}"
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr "Aan"
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr "Uit"
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr "Zoekresultaten"
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr "Bibliotheek doorzoeken"
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr "{title} selecteren"
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr "Sepia-thema"
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr "Reekspositie {n}"
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr "{series} #{n}"
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr "Inloggen"
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr "Inloggen mislukt. Probeer het opnieuw."
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr "Doorgaan naar inhoud"
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr "Sommige velden konden niet worden opgeslagen."
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr "Inhoudsopgave"
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr "Labels (door komma's gescheiden)"
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Titel"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr "Ongelezen"
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr "Wachtwoord bijwerken"
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Uploaden"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr "Kies boeken om te uploaden"
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr "Uploaden mislukt."
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr "Afbeelding uploaden"
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr "Uploaden…"
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr "Geel"
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr "bijv. MOBI"
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr "{format} lezer"
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr "{name} API-sleutel"
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr "{n} boek(en) toegevoegd aan de boekenplank."
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr "{n} boek(en) verwijderd."
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr "{n} gemarkeerd als gelezen."
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr "{n} gemarkeerd als ongelezen."
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr "{n} geselecteerd"
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr "{pct}% gelezen"
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr "Wat is er nieuw"
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr "Hulp — nieuwe updates beschikbaar"
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 "De nieuwste functies en oplossingen in Calibre-Web NextGen — nieuwste eerst."
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr "{n} update"
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr "{n} updates"
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr "Nog geen release-opmerkingen — kom terug na de volgende update."
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
@@ -3494,250 +3438,247 @@ msgstr ""
 "De interface is vertaald naar jouw taal; deze update-notities zijn "
 "geschreven in het Engels."
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr "Lezen"
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr "Rasterweergave"
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr "Bibliotheek"
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr "Lijstweergave"
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr "Synchronisatie"
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Account"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Beheer"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr "Onder de motorkap"
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr "Je bibliotheek openen"
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr "Labels verkennen"
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr "Tabelweergave openen"
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr "Duplicaten bekijken"
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr "Je boekenplanken openen"
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr "Synchronisatie en app-wachtwoorden beheren"
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr "Controleer je e-readeradres"
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr "Maak een app-wachtwoord aan"
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr "Boekenreeksen verkennen"
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr "Auteurs verkennen"
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr "Talen verkennen"
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr "Tabelweergave openen"
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr "Beheer openen"
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr "Accountinstellingen openen"
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr "Willekeurige boeken verkennen"
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr "Verken je bibliotheek"
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr "Ga naar Uploaden"
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr "Zoeken openen"
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr "Edities"
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr "Terug naar de nieuwe interface"
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr "Terug naar resultaten"
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr "Geen edities gevonden voor dit boek."
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr "Alle details tonen"
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr "Resultaatdetails"
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Gepubliceerd"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr "Formaat"
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Bron"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr "Aanpassen"
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr "Zijbalk aanpassen"
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr "Navigatie aanpassen"
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr "Klaar"
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr "Terugzetten naar standaard"
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr "Altijd tonen"
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr "Zijbalk bewerken. Herschik of verberg secties en tik daarna op Klaar."
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr "Bewerken geannuleerd."
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 "Sleep om te herschikken. Tik op ✕ om een sectie te verbergen. "
 "Pijltjestoetsen verplaatsen de gefocuste hendel."
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr "Zijbalk opgeslagen."
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr "Zijbalk teruggezet naar standaard."
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr "{label} verplaatst naar positie {pos} van {total}"
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 "{label} herschikken (positie {pos} van {total}). Gebruik de pijltoetsen om "
 "te verplaatsen."
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr "{label} verwijderen"
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr "{label} herstellen"
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr "{label} verborgen"
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr "{label} hersteld"
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr "Kan zijpaneel niet opslaan. Probeer het opnieuw."
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr "Bibliotheek vernieuwen"
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr "<"
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr "="
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ">"
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
@@ -3745,46 +3686,45 @@ msgstr ""
 "Een eenmalige volledige duplicaatscan is nodig. Start deze vanuit de CWA-"
 "instellingen en kom daarna hier terug."
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr "Datum toegevoegd"
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 "„{name}” verwijderen? Het wordt van {count} boek verwijderd; het boek blijft "
 "behouden."
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 "„{name}” verwijderen? Het wordt van {count} boeken verwijderd; de boeken "
 "blijven behouden."
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr "Ko-fi-steunbericht sluiten"
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr "Hulpmelding sluiten"
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr "Ko-fi openen →"
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr "Publicatiedatum"
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr "Steun ons op Ko-fi!"
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
@@ -3792,89 +3732,89 @@ msgstr ""
 "Deze openen de volledige configuratiepagina’s. Wijzigingen daar gelden voor "
 "de hele server."
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr "„{name}” bestaat al op {count} boek. Dit label daarmee samenvoegen?"
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr "„{name}” bestaat al op {count} boeken. Dit label daarmee samenvoegen?"
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr "begint met"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr "bevat"
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr "bevat niet"
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr "eindigt op"
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr "in de afgelopen N dagen"
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr "is niet"
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr "is"
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr "niet in de afgelopen N dagen"
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr "op of na"
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr "op of voor"
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr "≤"
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr "≥"
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr "(omslag vervangen)"
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr "2:3 (uitgeversomslag — geen opvulling voor standaard omslagen)"
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr "3:4 (algemeen)"
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 "Er is al een duplicatenscan bezig. Deze lijst wordt bijgewerkt zodra deze "
 "klaar is."
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr "Enkele willekeurige keuzes uit je bibliotheek"
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
@@ -3882,173 +3822,169 @@ msgstr ""
 "Er is een eenmalige volledige duplicatenscan nodig. Gebruik hierboven "
 "\"Zoeken naar duplicaten\" om deze uit te voeren."
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr "API-sleutels"
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "Informatie"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr "Accountinstellingen"
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr "Account: {name}"
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr "Identificatiecode toevoegen"
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr "Toevoegen aan favorieten"
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr "Beheerdersgroep"
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr "Geavanceerd"
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr "Geavanceerd zoeken"
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr "Alle boekenplanken"
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr "Inloggen op afstand (magic link) toestaan"
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr "Toegestane groepen (door komma's gescheiden)"
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr "Willekeurig"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr "Elk formaat"
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr "Elke taal"
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr "Elke reeks"
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr "Elk label"
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr "Geselecteerde toepassen"
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 "Toepassen op alle geselecteerde (alleen ingevulde velden veranderen; "
 "bestaande waarden worden vervangen):"
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr "Toepassen…"
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr "Archiveren"
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Gearchiveerd"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr "Vraag het in Discord"
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr "Authenticatie"
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr "Authenticatie & beveiliging"
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr "Auteur A–Z"
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr "Auteur Z–A"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr "Geautoriseerd — je wordt aangemeld…"
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr "Autorisatie-URL"
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr "Gebruikers automatisch aanmaken"
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr "Gebruikers automatisch aanmaken bij eerste aanmelding"
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr "Terug naar bibliotheek"
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr "Terug naar de klassieke weergave"
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr "Basis DN"
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr "Basisconfiguratie"
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr "Boek standaard"
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr "Boekdichtheid"
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr "Boek {number}"
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr "Aantal boeken per pagina"
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
@@ -4057,489 +3993,475 @@ msgstr ""
 "bij de volgende synchronisatie van het apparaat verwijderd. Ze blijven wel "
 "in je bibliotheek hier."
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr "Ingebouwde providers (laat leeg om uit te schakelen):"
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr "Bulkacties"
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr "CA-certificaatpad"
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr "CWA-instellingen (importeren/converteren)"
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr "Kan boeken uploaden"
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr "Hernoemen annuleren"
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr "Titelbewerking annuleren"
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr "{task} annuleren"
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr "Bestandspad certificaat"
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr "Certificaatpad"
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr "Omslag wijzigen"
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr "Controleren…"
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr "Kies een omslag"
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr "Kies een omslagafbeelding om te uploaden"
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr "Kies een afbeelding…"
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr "Kies velden"
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr "Kies je thema"
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr "Standaard wissen"
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr "Selectie wissen"
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr "Client ID"
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr "Client geheim"
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr "Client geheim (laat leeg om te behouden)"
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr "Lezer sluiten"
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr "Kolommen"
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr "Comfortabel"
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr "Compact"
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr "Geconfigureerd"
 
 # #973 — consolidating tags from the Tag view (merge on rename collision, delete).
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr "Verwijderen van label {name} bevestigen"
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr "Nieuw wachtwoord bevestigen"
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "Overzetten"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr "Converteren voor verzenden"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr "Converteren van"
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr "Gekopieerd naar klembord"
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr "Link kopiëren"
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr "Kan boekenplank niet aanmaken."
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr "Kan de boekenplank niet aanmaken."
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr "Kan boekenplank niet verwijderen."
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr "Kan label niet verwijderen"
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr "Kan kandidaten niet laden."
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr "Kan duplicaten niet laden."
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr "Kan markeringen niet laden."
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr "Kan statistieken niet laden."
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr "Kan taken niet laden."
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr "Kan dit tekstbestand niet laden."
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr "Kan gebruikers niet laden."
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr "Kan dit comic-archief niet lezen."
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr "Kan metagegevens niet opnieuw laden"
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr "Kan boekenplank niet hernoemen."
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr "Kan wachtwoord niet herstellen."
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr "Kan volgorde niet opslaan."
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr "Kan lezersinstellingen niet opslaan."
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr "Kan het standaard bibliotheekfilter niet opslaan."
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr "Kan de boekenplank niet opslaan."
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr "Kan titel niet opslaan."
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr "Kan je leespositie niet opslaan."
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr "Kan de duplicatenscan niet starten."
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr "Kan boekenplank niet bijwerken."
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr "Kan je accountinstelling niet bijwerken."
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr "Kan geen magic link starten. Probeer het opnieuw."
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr "Omslag vergrendeld"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr "Omslag niet bereikbaar"
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr "Omslag bijgewerkt vanuit het geselecteerde resultaat."
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr "Aanmaken"
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr "Account aanmaken"
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr "Een account aanmaken"
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr "Aanmaken mislukt."
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr "Boekenplank aanmaken en boek toevoegen"
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr "Gebruiker aanmaken"
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr "{name} aangemaakt."
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr "Aanmaken…"
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr "Bijsnijden om te vullen — geen rand, snijdt de randen bij"
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr "Huidig"
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr "Huidige omslag"
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr "Huidig wachtwoord"
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr "Momenteel aan het lezen"
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr "Aangepaste randkleur"
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr "Aangepaste kolommen"
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr "Database- & bibliotheekpad"
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr "Datum toegevoegd"
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr "Standaard (systeem sans-serif)"
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr "Standaard boekentaal"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr "Standaard interfacetaal"
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr "Standaard bibliotheekfilter gewist."
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr "Standaard bibliotheekfilter opgeslagen."
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr "Standaardrollen voor nieuwe OAuth-gebruikers:"
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr "Standaardwaarden staan onder Beheer → Configuratie → Kobo sync."
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr "Boeken verwijderen"
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr "Verwijderen mislukt."
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 "Boekenplank \"{name}\" verwijderen? Dit kan niet ongedaan worden gemaakt."
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr "Label {name} verwijderen"
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr "Deze slimme boekenplank verwijderen? Je boeken worden niet beïnvloed."
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 "Gebruiker \"{name}\" verwijderen? Ook hun boekenplanken en leesgegevens "
 "worden verwijderd."
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr "{name} verwijderen"
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr "Label {name} verwijderd"
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr "{name} verwijderd."
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr "Compact"
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Omschrijving"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr "Standaard wachtwoordlogin uitschakelen"
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr "Verkennen-keuzes bijgewerkt."
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr "Verkennen — Willekeurige keuzes"
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr "Afwijzen"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr "Deze groep afwijzen"
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr "Documentatie"
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr "Klaar met herschikken"
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Downloaden"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr "Sleep bestanden hierheen, of klik om te kiezen"
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr "Duplicaat"
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr "Dubbele boeken"
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr "Instellingen voor duplicatendetectie"
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
@@ -4547,290 +4469,286 @@ msgstr ""
 "Duplicatenscan gestart. De scan wordt op de achtergrond uitgevoerd — deze "
 "lijst wordt bijgewerkt zodra hij klaar is."
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr "E-reader voorbeeld"
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr "Elk type (isbn, amazon, google, doi…) mag één keer voorkomen."
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr "Randvervaging — zachte bokeh-rand"
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr "Randspiegeling — breid het artwork uit (aanbevolen)"
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Bewerken"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr "Openbare boekenplanken bewerken"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr "Slimme boekenplank bewerken"
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr "Titel bewerken voor {title}"
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "E-mailadres"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr "E-mail (SMTP)-server"
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr "E-mail (optioneel)"
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr "E-mail claim"
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr "Stuur me een herstellink"
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr "E-mailinstellingen opgeslagen."
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Zet Kobo sync aan"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Encryptie"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr "Verloopt over"
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr "Alleen geselecteerde boekenplanken via OPDS tonen"
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr "Boekenplanken laden mislukt."
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr "Laden mislukt."
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr "Favoriet"
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr "Aan favorieten toegevoegd"
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr "Ophalen"
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr "Metagegevens van het web ophalen"
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr "Bestanden"
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 "Bestanden staan in de wachtrij voor het importeerproces van de bibliotheek "
 "en verschijnen zodra ze geïmporteerd zijn."
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr "Opvulstijl"
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr "{items} filteren"
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr "{items} filteren…"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr "Lettertypefamilie"
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr "Lettergrootte"
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr "Wachtwoord vergeten?"
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 "Formaat in de wachtrij geplaatst — het verschijnt zodra het verwerkt is."
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr "Formaten"
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr "Formaten — uitsluiten"
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr "Formaten — opnemen"
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr "Van-adres"
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr "Volledige gebruikerstabel & beperkingen"
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr "Genereer een nieuwe link"
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr "Geef je slimme boekenplank een naam."
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr "Ga naar je bibliotheek"
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr "Kleurverloop — op palet afgestemde menging van boven- en onderkant"
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr "Groep claim"
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr "Groepleden veld"
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr "Groepsnaam"
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr "Groep object filter"
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr "HTML is toegestaan en wordt bij weergave opgeschoond."
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr "Header naam"
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr "Hulp & ondersteuning"
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr "Hulpmenu"
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr "Verborgen"
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "Verberg"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr "Verkennen-sectie verbergen"
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr "Velden verbergen"
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr "Wachtwoord verbergen"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr "Markeren"
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr "Markeringen"
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr "Populair"
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr "Populair — Meest gedownload"
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr "Pictogram"
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr "Identificatietype"
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr "Identificatiewaarde"
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Identificatoren"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr "Afbeelding van {source}"
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr "Geïmporteerd als"
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr "In je boek"
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
@@ -4838,341 +4756,340 @@ msgstr ""
 "Lezen in de browser ondersteunt momenteel EPUB. Gebruik download of de "
 "klassieke lezer voor andere formaten."
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr "Issuer / basis-URL"
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 "Het is misschien verplaatst, of het staat mogelijk nog in de klassieke "
 "interface."
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr "KOReader-voortgang"
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr "Pad naar sleutelbestand"
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr "Sleutelpad"
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr "Kobo Libra Color / Libra 2 (1264×1680)"
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr "Kobo sync aan"
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Taal"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr "Talen — opnemen"
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr "Laatst gewijzigd"
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr "Laatst gesynchroniseerd"
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr "Bibliotheekinstellingen"
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr "Regelhoogte"
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr "Meer laden"
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr "Bezig met laden"
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr "Nieuwe Verkennen-keuzes worden geladen."
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr "Bezig met laden…"
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr "Omslag vergrendelen"
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr "Tekst van inlogknop"
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr "Inlogmethode"
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr "Inloggen met"
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr "Logboeken"
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr "Ziet er goed uit"
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr "Lage resolutie"
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr "Magische link"
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr "Magische link QR-code"
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr "Privé maken"
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr "Openbaar maken"
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr "Dit mijn standaard bibliotheekweergave maken"
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr "Beheerdersrol beheren via OAuth-groep"
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr "Boekenplanken beheren"
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr "Markeren als gelezen"
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr "Markeren als ongelezen"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr "Overeenkomst"
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr "Max"
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr "Maximaal aantal getoonde auteurs"
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr "Maximale beoordeling"
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr "Lid gebruiker filter"
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr "Samenvoegen met {name}"
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr "Samengevoegd met {name}"
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr "Metadata URL (OIDC automatische detectie)"
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr "Min"
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr "Minimale beoordeling"
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr "Meer omslagopties (zoekproviders, e-reader voorbeeld)"
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr "Meer serverconfiguratie"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr "Naar beneden"
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr "Naar boven"
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr "Mijn account"
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr "Naam"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr "Een probleem melden? Probeer de nieuwe"
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr "Nieuw"
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr "Nieuw wachtwoord"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr "Nieuwe boekenplanknaam"
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr "Nieuwe boekenplanknaam…"
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr "Nieuwe boekenplank…"
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr "Nieuwe slimme boekenplank"
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr "Nieuwe gebruiker"
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr "Nieuwste"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr "Nieuwst gepubliceerd"
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr "Volgende pagina"
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 "Er zijn momenteel geen boeken die overeenkomen met deze slimme boekenplank."
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr "Er zijn geen boeken die aan deze criteria voldoen."
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 "Nog geen kandidaten gevonden. Probeer een andere zoekopdracht of vernieuw."
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr "Geen inhoud gevonden."
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr "Geen duplicaat groepen gevonden."
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr "Geen uitgesloten labels"
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 "Nog geen markeringen. Markeer tijdens het lezen, of importeer van een Kobo-"
 "apparaat."
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr "Geen overeenkomende {items} voor \"{query}\"."
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr "Geen pagina's gevonden in deze strip."
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr "Nog geen boekenplanken — maak er hieronder een aan."
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 "Nog geen boekenplanken. Maak er hierboven een aan om boeken te verzamelen."
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr "Geen bronnen die een sleutel nodig hebben."
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr "Geen actieve taken."
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr "Nog geen {items}."
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr "Niet geconfigureerd"
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr "Niet ingesteld"
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr "Oudste"
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr "Oudst gepubliceerd"
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
@@ -5180,56 +5097,56 @@ msgstr ""
 "Scan op een ander apparaat waarop je al bent aangemeld deze code of open de "
 "onderstaande link om dit apparaat te autoriseren."
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr "Account openen"
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr "Klassieke lezer openen"
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr "Navigatie openen"
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr "Lezer openen"
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr "Klassieke interface openen"
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr "Open de onderstaande link op je aangemelde apparaat."
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr "OpenLDAP server"
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr "Opent in klassieke weergave"
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr "PDF-lezer"
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr "Paginamarges"
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr "Paginathema"
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr "Pagina {number}"
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
@@ -5237,17 +5154,16 @@ msgstr ""
 "Hieronder gemarkeerde pagina's openen in de klassieke weergave. Wijzigingen "
 "daar gelden voor de hele server."
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr "Wachtwoord (laat leeg om te behouden)"
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
@@ -5255,159 +5171,154 @@ msgstr ""
 "Kies een omslag uit elke door ons ondersteunde bron, plak een URL, upload "
 "een bestand, of gebruik de omslag die in het boek zelf is ingesloten."
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr "{label} opgepakt. Sleep om te herschikken, laat los om neer te zetten."
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Poort"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr "Je magische link voorbereiden…"
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr "Vorige pagina"
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Voortgang"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr "Openbaar"
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr "Gepubliceerd na"
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr "Gepubliceerd voor"
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr "Willekeurige boeken getoond"
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Beoordeling"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr "Beoordeling (sterren)"
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr "Gelezen/ongelezen status"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr "Gelezen/ongelezen status filter"
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr "Lezerinstellingen opgeslagen."
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr "Leesweergave"
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr "Ontvanger(s)"
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr "Redirect host (volledige URL)"
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr "Verversen"
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr "Registreren…"
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr "Herladen"
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr "Metagegevens vanaf schijf herladen"
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr "Herladen…"
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr "Onthoud mij"
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr "Verwijderen uit favorieten"
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr "Verwijderen van boekenplank"
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr "Markering verwijderen"
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr "Identifier verwijderen"
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr "Regel verwijderen"
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr "Hernoemen"
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr "Herschikken"
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr "Omslag vervangen door deze?"
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr "Omslag vervangen?"
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr "Probleem melden op Discord"
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr "Probleem melden op GitHub"
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr "Groepslidmaatschap vereisen"
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr "Wachtwoord herstellen voor {name}"
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
@@ -5416,372 +5327,370 @@ msgstr ""
 "Wachtwoord herstellen voor {name}? Hun huidige wachtwoord werkt dan niet "
 "meer en er wordt een vervangend wachtwoord gemaild."
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr "Reverse-proxy header aanmelding"
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr "Rijen per keer laden"
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr "Uitvoertijd"
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr "SMTP-server"
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Opslaan"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr "E-mailinstellingen opslaan"
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr "Naam opslaan"
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr "Beveiligingsinstellingen opslaan"
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr "Instellingen opslaan"
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 "Opgeslagen. Herstart de server om de aanmeldingswijzigingen door te voeren."
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr "Scan op duplicaten"
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr "Geplande taken"
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr "Scopes"
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr "Zoeken op titel, auteur…"
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr "Elke bron doorzoeken…"
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr "Zoeken…"
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr "Beveiligingsinstellingen opgeslagen."
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr "Bekijk hoe elke omslag eruitziet opgevuld voor je apparaat"
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "Selecteer"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr "Meerdere selecteren"
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr "Verzenden"
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr "Verzenden mislukt."
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr "Versturen naar e-reader"
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr "Verstuur-naar-eReader e-mail"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr "Versturen…"
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr "Reeksindex"
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr "Reeksweergave"
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr "Reeks — opnemen"
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr "Serveren via HTTPS"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr "Server SSL / HTTPS"
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr "Serveraankondiging (getoond aan alle gebruikers)"
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr "Server host"
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr "Serviceaccount (DN)"
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr "Servicewachtwoord"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr "Servicewachtwoord (leeg laten om te behouden)"
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 "Stel een metadata-URL in om de onderstaande endpoints automatisch in te "
 "vullen, of voer ze handmatig in."
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr "Instellingen opgeslagen."
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr "Boekenplanknaam"
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr "Boekenplank niet gevonden."
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr "Verkennen-sectie tonen"
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr "Knoppen Nu lezen en bewerken tonen"
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr "Tabelweergave tonen"
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr "Alle {count} labels tonen"
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr "Alle {items} tonen"
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr "Boeken in taal tonen"
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr "E-reader-voorvertoningen tonen bij elke kandidaat"
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr "Minder labels tonen"
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr "Verborgen boeken tonen"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr "Wachtwoord tonen"
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr "Selectie schudden"
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr "Inloggen met een magic link"
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr "Uitloggen"
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr "Inloggen…"
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr "Websitetitel"
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr "Slimme boekenplank niet gevonden."
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr "Slimme boekenplanken"
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr "Effen: gemiddelde kleur van de omslag"
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr "Effen: aangepaste kleur"
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr "Effen: meest voorkomende kleur in de omslag"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr "Sommige bronnen hebben een sleutel nodig voor betere omslagen"
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr "Er is iets misgegaan"
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr "Er is iets misgegaan. Probeer het opnieuw."
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr "Sorteervolgorde"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr "Brondetails"
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr "Begonnen met lezen"
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr "Scan starten…"
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr "Statistiekendashboard"
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Status"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr "Uitrekken om te vullen — geen rand, lichte vervorming"
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr "Steunen op Ko-fi →"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr "Alleen mijn geselecteerde boekenplanken synchroniseren"
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr "Alleen geselecteerde boekenplanken synchroniseren met Kobo"
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr "Tabelweergave"
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr "Label"
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Labels"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr "Labels — uitsluiten"
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr "Labels — opnemen"
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr "Doel-beeldverhouding"
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Taak"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Taken"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr "Technische details"
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr "Die URL is geen bruikbare afbeelding."
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr "Dit formaat wordt geopend in de lezer op volledig scherm."
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 "Deze magic link is verlopen. Genereer een nieuwe om het opnieuw te proberen."
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr "Deze pagina bestaat hier niet."
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
@@ -5789,77 +5698,76 @@ msgstr ""
 "Deze pagina liep tegen een fout aan en kon niet worden weergegeven. Jouw "
 "bibliotheek is in orde — herladen lost het meestal op."
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 "Deze boekenplank is leeg. Voeg boeken toe vanaf de pagina van een boek."
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr "Titel A–Z"
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr "Titel Z–A"
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr "Titel, auteur of ISBN"
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr "Token URL"
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr "Best beoordeeld"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr "Authenticatie-header vertrouwen"
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr "UI / weergave-configuratie"
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr "Dearchiveren"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr "Zichtbaar maken"
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr "Ontgrendel de omslag hierboven om een nieuwe toe te passen."
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr "Ontgrendel de omslag om deze te wijzigen"
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr "Zonder titel"
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr "Bijwerken mislukt."
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr "Uploaden als omslag"
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr "Boeken uploaden"
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr "Uploaden is niet beschikbaar voor je account op deze server."
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
@@ -5867,70 +5775,67 @@ msgstr ""
 "Gebruik deze om OPDS-lezers of KOReader-synchronisatie te verbinden zonder "
 "jouw hoofdwachtwoord."
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr "Deze omslag gebruiken"
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Gebruiker"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr "Gebruikersbeheer"
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr "Gebruikersobject filter"
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr "Userinfo URL"
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr "Gebruikersnaam claim"
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr "Versies"
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Toon"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr "Weergave-instellingen"
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr "Viewer"
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr "Wachten tot je autoriseert…"
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 "Indien vergrendeld zal het ophalen van metagegevens deze omslag niet "
 "overschrijven."
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr "Wanneer de leesvoortgang voor het eerst is gesynchroniseerd"
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
@@ -5941,190 +5846,189 @@ msgstr ""
 "account over naar synchronisatie van alleen boekenplanken om het van kracht "
 "te laten worden."
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr "Jouw bibliotheek"
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr "Jouw browser kan dit audioformaat niet afspelen."
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr "Jouw persoonlijke digitale bibliotheek"
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 "Jouw opgeslagen e-readeradres wordt getoond — wijzig het alleen voor deze "
 "verzending."
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr "alle regels"
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr "elke regel"
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr "boeken"
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr "boeken komen overeen"
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr "exemplaren"
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr "e-reader"
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr "bijv. Ongelezen sci-fi"
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr "eReader e-mailonderwerp"
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr "gedeeld"
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr "naar"
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr "type (isbn, amazon, doi…)"
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr "waarde"
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr "je"
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr "{count} boek"
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr "{count} boeken"
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr "{count} bestand in de wachtrij geplaatst voor import"
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr "{count} bestand afgewezen"
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr "{count} bestanden in de wachtrij geplaatst voor import"
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr "{count} bestanden afgewezen"
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr "{count} resultaat"
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr "{count} resultaten"
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr "{count} resultaten voor \"{query}\""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr "{field} (door komma's gescheiden)"
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr "{n} gevonden"
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr "{ok} van de {total} bronnen hebben geantwoord"
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr "…of plak een afbeelding-URL"
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr "← Terug naar boek"
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr "← Terug naar inloggen"
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr "← Bibliotheek"
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Wachten"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Mislukt"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Gestart"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Voltooid"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "Beëindigd"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "Geannuleerd"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Onbekende status"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Onverwachte gegevens tijdens het uitlezen van de update-informatie"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr "Er is geen update beschikbaar"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6132,16 +6036,16 @@ msgstr ""
 "Er is een update beschikbaar. Klik op de knop hieronder om te updaten naar "
 "de nieuwste versie."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "De update-informatie kan niet worden opgehaald"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr ""
 "Klik op de onderstaande knop om de laatste stabiele versie te installeren."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6150,320 +6054,318 @@ msgstr ""
 "Er is een update beschikbaar. Klik op de knop hieronder om te updaten naar "
 "versie: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Geen update-informatie beschikbaar"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Verkennen (willekeurige boeken)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Populaire boeken (meest gedownload)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "Gedownloade boeken door %(user)s"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Auteur: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Uitgever: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Reeks: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "Beoordeling: geen"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Beoordeling: %(rating)s sterren"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Bestandsformaat: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Categorie: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Taal: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Populaire boeken"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Verborgen boek"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "Fout bij verwijderen boekenplank!"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 msgid "Invalid rules format"
 msgstr "Ongeldig regel-formaat"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 #, fuzzy
 msgid "Invalid request"
 msgstr "Ongeldige rol"
 
-#: cps/web.py:1470
+#: cps/web.py
 #, fuzzy
 msgid "Name and rules are required"
 msgstr "Zowel gebruikersnaam als regels zijn vereist"
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 msgid "Error creating shelf"
 msgstr "Fout bij aanmaken boekenplank"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 msgid "Create Magic Shelf"
 msgstr "Magische boekenplank maken"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 msgid "Shelf name is required"
 msgstr "Boekenplank-naam is verplicht"
 
-#: cps/web.py:1647
+#: cps/web.py
 msgid "Error updating shelf"
 msgstr "Fout bij bijwerken boekenplank"
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "Pas een boekenplank aan"
 
-#: cps/web.py:1668
+#: cps/web.py
 msgid "Shelf not found"
 msgstr "Boekenplank niet gevonden"
 
-#: cps/web.py:1673
+#: cps/web.py
 #, fuzzy
 msgid "Permission denied"
 msgstr "Toegang geweigerd"
 
-#: cps/web.py:1704
+#: cps/web.py
 msgid "Shelf duplicated successfully"
 msgstr "Boekenplank succesvol gedupliceerd"
 
-#: cps/web.py:1710
+#: cps/web.py
 msgid "Error duplicating shelf"
 msgstr "Fout bij dupliceren boekenplank"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 msgid "Error deleting shelf"
 msgstr "Fout bij verwijderen boekenplank"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 msgid "Error hiding shelf"
 msgstr "Fout bij verbergen boekenplank"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 msgid "Error unhiding shelf"
 msgstr "Fout bij zichtbaar maken boekenplank"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Downloads"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Alle bestandsformaten"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 #, fuzzy
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Stel eerst SMTP-mail in..."
 
-#: cps/web.py:2400
+#: cps/web.py
 #, fuzzy
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr "Stel je kindle-e-mailadres in..."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr ""
 "Het boek is in de wachtrij geplaatst om te worden verstuurd aan "
 "%(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Fout opgetreden bij het versturen van dit boek: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr "Geen e-mailadressen geselecteerd"
 
-#: cps/web.py:2473
+#: cps/web.py
 #, fuzzy
 msgid "Additional email addresses are disabled for your account."
 msgstr "Kies e-mailadressen:"
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr ""
-"Het boek is in de wachtrij geplaatst om te worden verstuurd aan "
-"%(eReadermail)s"
+"Het boek is in de wachtrij geplaatst om te worden verstuurd aan %"
+"(eReadermail)s"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr ""
 "Wacht alstublieft één minuut voor het registreren van de volgende gebruiker"
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Registreren"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 #, fuzzy
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr "E-mailserver is niet geconfigureerd, neem contact op met de beheerder!"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr "E-mailserver is niet geconfigureerd, neem contact op met de beheerder!"
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "Dit e-mailadres mag niet worden gebruikt voor registratie."
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "Er is een bevestigings-e-mail verstuurd naar je e-mailadres."
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
 msgstr "E-mailserver is niet geconfigureerd, neem contact op met de beheerder!"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "E-mailserver is niet geconfigureerd, neem contact op met de beheerder!"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 #, fuzzy
 msgid "Cannot activate LDAP authentication"
 msgstr "Kan de LDAP authenticatie niet activeren"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr "Wacht alstublieft één minuut voor de volgende inlogpoging"
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, fuzzy, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "je bent ingelogd als: '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "je bent ingelogd als: '%(nickname)s'"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
 msgstr "E-mailserver is niet geconfigureerd, neem contact op met de beheerder!"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6472,709 +6374,679 @@ msgstr ""
 "Terugvallen op login: '%(nickname)s', LDAP Server is onbereikbaar, of de "
 "gebruiker is onbekend"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, fuzzy, python-format
 msgid "Could not login: %(message)s"
 msgstr "Inloggen mislukt: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 #, fuzzy
 msgid "Wrong Username or Password"
 msgstr "Verkeerde gebruikersnaam of wachtwoord"
 
-#: cps/web.py:2832
+#: cps/web.py
 #, fuzzy
 msgid "New Password was sent to your email address"
 msgstr "Een nieuw wachtwoord is verzonden naar je e-mailadres"
 
-#: cps/web.py:2836
+#: cps/web.py
 #, fuzzy
 msgid "An unknown error occurred. Please try again later."
 msgstr "Onbekende fout opgetreden. Probeer het later nog eens."
 
-#: cps/web.py:2838
+#: cps/web.py
 #, fuzzy
 msgid "Please enter valid username to reset password"
 msgstr "Geef een geldige gebruikersnaam op om je wachtwoord te herstellen"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "Je bent nu ingelogd als: '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 #, fuzzy
 msgid "Success! Profile Updated"
 msgstr "Profiel bijgewerkt"
 
-#: cps/web.py:3164
+#: cps/web.py
 #, fuzzy
 msgid "Oops! An account already exists for this Email."
 msgstr "Bestaand account met dit e-mailadres aangetroffen."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr "Ongeldige boek ID."
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr "KOReader Synchronisatie Plugin"
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "Geen geldig gmail.json bestand gevonden met OAuth informatie"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 msgid "Preparing to send to eReader..."
 msgstr "%(book)s verzonden naar eReader"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 msgid "Sending to eReader..."
 msgstr "Versturen naar eReader"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 msgid "Auto-send completed successfully"
 msgstr "Automatisch versturen succesvol afgerond"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr "Automatisch verzenden"
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr "Verwijder inhoud van tijdelijke map"
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s verzonden naar eReader"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Calibre ebook-convert %(tool)s niet gevonden"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "%(format)s formaat is niet gevonden op de schijf"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "E-Book converter mislukt met een onbekende foutmelding"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Kepubify-converteerder mislukt: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "Omgezette bestand is niet gevonden of meer dan een bestand in map %(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre mislukt met foutmelding: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "E-boek-conversie mislukt: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Opnieuw verbinding aan het maken met Calibre database"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan"
 msgstr "Duplicaten zoeken"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Zoeken naar duplicaten"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Update uitpakken"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Duplicaten scan in wachtrij"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Zet Hardcover-sync aan"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "E-mail"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr "metagegevens opslaan"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 msgid "Convert Library"
 msgstr "Omzetten bibliotheek"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "%(count)s omslagminiaturen gegenereerd"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "Omslag miniaturen"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "{0} serieminiaturen gegenereerd"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "Cache met omslagminiaturen aan het opschonen"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "Boeken georganiseerd op boekenplanken"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Wachtwoord wijzigen"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Kies eerst een boek"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "OAuth Instellingen"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Gebruikerinstellingen"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "kies een optie"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 msgid "Add to Shelf"
 msgstr "Toevoegen aan boekenplank"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Openbaar)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "Downloads"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Downloads"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "Sorteren op datum, nieuwste boeken eerst"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "Sorteren op datum, oudste boeken eerst"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Auteur"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Auteur"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Gepubliceerd vóór "
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Gepubliceerd vóór "
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Sorteren op datum, nieuwste boeken eerst"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "Sorteren op datum, oudste boeken eerst"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr "Gebruikers&nbsp;&nbsp;👤"
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Send to eReader Email"
 msgstr "Verstuur naar eReader E-mail"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 msgid "Send to eReader Subject"
 msgstr "Verstuur naar eReader onderwerp"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Boeken lezen"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Openbare boekenplank"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr "Beheer Profielafbeeldingen"
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "LDAP gebruikers importeren"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "E-mail Server Instellingen&nbsp;&nbsp;📬"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr ""
 "SMTP-hostnaam (gebruik mail.example.org om wachtwoordherstel uit te "
 "schakelen)"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "SMTP-poort"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "SMTP-gebruikersnaam"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Van e-mail"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Service"
 msgstr "E-mail Service"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail via OAuth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr "Configuratie&nbsp;&nbsp;⚙️"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Calibre-database locatie"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Logniveau"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Externe poort"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Aantal boeken per pagina"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Uploaden toestaan"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Anoniem verkennen"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Openbare registratie"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Inloggen op afstand"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Reverse Proxy Login"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Reverse proxy header naam"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Bewerk basisconfiguratie"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Bewerk gebruikersinterface configuratie"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Edit Calibre Database Configuration"
 msgstr "Bewerk Calibre databaseconfiguratie"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "Geplande taken"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "Starttijd"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "Maximale duur"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "Genereer serie miniaturen"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Opnieuw verbinding maken met Calibre database"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr "Genereer backupbestanden voor metagegevens"
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "Ververs cache met omslagminiaturen"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Setup KOReader Sync"
 msgstr "PDF lezer"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr "Start Hardcover Auto-Fetch"
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Systeembeheer"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Download foutopsporingspakket"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Logboeken bekijken"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Calibre-Web herstarten"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Calibre-Web stoppen"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "Versie informatie"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Versie"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Details"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "Update mislukt:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Updatekanaal"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Huidige versie"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Controleren op updates"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Update uitvoeren"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Weet je zeker dat je Calibre-Web wilt herstarten?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "Oké"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Weet je zeker dat je Calibre-Web wilt stoppen?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Bezig met bijwerken, vernieuw de pagina niet"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7182,607 +7054,584 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Boeken in deze bibliotheek"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Bezig met uploaden..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "Update mislukt:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Verbindingsfout"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Reeks: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "via"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "In bibliotheek"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "beperken"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Meer van"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Boek verwijderen"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Formaten verwijderen:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Boekformaat converteren:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Converteren van:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr "kies een optie"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Converteren naar:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Boek converteren"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Fout"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Uploadformaat"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "Boekenreeks volgnummer"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Publicatiedatum"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Identificatie type"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Identificatie waarde"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Verwijderen"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Identificator toevoegen"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Omslag-url (jpg) (de omslag wordt gedownload en opgeslagen in de database)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Omslag uploaden vanaf de harde schijf"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 msgid "Hardcover Sync Blacklist"
 msgstr "Hardcover Sync Blacklist"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Boek inkijken na bewerking"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Metagegevens ophalen"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Trefwoord"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "Trefwoord zoeken"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Bezig met laden..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Zoekfout!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "Geen resultaten gevonden! Gebruik een ander trefwoord."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "Dit veld is verplicht"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr "Auteur en titel omwisselen"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 msgid "Select all"
 msgstr "Alles selecteren"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr "Alles wissen"
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 msgid "Update Title Sort automatically  "
 msgstr "Automatisch sorteren op titel "
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Automatisch sorteren op auteur"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Geef titel"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Voer Titel sorteervolgorde in"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Titel sorteren"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Voer Auteur sorteervolgorde in"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Auteur sorteren"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Voer Auteurs in"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Voer categorieën in"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Voer serie in"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Voer talen in"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Voer publicatiedatum in"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Voer uitgevers in"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Voer opmerkingen in"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Comments"
 msgstr "Opmerkingen"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 msgid "Archived?"
 msgstr "Gearchiveerd?"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 msgid "Read?"
 msgstr "Gelezen?"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "Invoeren "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Weet je het zeker?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "Boeken met de titel zullen worden samengevoegd van:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "In boek met titel:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr "De volgende boeken zullen worden verwijderd:"
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr "De volgende boeken zullen worden gearchiveerd:"
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr "De volgende boeken zullen worden gedearchiveerd:"
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr "De volgende boeken zullen als gelezen worden gemarkeerd:"
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr "De volgende boeken zullen als ongelezen worden gemarkeerd:"
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Metagegevens bewerken"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr "Bewerk de velden die je wilt wijzigen. Lege velden worden genegeerd:"
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 msgid "Select a Shelf"
 msgstr "Boekenplank selecteren"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 "Selecteer een boekenplank om de geselecteerde boeken aan toe te voegen:"
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr "-- Selecteer een Boekenplank --"
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Toevoegen"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr "E-mailserver is niet geconfigureerd, neem contact op met de beheerder!"
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr "Bericht"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Een nieuw wachtwoord is verzonden naar je e-mailadres"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Versturen naar eReader"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Annuleren"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Locatie van de Calibre-database"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7798,13 +7647,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7815,7 +7664,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7832,11 +7681,11 @@ msgstr ""
 "zodra je de <b>Scheid Boekbestanden van Bibliotheek</b> optie hebt "
 "aangevinkt."
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr "Gesplitste Bibliotheek Functionaliteit"
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
@@ -7846,32 +7695,32 @@ msgstr ""
 "bestand moet in <code>/calibre-library</code> blijven, maar je "
 "bibliotheekbestanden kunnen zijn waar je maar wilt"
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Google Drive gebruiken?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Google Drive goedkeuren"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Google Drive Calibre-map"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "Metagegevens Watch Channel ID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Intrekken"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Opnieuw verbinding maken met Calibre database"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7881,130 +7730,130 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "Weet je zeker dat je Calibre-Web wilt stoppen?"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Opnieuw verbinding maken met Calibre database"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "New db location is invalid, please enter valid path"
 msgstr "Database niet gevonden, voer een geldig pad in"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Gebruik standaard authenticatie"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Gebruik LDAP authenticatie"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Gebruik OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Serverinstellingen"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Serverpoort"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL-certificaatlocatie ('certfile' - laat leeg voor niet-SSL-servers)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL-sleutellocatie ('keyfile' - laat leeg voor niet-SSL-servers)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Updatekanaal"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Stabiel"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Bèta"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "Vertrouwde hosts (komma gescheiden)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Logbestanden"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "Locatie en naam van het toegangslog (access.log indien niet opgegeven)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Toegangslog aanzetten"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "Locatie en naam van het toegangslog (access.log indien niet opgegeven)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "Serverinstellingen"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr "Zet niet Engelse tekens in titel en auteur om tijdens het opslaan"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Uploaden inschakelen"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr "(Zorg dat gebruikers uploadrechten hebben)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Toegelaten upload bestandsformaten"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Anoniem verkennen inschakelen"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Openbare registratie inschakelen"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "Gebruik e-mail als inlognaam"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Inloggen op afstand inschakelen ('magic link')"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -8012,152 +7861,152 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Proxy onbekende verzoeken naar Kobo winkel"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Server Externe Port (voor port doorgestuurde API oproepen)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Gebruik Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Goodreads API-sleutel"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 msgid "Enable Hardcover Sync"
 msgstr "Zet Hardcover-sync aan"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr "Tokenstatus: niet geconfigureerd."
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr "Tokenstatus: geldig."
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 msgid "Token status: rejected or expired."
 msgstr "Tokenstatus: geweigerd of verlopen."
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr "Tokenstatus: aanwezig; validatie is tijdelijk niet beschikbaar."
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr "Vervaldatum: niet opgegeven door dit token."
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Goodreads API-sleutel"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8165,177 +8014,177 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Reverse Proxy authenticatie toestaan"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Login type"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "LDAP Server hostnaam of IP-adres"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "LDAP Server Poort"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "LDAP encryptie"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "LDAP CACertificataat Path (Alleen nodig voor Client Certificaat Autorisatie)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "LDAP Certificaat Pad (Alleen nodig voor Client Certificaat Autorisatie)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "LDAP SleutelBestand Pad (alleen nodig voor Client Certificaat Autorisatie)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "LDAP Authenticatie"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Eenvoudig"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "LDAP Administrator naam"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "LDAP Administrator wachtwoord"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "LDAP Distinguished Name (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "LDAP User Object Filter"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "LDAP Server is OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr ""
 "De volgende instellingen zijn nodig voor het importeren van gebruikers:"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "LDAP Groep Object Filter"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "LDAP groepnaam"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "LDAP groepleden veld"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "LDAP Lid Gebruiker Filter Detectie"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "Automatisch detecteren"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "Aangepast Filter"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "LDAP Lid Gebruiker Filter"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr "Generieke OAuth Provider"
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr "OAuth Metadata URL (voor automatische detectie)"
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 msgid "Test Metadata"
 msgstr "Metagegevens test"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr "Laat leeg om handmatige configuratie hieronder te gebruiken"
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr "Gebruik Handmatige Endpoint URL's (negeer automatische detectie)"
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
@@ -8343,242 +8192,242 @@ msgstr ""
 "Vink dit aan om individuele OAuth endpoints handmatig te configureren in "
 "plaats van automatische detectie te gebruiken"
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "Bewerk gebruikersinterface configuratie"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr "OAuth Basis URL"
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr "Autorisatie Endpoint"
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "Toegangssleutel niet gevonden"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr "GebruikersInfo Endpoint"
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 msgid "Test Connection"
 msgstr "Verbindingstest"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "OAuth Instellingen"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr "Spatie-gescheiden lijst van OAuth scopes"
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Id"
 msgstr "%(provider)s OAuth Client Id"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Secret"
 msgstr "%(provider)s OAuth Client geheim"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "Instellingen bekijken"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "Gebruikersnaam"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr "JWT veld om gebruikersnaam uit te halen"
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "EMail Service"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr "JWT veld om e-mail uit te halen"
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "OAuth groep voor Admin"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr "OAuth groep voor Admin"
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Standaardinstellingen voor nieuwe gebruikers"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Downloads toestaan"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Boeken lezen toestaan"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Uploads toestaan"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Bewerken toestaan"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Verwijderen van boeken toestaan"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Wachtwoord wijzigen toestaan"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Bewerken van openbare boekenplanken toestaan"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr "Login Knop Tekst"
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Verkrijg %(provider)s OAuth Verificatiegegevens"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "%(provider)s OAuth Client Id"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "%(provider)s OAuth Client geheim"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Externe programma's"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Path to Calibre Binaries"
 msgstr "Pad naar Calibre E-Book Converteerder"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Calibre E-Book Converter Settings"
 msgstr "Calibre E-Book omzet instellingen"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Pad naar Kepubify E-book Converteerder"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "Locatie van UnRar-programma"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Security Settings"
 msgstr "OAuth Instellingen"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8586,335 +8435,330 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr "Beperk aantal mislukte inlogpogingen"
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr "Configureer Backend voor Limiter"
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr "Opties voor Limiter Backend"
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 "Controleer of bestandsextensies overeenkomen met bestandsinhoud bij upload"
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Session protection"
 msgstr "Sessiebescherming"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr "Basis"
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr "Sterk"
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "User Password policy"
 msgstr "Gebruikerswachtwoord herstellen"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr "Minimale wachtwoordlengte"
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr "Forceer getal"
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr "Forceer kleine letter"
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr "Forceer hoofdletter"
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr "Forceer karakters (nodig voor Chinese/Japanse/Koreaanse karakters)"
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr "Forceer speciaal teken"
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Instellingen bekijken"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Aantal te tonen willekeurige boeken"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr "Aantal te tonen auteurs alvorens te verbergen (0=nooit verbergen)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "Verwijderen"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "caliBlur! donker thema"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Reguliere expressie om kolommen te negeren"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Gelezen/ongelezen-status koppelen aan Calibre-kolom"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "Gelezen/ongelezen-status koppelen aan Calibre-kolom"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Bekijk restricties gebaseerd op Calibre kolommen"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Reguliere expressie voor het sorteren op titel"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Instellingen bekijken"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Custom CSS"
 msgstr "Aangepast Filter"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Standaardinstellingen voor nieuwe gebruikers"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 msgid "Permissions"
 msgstr "Autorisaties"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Systeembeheerder"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 msgid "Language & Display"
 msgstr "Taal & Weergave"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "Standaard taal"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 msgid "Default interface language for new users."
 msgstr "Standaardinstelling taal voor nieuwe gebruikers"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "Standaard taal van boeken"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 msgid "Default book language filter for new users."
 msgstr "Standaard taalfilter voor nieuwe gebruikers"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Standaard zichtbaar voor nieuwe gebruikers"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Willekeurige boeken tonen in gedetailleerde weergave"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Voeg toegestane/geweigerde tags toe"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Voeg toegestane/geweigerde aangepaste kolomwaarden toe"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Uploaden"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "Gearchiveerd"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 msgid "Download Log"
 msgstr "Downloaden log"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Starten"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8923,14 +8767,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8938,91 +8782,90 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on selected book"
 msgstr "Uitvoeren voor geselecteerde boeken"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "{} gebruikers succesvol verwijderd"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "Fout bij verwijderen boekenplank!"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 msgid "No matches found"
 msgstr "Geen resultaten gevonden"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 msgid "Enter a search term"
 msgstr "Voer zoekgegevens in"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 msgid "Failed to search library"
 msgstr "Zoeken in bibliotheek mislukt"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 msgid "Select a book first"
 msgstr "Kies eerst een boek"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "Geselecteerde boeken samenvoegen"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "Fout bij verwijderen boekenplank!"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Calibre-Web Logbestand: "
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -9030,11 +8873,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -9045,11 +8888,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -9059,163 +8902,163 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "Gearchiveerde boeken"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr "Iedere 15 minuten"
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr "Iedere 30 minuten"
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr "Ieder uur"
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr "Iedere 2 uur"
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr "Iedere 4 uur"
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr "Iedere 6 uur"
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr "Iedere 12 uur"
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr "Dagelijks/Wekelijks/Maandelijks"
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr "Dagelijks op vaste tijd"
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr "Wekelijks op vaste dag"
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr "Maandelijks op vaste dag"
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr "Standaard: dagelijks om 03:00"
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr "Dag van de week:"
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr "Maandag"
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr "Dinsdag"
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr "Woensdag"
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr "Donderdag"
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr "Vrijdag"
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr "Zaterdag"
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr "Zondag"
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr "Dag van de maand:"
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr "(1-28)"
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr "Tijdstip op de dag:"
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr "Schakel CWA Automatische Omslag & Metadata Afdwingingsservice in"
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9223,11 +9066,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9235,63 +9078,61 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "De metagegevens zijn bijgewerkt"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identificatoren"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 msgid "Cover Image"
 msgstr "Kaft-afbeelding"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr "Bereik: 5-120 MB (standaard: 15)"
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr "Opname Verwerkings Timeout"
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
@@ -9301,47 +9142,47 @@ msgstr ""
 "voordat er een timeout optreedt. Bestanden die een timeout krijgen worden "
 "verplaatst naar de mislukte backup map voor onderzoek."
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr "Timeout (minuten):"
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr "Bereik: 5-120 minuten (standaard: 15)"
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Stale temp age (minutes):"
 msgstr "Timeout (minuten):"
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr "Bereik: 5-10080 minuten (standaard: 120)"
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr "Bereik: 0-86400 seconden (standaard: 600)"
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9349,159 +9190,159 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr "Vertraging (minuten):"
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr "Bereik: 5-60 minuten (standaard: 5)"
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Hardcover API token"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Token Required"
 msgstr "Hardcover API token"
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr "Bereik: 5-120 minuten (standaard: 15)"
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr "Bereik: 10-200 boeken per uitvoering (default: 50)"
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr "Bereik: 5-60 seconden (standaard: 5.0)"
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "Instellingen"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "OAuth Instellingen"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9509,58 +9350,57 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr "Schakel Bijdragen Vertalingen Meldingen in"
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Synchroniseer geselecteerde boekenplanken met Kobo"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Schakel Onscherpe Achtergronden in op Mobiel (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -9569,16 +9409,16 @@ msgstr ""
 "op kleine schermen. Schakel uit als je scroll- of animatie vertraging "
 "opmerkt."
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "OAuth Instellingen"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -9586,11 +9426,11 @@ msgstr ""
 "Wanneer actief, wordt een kopie van alle geïmporteerde bestanden opgeslagen "
 "in <i>/config/processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -9598,21 +9438,21 @@ msgstr ""
 "Wanneer actief, worden de originelen van opgenomen bestanden die conversie "
 "ondergaan opgeslagen in /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9625,11 +9465,11 @@ msgstr ""
 "processed_books georganiseerd te houden en om schijfruimtegebruik te "
 "minimaliseren."
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -9639,33 +9479,33 @@ msgstr ""
 "automatisch geconverteerd worden naar het hier gekozen formaat (behalve de "
 "formaten geselecteerd in de negeerlijst hieronder)"
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Boekformaat converteren:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9673,20 +9513,20 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "Calibre kan Dubbele Boektitels detecteren bij Import en afhankelijk van de"
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr "autosamenvoegen"
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -9694,583 +9534,571 @@ msgstr ""
 "instelling. Deze kan ingesteld worden om een van de instanties van een "
 "gedupliceerd boek te verwijderen of beide te behouden (standaard)."
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Verwijdert dubbele import, behoudt bibliotheekexemplaar"
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr "Overschrijft bibliotheekexemplaar met nieuw geïmporteerd bestand"
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Creëert een dubbel record, behoudt beide exemplaren"
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Openbare registratie inschakelen"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "OAuth Instellingen"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Manual only"
 msgstr "Handmatig?"
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Schakel CWA Update Meldingen in"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Openbare registratie inschakelen"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Origineel Formaat"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Metagegevens ophalen"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Beoordeling"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr "Klik om meer te zien"
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Volgende"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Markeren als ongelezen"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Markeren als gelezen"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 msgid "Marked as read"
 msgstr "Gemarkeerd als gelezen"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 msgid "Marked as unread"
 msgstr "Gemarkeerd als ongelezen"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Toevoegen aan archief"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Teruggehaald uit archief"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Terughalen uit archief"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Toevoegen aan archief"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 msgid "Restored from archive"
 msgstr "Teruggehaald uit archief"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "Zoeken in bibliotheek mislukt"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "E-mailserver-instellingen bijgewerkt"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "Met beoordeling hoger dan"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, fuzzy, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "Boek %(index)s van %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 #, fuzzy
 msgid "File sizes"
 msgstr "Lettertypegrootte"
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Beschrijving:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "Kindle-e-mailadres"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 msgid "Choose email addresses:"
 msgstr "Kies e-mailadressen:"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "Boekenplank maken"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Additional email addresses:"
 msgstr "Kies e-mailadressen:"
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Enter additional email addresses (separated by commas):"
 msgstr "Kies e-mailadressen:"
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "Formaten verwijderen:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "Locatie aanmaken voor omslag mislukt"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "Locatie aanmaken voor omslag mislukt"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
@@ -10279,143 +10107,143 @@ msgstr ""
 "Boeken met overeenkomende titels en auteurs. Visuele inspectie wordt "
 "aanbevolen om echte duplicaten te identificeren."
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Duplicaten zoeken"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "Best beoordeelde boeken tonen"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr "Selecteer Duplicaten"
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 msgid "Select None"
 msgstr "Selecteer niets"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 msgid "Delete Selected"
 msgstr "Geselecteerde boeken verwijderen"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Duplicaten zoeken"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr "Automatisch oplossen Duplicaten"
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 msgid "Preview"
 msgstr "Voorbeeld"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "Geselecteerde boeken samenvoegen"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "Boekgegevens"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 msgid "Edit book metadata"
 msgstr "Boek metagegevens bewerken"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 msgid "Archive/delete book"
 msgstr "Archiveren/verwijderen boek"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "Geen resultaten gevonden"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 "Je bibliotheek heeft geen boeken met dezelfde titel en auteur combinaties."
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
@@ -10423,124 +10251,124 @@ msgstr ""
 "Deze zoekopdracht zoekt naar boeken met identieke titels EN auteurs om "
 "foutpositieven te voorkomen."
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Formaten verwijderen:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr "Deze actie kan niet ongedaan worden gemaakt!"
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be permanently deleted:"
 msgstr "Het boek wordt verwijderd uit de Calibre-database"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "Ongelezen boeken"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "De volgende boeken zullen worden verwijderd:"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "Het boek wordt verwijderd uit de Calibre-database"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr "Succes"
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr "Geselecteerde dubbele boeken zijn succesvol verwijderd!"
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr "Er is een fout opgetreden tijdens het verwerken van je verzoek."
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "Kies Server Type"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr "Standaard E-Mail Account"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr "Gmail Account"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr "Gmail account instellen"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Gmail toegang intrekken"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "SMTP-wachtwoord"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Bijlage bestandsgrootte limiet"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 msgid "Save and Send Test Email"
 msgstr "Opslaan en test-e-mail versturen"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Toegelaten domeinen voor registratie"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Domein toevoegen"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Voer domeinnaam in"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Geweigerde domeinen voor registratie"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10548,120 +10376,114 @@ msgstr ""
 "Open het .kobo/Kobo/Kobo eReader.conf bestand in een teksteditor en voeg toe "
 "(of bewerk):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 #, fuzzy
 msgid "Kobo Token:"
 msgstr "Kobo Sync Token"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "Lijst"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "Boekenplank maken"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "Zoekterm:"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "Boek inkijken na bewerking"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "Boekenplank maken"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "Bezig met laden..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
@@ -10670,17 +10492,16 @@ msgstr ""
 "Weet je zeker dat je de geselecteerde rol van de geselecteerde gebruiker(s) "
 "wil veranderen?"
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "Locatie aanmaken voor omslag mislukt"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
@@ -10688,445 +10509,442 @@ msgstr ""
 "Weet je zeker dat je de geselecteerde rol van de geselecteerde gebruiker(s) "
 "wil veranderen?"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "Boekenplank maken"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "Locatie aanmaken voor omslag mislukt"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "E-mailserver is niet geconfigureerd, neem contact op met de beheerder!"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Probleem melden"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Terug naar startpagina"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "Gebruiker uitloggen"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "Pas een boekenplank aan"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show this shelf in your sidebar"
 msgstr "Synchroniseer deze boekenplank met een Kobo-apparaat"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "Alle talen"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "Openbare boekenplank"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Toevoegen aan boekenplank"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 #, fuzzy
 msgid "KOReader Sync is disabled."
 msgstr "KOReader Synchronisatie Plugin"
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Startpagina"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Navigatie aanpassen"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Zoek in bibliotheek"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Calibre-Web - e-boekcatalogus"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Afmelden"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "Instellingen"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "Zoek in bibliotheek"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Geen update-informatie beschikbaar"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Calibre-Web - e-boekcatalogus"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr "Zie Changelog"
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Duplicaten"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr "Draag hier bij!"
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Deze pagina niet vernieuwen"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Boekenplank maken"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Vorige"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Boekgegevens"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Deze actie kan niet ongedaan worden gemaakt!"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Geselecteerde boeken verwijderen"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Uploadformaat"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Formaten verwijderen:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 msgid "Duplicate Books Detected"
 msgstr "Duplicaat boek gevonden"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 msgid "Duplicate Groups Found"
 msgstr "Duplicaat groepen gevonden"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr "Bekijken en oplossen Duplicaten"
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Optimaal inpassen"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "Tot:"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "Instellingen"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Toevoegen aan boekenplank"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Geselecteerde boeken samenvoegen"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Gemarkeerd als ongelezen"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Boek verwijderen"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Boek verwijderen"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Kies eerst een boek"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Hertel mislukt: %(err)s"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr "Filter op eerste letter"
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "Raster"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 msgid "Show Password"
 msgstr "Toon wachtwoord"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Gegevens opslaan"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Wachtwoord Vergeten?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Inloggen met magische koppeling"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 #, fuzzy
 msgid "Log in with SSO"
 msgstr "Inloggen met magische koppeling"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Toon Calibre-Web logbestand: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Calibre-Web Log: "
 msgstr "Toon Calibre-Web logbestand: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Stream uitvoer, kan niet worden weergegeven"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Toon toegangslog: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Download Calibre-Web log"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "Download toegangslog"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 msgid "Share with Everyone (Public)"
 msgstr "Delen met iedereen (Openbaar)"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Selecteer toegestane/geweigerde tags"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Selecteer toegestane/geweigerde aangepaste kolom waarden"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Selecteer toegestane/geweigerde tags van gebruikers"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr ""
 "Selecteer toegestane/geweigerde aangepaste kolom waarden van gebruikers"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Voer Tag in"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Voeg inkijk restrictie toe"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "Het boekformaat wordt permanent gewist uit de database"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Het boek wordt verwijderd uit de Calibre-database"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "en van de harde schijf"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Belangrijke Kobo Opmerking: Verwijderde boeken zullen op alle gekoppelde "
 "Kobo Apparaten blijven."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11134,566 +10952,562 @@ msgstr ""
 "Boeken moeten eerst worden gearchiveerd en het apparaat moet worden "
 "gesynchroniseerd, voordat een boek veilig kan worden verwijderd."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Kies bestandslocatie"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "type"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "naam"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "grootte"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "Bovenliggende map"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "Oké"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Calibre-Web - e-boekcatalogus"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "EPUB lezer"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "Acties"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "Zwart"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "Lettertypegrootte"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Volgende pagina"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr "Lettertype"
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 msgid "Default"
 msgstr "Standaard"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr "Yahei"
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr "SimSun"
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 msgid "KaiTi"
 msgstr "KaiTi"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 msgid "Arial"
 msgstr "Arial"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 msgid "Spread"
 msgstr "Verspreiden"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr "Twee kolommen"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr "Éé kolom"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Tekstindeling automatisch aanpassen als het zijpaneel geopend is."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Comic Reader"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Sneltoetsen"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Vorige pagina"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Volgende pagina"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 msgid "Single Page Display"
 msgstr "Weergave van één pagina"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr "Lange Strip Weergave"
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Optimaal inpassen"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Aanpassen aan breedte"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Aanpassen aan hoogte"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Ware grootte"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Rechtsom draaien"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Linksom draaien"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Afbeelding omdraaien"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "Weergeven"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 msgid "Single Page"
 msgstr "Enkele pagina"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr "Lange Strip"
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Schaal"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Beste"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Breedte"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Hoogte"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Ware grootte"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Draaien"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Omdraaien"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Horizontaal"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Verticaal"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 msgid "Direction"
 msgstr "Richting"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Links-naar-rechts"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Rechts-naar-links"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr "Terug naar boven"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 msgid "Remember Position"
 msgstr "Onthoud positie"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "Schuifbalk"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "Toon"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "DJVU lezer"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "PDF lezer"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "txt lezer"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Nieuw account registreren"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Kies een gebruikersnaam"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Je e-mailadres"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Magische link - autoriseer een nieuw apparaat"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "Meld je aan op een ander apparaat en ga naar:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "Na controle wordt je automatisch op dit apparaat ingelogd."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "De link vervalt na 10 minuten."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "Genereer serie omslagminiaturen"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Geen resultaten gevonden"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Zoekterm:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Resultaten voor:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Publicatiedatum van"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Publicatiedatum tot"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr "Leeg"
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Labels uitsluiten"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Boekenreeksen uitsluiten"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "Boekenplanken uitsluiten"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Talen uitsluiten"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Extenties"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Extenties uitsluiten"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Met beoordeling hoger dan"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Met beoordeling lager dan"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "Van:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "Tot:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Deze boekenplank verwijderen"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "Bewerk boekenplank eigenschappen"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Verborgen boek"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "Boeken handmatig rangschikken"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "Schakel verandering van de volgorde uit"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "Schakel verandering van de volgorde in"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Uitvoeren voor geselecteerde boeken"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Account"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Boek niet gevonden"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Deze boekenplank verwijderen"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Toevoegen aan boekenplank"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Zoek in bibliotheek"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Zoek in bibliotheek"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Delen met iedereen"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "Synchroniseer deze boekenplank met een Kobo-apparaat"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Boekenplank niet gevonden"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Verborgen boek"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Calibre bibliotheekstatistieken"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Boeken in deze bibliotheek"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Auteurs in deze bibliotheek"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Categorieën in deze bibliotheek"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Boekenreeksen in deze bibliotheek"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Systeeminformatie"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 #, fuzzy
 msgid "Program"
 msgstr "Voortgang"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Geïnstalleerde Versie"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Looptijd"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr "Acties"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "Draaien"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 "Deze taak wordt geannuleerd. De voortgang van deze taak wordt opgeslagen."
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
@@ -11701,394 +11515,394 @@ msgstr ""
 "Als dit een geplande taak is wordt deze opnieuw uitgevoerd tijdens de "
 "volgende geplande tijd."
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "Geselecteerde dubbele boeken zijn succesvol verwijderd!"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Calibre-Web - e-boekcatalogus"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "Your Profile"
 msgstr "Je profiel"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "User Settings"
 msgstr "Gebruikerinstellingen"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Gebruikerswachtwoord herstellen"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "Serverinstellingen"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "Kindle-e-mailadres"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "Voer talen in"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Taal van boeken"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "Geen geldige boek taal is opgegeven"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "OAuth Instellingen"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Koppelen"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Ontkoppelen"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Hardcover API Token"
 msgstr "Hardcover API token"
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Kobo Sync Token"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Aanmaken/Bekijken"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "Forceer volledige Kobo synchronisatie."
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "Synchroniseer alleen boeken op geselecteerde boekenplanken met Kobo"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "Synchroniseer alleen boeken op geselecteerde boekenplanken met Kobo"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "OAuth Instellingen"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Voeg toegestane/geweigerde aangepaste kolomwaarden toe"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Magic Shelves Order"
 msgstr "Synchroniseer geselecteerde boekenplanken met Kobo"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "Recent toegevoegde boeken"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "Openbare boekenplank bewerken"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Gebruiker verwijderen"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12096,161 +11910,161 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Wachtwoord wijzigen"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Wachtwoord wijzigen"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Aanmaken/Bekijken"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Genereer Kobo Auth URL"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Selecteer..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Geselecteerde boeken verwijderen"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "Gebruiker Bewerken"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "Voer gebruikersnaam in"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Email"
 msgstr "Test-e-mail"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email"
 msgstr "Kindle-e-mailadres"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email"
 msgstr "Test-e-mail"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "Kindle-e-mailadres"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "Test-e-mail"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Locale"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "Zichtbare Boek Talen"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "Toegestaande labels bewerken"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Toegestaande Labels"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Verboden labels bewerken"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Verboden Labels"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "Toegestane kolomwaarden bewerken"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "Toegestane kolomwaarden"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Denied Column Values"
 msgstr "Geweigerde kolomwaarden bewerken"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Denied Column Values"
 msgstr "Geweigerde kolomwaarden"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Change Password"
 msgstr "Wachtwoord wijzigen"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "Openbare boekenplank bewerken"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "Synchroniseer geselecteerde boekenplanken met Kobo"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "Synchroniseer geselecteerde boekenplanken met Kobo"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Read/Unread Section"
 msgstr "Toon gelezen/niet gelezen selectie"
@@ -12424,10 +12238,11 @@ msgstr "Toon gelezen/niet gelezen selectie"
 #~ msgstr ""
 #~ "Deze paden zijn alleen intern voor CWA, je kunt aan de linkerkant naar "
 #~ "hartenlust wijzigen waar ze aan gekoppeld zijn, maar er is geen reden om "
-#~ "de paden aan de rechterkant te wijzigen.<br><br>Als je je <code>metadata."
-#~ "db</code> bestand op een andere locatie wilt dan de rest van je "
-#~ "bibliotheek, gebruik dan de <b>Scheid Boekbestanden van Bibliotheek Optie "
-#~ "hieronder en voer daar het pad naar de rest van de bibliotheek in</b>"
+#~ "de paden aan de rechterkant te wijzigen.<br><br>Als je je "
+#~ "<code>metadata.db</code> bestand op een andere locatie wilt dan de rest "
+#~ "van je bibliotheek, gebruik dan de <b>Scheid Boekbestanden van "
+#~ "Bibliotheek Optie hieronder en voer daar het pad naar de rest van de "
+#~ "bibliotheek in</b>"
 
 #~ msgid "Enable CWA Auto-Convert"
 #~ msgstr "Schakel CWA Auto-Conversie in"

--- a/cps/translations/no/LC_MESSAGES/messages.po
+++ b/cps/translations/no/LC_MESSAGES/messages.po
@@ -19,253 +19,251 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Statistikk"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 #, fuzzy
 msgid "Server restarted, please reload page."
 msgstr "Server startet på nytt. Last inn siden på nytt"
 
-#: cps/admin.py:210
+#: cps/admin.py
 #, fuzzy
 msgid "Performing Server shutdown, please close window."
 msgstr "Utfører avslutning av server, vennligst lukk vinduet"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr ""
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Ukjent kommando"
 
-#: cps/admin.py:232
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 "Test e-post i kø for sending til %(email)s, sjekk Oppgaver for resultat"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr ""
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 
-#: cps/admin.py:414
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover ID applied successfully"
 msgstr "{} brukere ble slettet"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr ""
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr ""
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr ""
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr ""
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr ""
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Admin side"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "Vis forfattervalg"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Grunnleggende konfigurasjon"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "UI-konfigurasjon"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr "Egendefinert kolonnenr.%(column)d finnes ikke i caliber-databasen"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Rediger brukere"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Alle"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Bruker ikke funnet"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} brukere ble slettet"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Vis alt"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Feil utformet forespørsel"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "Gjestenavn kan ikke endres"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "Gjesten kan ikke ha denne rollen"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr "Ingen administratorbruker igjen, kan ikke fjerne administratorrollen"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "Verdien må være sann eller usann"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Ugyldig rolle"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "Gjestene kan ikke ha denne utsikten"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "Ugyldig visning"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr "Gjestenes lokalitet bestemmes automatisk og kan ikke angis"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Ingen gyldig lokalitet gitt"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Ikke oppgitt gyldig bokspråk"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Parameter ikke funnet"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "Innstillinger DB er ikke skrivbar"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Ugyldig lesekolonne"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Ugyldig begrenset kolonne"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Vil du virkelig slette Kobo-tokenet?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "Vil du virkelig slette dette domenet?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "Vil du virkelig slette denne brukeren?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Er du sikker på at du vil slette denne hyllen?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr "Er du sikker på at du vil endre lokaliteter for valgte bruker(e)?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr "Er du sikker på at du vil endre synlige bokspråk for valgte bruker(e)?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 "Er du sikker på at du vil endre den valgte rollen for den(e) valgte brukeren?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
@@ -273,7 +271,7 @@ msgstr ""
 "Er du sikker på at du vil endre de valgte begrensningene for den(e) valgte "
 "brukeren?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -281,14 +279,14 @@ msgstr ""
 "Er du sikker på at du vil endre de valgte synlighetsbegrensningene for "
 "valgte bruker(e)?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "Er du sikker på at du vil endre atferden for hyllesynkronisering for de(n) "
 "valgte brukeren(e)?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
@@ -296,120 +294,115 @@ msgstr ""
 "Er du sikker på at du vil endre atferden for hyllesynkronisering for de(n) "
 "valgte brukeren(e)?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Er du sikker på at du vil endre plassering av Caliber-biblioteket?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Benekte"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Tillate"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "{} synkroniseringsoppføringer slettet"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Token ikke funnet"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Merket ble ikke funnet"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Ugyldig handling"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json er ikke konfigurert for webapplikasjon"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "Loggfilplasseringen er ikke gyldig, skriv inn riktig bane"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Plasseringen av tilgangsloggfilen er ikke gyldig, skriv inn riktig bane"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr "Angi en LDAP-leverandør, port, DN og brukerobjektidentifikator"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Vennligst skriv inn en LDAP-tjenestekonto og passord"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "Angi en LDAP-tjenestekonto"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP-gruppeobjektfilter må ha én \"%s\"-formatidentifikator"
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "LDAP-gruppeobjektfilter har uovertruffen parentes"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP-brukerobjektfilter må ha én \"%s\"-formatidentifikator"
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "LDAP-brukerobjektfilter har uovertruffen parentes"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP-medlemsbrukerfilter må ha én \"%s\"-formatidentifikator"
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "LDAP-medlemsbrukerfilter har uovertruffen parentes"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -417,91 +410,86 @@ msgstr ""
 "LDAP CA-sertifikat, sertifikat eller nøkkelplassering er ikke gyldig. Angi "
 "riktig bane"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Legg til ny bruker"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Edit Email Server Settings"
 msgstr "Rediger e-postserverinnstillinger"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr ""
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, fuzzy, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Databasefeil: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
 msgstr ""
 "Test e-post i kø for sending til %(email)s, sjekk Oppgaver for resultat"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Det oppsto en feil ved sending av test-e-posten: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Vennligst konfigurer e-postadressen din først..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 #, fuzzy
 msgid "Email Server Settings updated"
 msgstr "E-postserverinnstillinger oppdatert"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "Rediger brukere"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Vennligst konfigurer SMTP-postinnstillingene først..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "Vennligst konfigurer e-postadressen din først..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "Nytt passord ble sendt til e-postadressen din"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
 msgstr ""
 "Test e-post i kø for sending til %(email)s, sjekk Oppgaver for resultat"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -509,889 +497,875 @@ msgid ""
 msgstr ""
 "Test e-post i kø for sending til %(email)s, sjekk Oppgaver for resultat"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "Rediger innstillinger for planlagte oppgaver"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "Ugyldig starttidspunkt for spesifisert oppgave"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "Ugyldig varighet for spesifisert oppgave"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "Innstillinger for planlagte oppgaver er oppdatert"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 #, fuzzy
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "En ukjent feil oppstod. Prøv igjen senere."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "Tittel"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Rediger bruker %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Passord for bruker %(user)s tilbakestilling"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Vennligst konfigurer SMTP-postinnstillingene først..."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Loggfilviser"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Ber om oppdateringspakke"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Laster ned oppdateringspakken"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Pakker ut oppdateringspakken"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Erstatter filer"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Databaseforbindelser er stengt"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Stopper server"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Oppdatering fullført, vennligst trykk OK og last inn siden på nytt"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Oppdatering mislyktes:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "HTTP-feil"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Tilkoblingsfeil"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Tidsavbrudd under etablering av tilkobling"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Generell feil"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr "Oppdateringsfilen kunne ikke lagres i temp dir"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "Filer kunne ikke erstattes under oppdatering"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "Kunne ikke pakke ut minst én LDAP-bruker"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Kunne ikke opprette minst én LDAP-bruker"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Feil: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Feil: Ingen bruker ble returnert som svar fra LDAP-serveren"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "Minst én LDAP-bruker ikke funnet i databasen"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} Bruker ble importert"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr ""
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "DB-plassering er ikke gyldig, skriv inn riktig bane"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "DB er ikke skrivbar"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "Nøkkelfilplasseringen er ikke gyldig. Angi riktig bane"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Sertifikatfilplasseringen er ikke gyldig, vennligst skriv inn riktig bane"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr ""
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "Databaseinnstillinger oppdatert"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "Databasekonfigurasjon"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 #, fuzzy
 msgid "Oops! Please complete all fields."
 msgstr "Vennligst fyll ut alle feltene!"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "E-post er ikke fra gyldig domene"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Legg til ny bruker"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Bruker '%(user)s' opprettet"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "Fant en eksisterende konto for denne e-postadressen eller navnet."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Brukeren '%(nick)s' slettet"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "Kan ikke slette gjestebruker"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "Ingen administratorbruker igjen, kan ikke slette bruker"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 #, fuzzy
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "E-postadresse kan ikke være tom og må være en gyldig e-post"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Bruker '%(nick)s' oppdatert"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr ""
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr ""
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Tilkoblingsfeil"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr ""
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "Ingen utgivelsesinformasjon tilgjengelig"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr ""
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr ""
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr ""
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "En ukjent feil oppstod. Prøv igjen senere."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "Tilkoblingsfeil"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Tilkoblingsfeil"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "Fil %(file)s lastet opp"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr ""
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr ""
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr ""
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr ""
 
-#: cps/constants.py:265
+#: cps/constants.py
 #, fuzzy
 msgid "Finnish"
 msgstr "Ferdig"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr ""
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr ""
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr ""
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr ""
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr ""
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr ""
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr ""
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr ""
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr ""
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr ""
 
-#: cps/constants.py:276
+#: cps/constants.py
 #, fuzzy
 msgid "Polish"
 msgstr "Forlegger"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr ""
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr ""
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr ""
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr ""
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr ""
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr ""
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr ""
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr ""
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr ""
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr ""
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "ikke installert"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Utførelsestillatelser mangler"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, fuzzy, python-format
 msgid "Change cover — %(title)s"
 msgstr "Bytt forfatter og tittel"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Tilkoblingsfeil"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr ""
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Book ID"
 msgstr "Bøker"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Boktittel"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "Forfatter"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr ""
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "Filformater"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filename"
 msgstr "Brukernavn"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr ""
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr ""
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "Last opp format"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "Ukjent"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr ""
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "Ugyldig rolle"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 msgid "Selected book has no EPUB format."
 msgstr ""
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "%(format)s format ikke funnet på disken"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB Fixer started for selected book."
 msgstr "Slå sammen valgte bøker"
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr ""
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr ""
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid image data format."
 msgstr "Ugyldig format for e-postadresse"
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Profile picture updated successfully."
 msgstr "{} brukere ble slettet"
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Ingen"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "Slett bok"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "Slett bok"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "Slett bok"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "Merket ble ikke funnet"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 #, fuzzy
 msgid "Invalid resolution strategy"
 msgstr "Ugyldig rolle"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr ""
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 #, fuzzy
 msgid "Failed to queue upload for processing"
 msgstr "Kunne ikke opprette bane for dekning"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Kilde- eller målformat for konvertering mangler"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "Boken ble satt i kø for konvertering til %(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Det oppsto en feil ved konvertering av denne boken: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 #, fuzzy
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "Filtypen «%(ext)s» er ikke tillatt å lastes opp til denne serveren"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr "Filtypen «%(ext)s» er ikke tillatt å lastes opp til denne serveren"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "Filen som skal lastes opp må ha en utvidelse"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 #, fuzzy
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
@@ -1399,40 +1373,39 @@ msgstr ""
 "Oops! Den valgte boktittelen er utilgjengelig. Filen eksisterer ikke eller "
 "er ikke tilgjengelig"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "Brukeren har ingen rettigheter til å laste opp cover"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 "Identifikatorer skiller ikke mellom store og små bokstaver, overskriver "
 "gammel identifikator"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "'%(langname)s' er ikke et gyldig språk"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Metadata ble oppdatert"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "Feil ved redigering av bok: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Ukjent"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1440,96 +1413,96 @@ msgstr ""
 "Opplastet bok finnes sannsynligvis i biblioteket, vurder å endre før du "
 "laster opp ny: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "Filen %(filename)s kunne ikke lagres i midlertidig dir"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Kunne ikke flytte omslagsfil %(file)s: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Bokformatet er slettet"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Boken ble slettet"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "Du mangler tillatelser til å slette bøker"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "redigere metadata"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "%(seriesindex)s er ikke et gyldig tall, hopper over"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr "Brukeren har ingen rettigheter til å laste opp flere filformater"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Kunne ikke opprette banen %(path)s (Tillatelse nektet)."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Kunne ikke lagre filen %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Filformat %(ext)s lagt til %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Token ikke funnet"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "%(format)s format ikke funnet på disken"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1537,7 +1510,7 @@ msgstr ""
 "Google Disk-konfigurasjonen er ikke fullført. Prøv å deaktivere og aktivere "
 "Google Disk på nytt"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1545,89 +1518,88 @@ msgstr ""
 "Tilbakeringingsdomene er ikke bekreftet. Følg fremgangsmåten for å bekrefte "
 "domenet i Googles utviklerkonsoll"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "%(format)s format ikke funnet for bok-ID: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(format)s ikke funnet på Google Disk: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s ikke funnet: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 #, fuzzy
 msgid "Send to eReader"
 msgstr "Send til E-Reader"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "%(format)s format ikke funnet for bok-ID: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "%(format)s format ikke funnet for bok-ID: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 #, fuzzy
 msgid "Test Email"
 msgstr "Test e-post"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Registrerings-e-post for bruker: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Konverter %(orig)s til %(format)s og send til E-Reader"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Send %(format)s til E-Reader"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s sendes til E-Reader"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "Den forespurte filen kunne ikke leses. Kanskje feil tillatelser?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "Lesestatus kunne ikke angis: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
@@ -1635,12 +1607,12 @@ msgstr ""
 "Sletting av bokmappe for bok %(id)s mislyktes, banen har undermapper: "
 "%(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "Sletting av bok %(id)s mislyktes: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1649,7 +1621,7 @@ msgstr ""
 "Sletter bok %(id)s kun fra databasen, bokbanen i databasen er ikke gyldig: "
 "%(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
@@ -1657,66 +1629,66 @@ msgstr ""
 "Endre navn på forfatter fra: '%(src)s' til '%(dest)s' mislyktes med feil: "
 "%(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Fil %(file)s ikke funnet på Google Disk"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Endre navn på tittel fra: '%(src)s' til '%(dest)s' mislyktes med feil: "
 "%(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Finner ikke bokbane %(path)s på Google Disk"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 #, fuzzy
 msgid "Found an existing account for this Email address"
 msgstr "Fant en eksisterende konto for denne e-postadressen"
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Dette brukernavnet er allerede tatt"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 #, fuzzy
 msgid "Invalid Email address format"
 msgstr "Ugyldig format for e-postadresse"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr ""
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 "Python-modulen 'advocate' er ikke installert, men er nødvendig for "
 "omslagsopplastinger"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Feil ved nedlasting av cover"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr "Cover-filen er ikke en gyldig bildefil, eller kunne ikke lagres"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Omslagsformatfeil"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
@@ -1724,133 +1696,133 @@ msgstr ""
 "Du har ikke tilgang til localhost eller det lokale nettverket for "
 "coveropplastinger"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Kunne ikke opprette bane for dekning"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "Bare jpg/jpeg/png/webp/bmp-filer støttes som coverfile"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "Ugyldig omslagsfilinnhold"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Bare jpg/jpeg-filer støttes som coverfile"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr "Dekke"
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "UnRar binær fil ikke funnet"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr "Feil ved kjøring av UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr ""
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr ""
 
-#: cps/helper.py:2125
+#: cps/helper.py
 #, fuzzy
 msgid "Calibre binaries not viable"
 msgstr "DB er ikke skrivbar"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Utførelsestillatelser mangler"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing Calibre"
 msgstr "Feil ved kjøring av UnRar"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr "Sett alle bøker i kø for sikkerhetskopiering av metadata"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Kobo oppsett"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Registrer deg hos %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "E-postserveren er ikke konfigurert, kontakt administratoren din!"
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1858,35 +1830,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, fuzzy, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "du er nå logget på som: '%(nickname)s'"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Link til %(oauth)s lyktes"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1894,4157 +1866,4089 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr "E-postserveren er ikke konfigurert, kontakt administratoren din!"
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "Fjern koblingen til %(oauth)s"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Fjern koblingen til %(oauth)s mislyktes"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "Ikke koblet til %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Kunne ikke logge på med GitHub."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Kunne ikke hente brukerinformasjon fra GitHub."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Kunne ikke logge på med Google."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Kunne ikke hente brukerinformasjon fra Google."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "Failed to log in with Generic OAuth."
 msgstr "Kunne ikke logge på med GitHub."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "GitHub Oauth-feil, prøv igjen senere."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "GitHub Oauth-feil: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Google Oauth-feil, prøv igjen senere."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Google Oauth-feil: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, fuzzy, python-brace-format
 msgid "OAuth error: {}"
 msgstr "GitHub Oauth-feil: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 #, fuzzy
 msgid "Alphabetical Books"
 msgstr "Slett bok"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr ""
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Hot bøker"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr ""
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Topprangerte bøker"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr ""
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "Nedlastede bøker"
 
-#: cps/opds.py:183
+#: cps/opds.py
 #, fuzzy
 msgid "The latest Books"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/opds.py:188
+#: cps/opds.py
 #, fuzzy
 msgid "Random Books"
 msgstr "Vis tilfeldige bøker"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Vis tilfeldige bøker"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Lese bøker"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Gjeldende versjon"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Uleste bøker"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Forfattere"
 
-#: cps/opds.py:213
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by Author"
 msgstr "Bøker per side"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Forlag"
 
-#: cps/opds.py:219
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by publisher"
 msgstr "Bøker per side"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Kategorier"
 
-#: cps/opds.py:225
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by category"
 msgstr "Bøker per side"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Serie"
 
-#: cps/opds.py:231
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by series"
 msgstr "Bøker per side"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Språk"
 
-#: cps/opds.py:237
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by Languages"
 msgstr "Bøker per side"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Vurderinger"
 
-#: cps/opds.py:243
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by Rating"
 msgstr "Bøker per side"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Filformater"
 
-#: cps/opds.py:249
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by file formats"
 msgstr "Bøker per side"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr ""
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr ""
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Offentlig hylle"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Feil ved sletting av hylle"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "Beskrivelse"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} Stjerner"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Søk"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Logg Inn"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Token ikke funnet"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Token har utløpt"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Suksess! Gå tilbake til enheten din"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Bøker"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Vis nyere bøker"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Vis populære bøker"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Nedlastede bøker"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Vis nedlastede bøker"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Vis best rangerte bøker"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Read and Unread"
 msgstr "Vis lest og ulest"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Vis ulest"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Oppdage"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Category Section"
 msgstr "Vis kategorivalg"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Series Section"
 msgstr "Vis serieutvalg"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Author Section"
 msgstr "Vis forfattervalg"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Publisher Section"
 msgstr "Vis utgivervalg"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Language Section"
 msgstr "Vis språkvalg"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Ratings Section"
 msgstr "Vis vurderingsvalg"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show File Formats Section"
 msgstr "Vis valg av filformater"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Arkiverte bøker"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Archived Books"
 msgstr "Vis arkiverte bøker"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Bøker Liste"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Vis bokliste"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr ""
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Vis best rangerte bøker"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Publisert etter "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Publisert før "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Vurdering <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Vurdering >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, fuzzy, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Lesestatus = %(status)s"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr "Feil ved søk etter egendefinerte kolonner. Start Calibre-Web på nytt"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Avansert søk"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Ugyldig hylle er angitt"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "Beklager at du ikke har lov til å legge til en bok i den hyllen"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "Boken er allerede en del av hyllen: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "Boken er lagt til i hyllen: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "Du har ikke lov til å legge en bok i hyllen"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Bøker er allerede en del av hyllen: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "Bøker er lagt til i hyllen: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Kunne ikke legge til bøker i hyllen: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "Ugyldig hylle er angitt"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Kunne ikke legge til bøker i hyllen: %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Bøker er allerede en del av hyllen: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "Bøker er lagt til i hyllen: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "Boken er fjernet fra hyllen: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "Beklager at du ikke har lov til å fjerne en bok fra denne hyllen"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Lag en hylle"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Beklager at du ikke har lov til å redigere denne hyllen"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Rediger en hylle"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "Feil ved sletting av hylle"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "Hylle slettet"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Endre rekkefølgen på hylle: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "Beklager at du ikke har lov til å opprette en offentlig hylle"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Hylle %(title)s opprettet"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Hylle %(title)s endret"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "det var en feil"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "En offentlig hylle med navnet '%(title)s' eksisterer allerede."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "En privat hylle med navnet '%(title)s' eksisterer allerede."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Hylle: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Feil ved åpning av hylle. Hylle finnes ikke eller er ikke tilgjengelig"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Skriv inn Språk"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Anonym"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Uautentisert"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Ja"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Nei"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Les status"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr ""
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr ""
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr ""
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr ""
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr ""
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Forfatter"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr ""
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Lukk"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Slett"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Slå sammen"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Forlegger"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr ""
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Tittel"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Laste opp"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr ""
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Admin"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr ""
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Kilde"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr ""
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "Konvertere"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "nedlasting"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Redigere"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Aktiver Kobo-synkronisering"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Kryptering"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Identifikatorer"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Språk"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Passord"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Havn"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Vurdering"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr ""
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr ""
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Lagre"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr ""
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Tagger"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr ""
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Oppgaver"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr ""
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Brukernavn"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr ""
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Venter"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Mislyktes"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Startet"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Ferdig"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "Endte"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "avbrutt"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Ukjent status"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Uventede data under lesing av oppdateringsinformasjon"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr ""
 "Ingen oppdatering tilgjengelig. Du har allerede den nyeste versjonen "
 "installert"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6052,15 +5956,15 @@ msgstr ""
 "En ny oppdatering er tilgjengelig. Klikk på knappen nedenfor for å oppdatere "
 "til siste versjon."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Kunne ikke hente oppdateringsinformasjon"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr "Klikk på knappen nedenfor for å oppdatere til siste stabile versjon."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6069,326 +5973,324 @@ msgstr ""
 "En ny oppdatering er tilgjengelig. Klikk på knappen nedenfor for å oppdatere "
 "til versjon: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Ingen utgivelsesinformasjon tilgjengelig"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Discover (tilfeldige bøker)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Hot Books (mest nedlastede)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "Lastet ned bøker av %(user)s"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Forfatter: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Utgiver: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Serie: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "Vurdering: Ingen"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Rangering: %(rating)s stjerner"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Filformat: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Kategori: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Språk: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Hot bøker"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Se bøker"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "Feil ved sletting av hylle"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "Ugyldig format for e-postadresse"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 #, fuzzy
 msgid "Invalid request"
 msgstr "Ugyldig rolle"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr ""
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 #, fuzzy
 msgid "Error creating shelf"
 msgstr "Feil ved sletting av hylle"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Lag en hylle"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 #, fuzzy
 msgid "Shelf name is required"
 msgstr "Dette feltet er obligatorisk"
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "Feil ved sletting av hylle"
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "Rediger en hylle"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "Bruker ikke funnet"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "{} brukere ble slettet"
 
-#: cps/web.py:1710
+#: cps/web.py
 #, fuzzy
 msgid "Error duplicating shelf"
 msgstr "Feil ved sletting av hylle"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 #, fuzzy
 msgid "Error deleting shelf"
 msgstr "Feil ved sletting av hylle"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "Feil ved sletting av hylle"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 #, fuzzy
 msgid "Error unhiding shelf"
 msgstr "Feil ved sletting av hylle"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Nedlastinger"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Liste over filformater"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 #, fuzzy
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Vennligst konfigurer SMTP-postinnstillingene først..."
 
-#: cps/web.py:2400
+#: cps/web.py
 #, fuzzy
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 "Vennligst oppdater profilen din med en gyldig Send til Kindle-e-postadresse."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, fuzzy, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "Boken ble satt i kø for sending til %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, fuzzy, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Oops! Det oppsto en feil ved sending av denne boken: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "Boken ble satt i kø for sending til %(eReadermail)s"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Registrere"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 #, fuzzy
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr "E-postserveren er ikke konfigurert, kontakt administratoren din!"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr "E-postserveren er ikke konfigurert, kontakt administratoren din!"
 
-#: cps/web.py:2570
+#: cps/web.py
 #, fuzzy
 msgid "Oops! Your Email is not allowed."
 msgstr "Din e-post kan ikke registreres"
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr ""
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
 msgstr "E-postserveren er ikke konfigurert, kontakt administratoren din!"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "E-postserveren er ikke konfigurert, kontakt administratoren din!"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 #, fuzzy
 msgid "Cannot activate LDAP authentication"
 msgstr "Kan ikke aktivere LDAP-autentisering"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr ""
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, fuzzy, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "du er nå logget på som: '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "du er nå logget på som: '%(nickname)s'"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
 msgstr "E-postserveren er ikke konfigurert, kontakt administratoren din!"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6397,716 +6299,686 @@ msgstr ""
 "Reservepålogging som: '%(nickname)s', LDAP-serveren er ikke tilgjengelig, "
 "eller brukeren er ukjent"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, fuzzy, python-format
 msgid "Could not login: %(message)s"
 msgstr "Kunne ikke logge på: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 #, fuzzy
 msgid "Wrong Username or Password"
 msgstr "Vennligst skriv inn gyldig brukernavn for å tilbakestille passordet"
 
-#: cps/web.py:2832
+#: cps/web.py
 #, fuzzy
 msgid "New Password was sent to your email address"
 msgstr "Nytt passord ble sendt til e-postadressen din"
 
-#: cps/web.py:2836
+#: cps/web.py
 #, fuzzy
 msgid "An unknown error occurred. Please try again later."
 msgstr "En ukjent feil oppstod. Prøv igjen senere."
 
-#: cps/web.py:2838
+#: cps/web.py
 #, fuzzy
 msgid "Please enter valid username to reset password"
 msgstr "Vennligst skriv inn gyldig brukernavn for å tilbakestille passordet"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, fuzzy, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "du er nå logget på som: '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 #, fuzzy
 msgid "Success! Profile Updated"
 msgstr "Profil oppdatert"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr ""
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 #, fuzzy
 msgid "Invalid book ID."
 msgstr "Ugyldig rolle"
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr ""
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "Fant ingen gyldig gmail.json-fil med OAuth-informasjon"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "%(book)s sendes til E-Reader"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "Send til E-Reader"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-send completed successfully"
 msgstr "{} brukere ble slettet"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr ""
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr ""
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s sendes til E-Reader"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Caliber ebook-convert %(tool)s ble ikke funnet"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "%(format)s format ikke funnet på disken"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "Ebook-konvertering mislyktes med ukjent feil"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Kepubify-konvertering mislyktes: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr "Konvertert fil ikke funnet eller mer enn én fil i mappen %(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Caliber mislyktes med feil: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Ebook-konvertering mislyktes: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Kobler til Caliber-databasen på nytt"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "Slett bok"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Slett bok"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Pakker ut oppdateringspakken"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Merket ble ikke funnet"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Aktiver Kobo-synkronisering"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "E-post"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr "Sikkerhetskopierer metadata"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "I biblioteket"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "Genererte %(count)s forsideminiatyrbilder"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "Forsideminiatyrbilder"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "Genererte {0} serieminiatyrbilder"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "Tømmer cache for miniatyrbilde for omslag"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 msgid "Book organizer"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Passord"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Lag en hylle"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "Vis forfattervalg"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Vurderinger"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "Velg et alternativ"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "Rediger en hylle"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 #, fuzzy
 msgid "(Public)"
 msgstr "Offentlig hylle"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "Nedlastinger"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Nedlastinger"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "Sorter etter bokdato, nyeste først"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "Sorter etter bokdato, eldste først"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Forfatter"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Forfatter"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Publisert før "
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Publisert før "
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Sorter etter bokdato, nyeste først"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "Sorter etter bokdato, eldste først"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Send to eReader Email"
 msgstr "Send til E-Reader E-postadresse"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "Send til E-Reader"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Se bøker"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Offentlig hylle"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr ""
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "Importer LDAP-brukere"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Innstillinger for e-postserver"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "SMTP vertsnavn"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "SMTP-port"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "SMTP-pålogging"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 #, fuzzy
 msgid "From Email"
 msgstr "Fra e-post"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Service"
 msgstr "E-posttjeneste"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail via Oauth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Caliber Database Directory"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Loggnivå"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Ekstern port"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Bøker per side"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Opplastinger"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Anonym surfing"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Offentlig registrering"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Magic Link ekstern pålogging"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Omvendt proxy-pålogging"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Omvendt proxy-overskriftsnavn"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Rediger grunnleggende konfigurasjon"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Rediger UI-konfigurasjon"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Rediger Caliber-databasekonfigurasjon"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "Planlagte oppgaver"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Start Time"
 msgstr "Startet"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 #, fuzzy
 msgid "Maximum Duration"
 msgstr "Maksimal oppgavevarighet"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "Generer serieomslagsminiatyrbilder"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Koble til Caliber-databasen på nytt"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr ""
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Refresh Thumbnail Cache"
 msgstr "Oppdater thumbnail cover Cache"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 msgid "Setup KOReader Sync"
 msgstr ""
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr ""
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Administrasjon"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Last ned feilsøkingspakken"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Vis logger"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Omstart"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Skru av"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "Versjonsinformasjon"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Versjon"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Detaljer"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "Oppdatering mislyktes:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Oppdater kanalen"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Current Version"
 msgstr "Gjeldende versjon"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Se etter oppdatering"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Utfør oppdatering"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Er du sikker på at du vil starte på nytt?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Er du sikker på at du vil slå av?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Oppdaterer, vennligst ikke last inn denne siden på nytt"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7114,618 +6986,595 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 msgid "for books not in this library (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Uploading..."
 msgstr "Laster inn..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "Oppdatering mislyktes:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Tilkoblingsfeil"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Serie: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "via"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "I biblioteket"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "redusere"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Mer av"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Slett bok"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Slett formater:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Konverter bokformat:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Konverter fra:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "select an option"
 msgstr "Velg et alternativ"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Konvertere til:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Konverter bok"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 #, fuzzy
 msgid "Error"
 msgstr "Serverport"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Last opp format"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "Serie-ID"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Publiseringsdato"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Identifikatortype"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Identifikatorverdi"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Ta bort"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Legg til identifikator"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Hent omslag fra URL (JPEG - Bilde vil bli lastet ned og lagret i databasen)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Last opp cover fra lokal disk"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "Aktiver Kobo-synkronisering"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Se bok på Lagre"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Hent metadata"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Nøkkelord"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "Søk nøkkelord"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Laster inn..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Søkefeil!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "Ingen resultater! Prøv et annet søkeord."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "Dette feltet er obligatorisk"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 #, fuzzy
 msgid " Exchange author & title"
 msgstr "Bytt forfatter og tittel"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "Lag en hylle"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr ""
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Update Title Sort automatically  "
 msgstr "Oppdater tittelsortering automatisk"
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Oppdater forfattersortering automatisk"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Skriv inn tittel"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Skriv inn tittelsortering"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Tittelsortering"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Skriv inn forfattersortering"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Forfatter Sort"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Skriv inn forfattere"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Skriv inn kategorier"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Gå inn i serien"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Skriv inn Språk"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Publiseringsdato"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Skriv inn Publishers"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Skriv inn kommentarer"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Comments"
 msgstr "Kommentarer"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Archived?"
 msgstr "Arkiverte bøker"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Read?"
 msgstr "redusere"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "Tast inn "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Er du virkelig sikker?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "Bøker med tittel vil bli slått sammen fra:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "Til bok med tittel:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr ""
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr ""
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr ""
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr ""
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr ""
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 #, fuzzy
 msgid "Edit Metadata"
 msgstr "redigere metadata"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "Lag en hylle"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr ""
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr "E-postserveren er ikke konfigurert, kontakt administratoren din!"
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 #, fuzzy
 msgid "Message"
 msgstr "Slå sammen"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Nytt passord ble sendt til e-postadressen din"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Send til E-Reader"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Plassering av Caliber-databasen"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7741,13 +7590,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7758,7 +7607,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7769,43 +7618,43 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr ""
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
 "can be wherever you desire"
 msgstr ""
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Bruker du Google Disk?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Autentiser Google Disk"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Google Drive Caliber-mappe"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "Metadata Se kanal-ID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Oppheve"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Koble til Caliber-databasen på nytt"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7815,131 +7664,131 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "Er du sikker på at du vil slå av?"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Koble til Caliber-databasen på nytt"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr "Ny db-plassering er ugyldig, vennligst skriv inn gyldig bane"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Bruk standardautentisering"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Bruk LDAP-autentisering"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Bruk OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Serverkonfigurasjon"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Serverport"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL-sertfilplassering (la den stå tom for ikke-SSL-servere)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL-nøkkelfilplassering (la den stå tom for ikke-SSL-servere)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Oppdater kanalen"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Stabil"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Nattlig"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "Klarerte verter (kommaseparert)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Loggfilkonfigurasjon"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "Plassering og navn på tilgangsloggfil (access.log for ingen oppføring)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Aktiver tilgangslogg"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "Plassering og navn på tilgangsloggfil (access.log for ingen oppføring)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "Serverkonfigurasjon"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 "Konverter ikke-engelske tegn i tittel og forfatter mens du lagrer på disk"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Aktiver opplastinger"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr "(Vennligst sørg for at brukerne også har opplastingsrettigheter)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Tillatte opplastingsfilformater"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Aktiver anonym surfing"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Aktiver offentlig registrering"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Use Email as Username"
 msgstr "Bruk e-post som brukernavn"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Aktiver Magic Link Remote Login"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7947,154 +7796,154 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Ukjente proxy-forespørsler til Kobo Store"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Server ekstern port (for portviderekoblede API-anrop)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Bruk Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Goodreads API-nøkkel"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Hardcover Sync"
 msgstr "Aktiver Kobo-synkronisering"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "Token har utløpt"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Goodreads API-nøkkel"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8102,421 +7951,421 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Tillat omvendt proxy-autentisering"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Påloggingstype"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "LDAP-serverens vertsnavn eller IP-adresse"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "LDAP-serverport"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "LDAP-kryptering"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "LDAP CACertificate Path (Kun nødvendig for klientsertifikatautentisering)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr "LDAP-sertifikatbane (kun nødvendig for klientsertifikatautentisering)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr "LDAP-nøkkelfilbane (kun nødvendig for klientsertifikatautentisering)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "LDAP-autentisering"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Enkel"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "LDAP-administratorbrukernavn"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "LDAP-administratorpassord"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "LDAP Distinguished Name (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "LDAP-brukerobjektfilter"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "LDAP Server er OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr "Følgende innstillinger er nødvendig for brukerimport"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "LDAP gruppeobjektfilter"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "LDAP-gruppenavn"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "Felt for LDAP-gruppemedlemmer"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "LDAP-medlemsbrukerfilterdeteksjon"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr ""
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Member User Filter"
 msgstr "LDAP-medlemsbrukerfilterdeteksjon"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "Hent metadata"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
 msgstr ""
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "Rediger UI-konfigurasjon"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "Token ikke funnet"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "Tilkoblingsfeil"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "Vis forfattervalg"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 msgid "OAuth Client Id"
 msgstr ""
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 msgid "OAuth Client Secret"
 msgstr ""
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "Konfigurasjon"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "Brukernavn"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr ""
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "E-posttjeneste"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr ""
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "LDAP-gruppenavn"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr ""
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr ""
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Allow Downloads"
 msgstr "Nedlastinger"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Allow eBook Viewer"
 msgstr "Vis nyere bøker"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Allow Uploads"
 msgstr "Aktiver opplastinger"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Allow Edit"
 msgstr "Tillate"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Allow Delete Books"
 msgstr "Vis nyere bøker"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Allow Changing Password"
 msgstr "Passord"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr ""
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr ""
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr ""
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr ""
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr ""
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "External binaries"
 msgstr "Ekstern port"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr ""
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Calibre E-Book Converter Settings"
 msgstr "Caliber ebook-convert %(tool)s ble ikke funnet"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr ""
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "Plassering av Caliber-databasen"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Security Settings"
 msgstr "Vis forfattervalg"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8524,340 +8373,335 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr ""
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr ""
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr ""
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Session protection"
 msgstr "Velg et alternativ"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr ""
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr ""
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 msgid "User Password policy"
 msgstr ""
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr ""
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr ""
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "View Configuration"
 msgstr "Konfigurasjon"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "Slett"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Konfigurasjon"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 msgid "Custom CSS"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "Versjon"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Admin User"
 msgstr "Legg til ny bruker"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "Admin side"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Language"
 msgstr "Språk"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 msgid "Default interface language for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Visible Language of Books"
 msgstr "Språk"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 msgid "Default book language filter for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Random Books in Detail View"
 msgstr "Vis tilfeldige bøker"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr ""
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Laste opp"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "Arkiverte bøker"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "nedlasting"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 #, fuzzy
 msgid "Start"
 msgstr "Omstart"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8866,14 +8710,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8881,96 +8725,95 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "{} brukere ble slettet"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "Feil ved sletting av hylle"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "Merket ble ikke funnet"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "Brukernavn"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "I biblioteket"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "Lag en hylle"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "Feil ved sletting av hylle"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Calibre-Web-konfigurasjonen er oppdatert"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8978,11 +8821,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -8993,11 +8836,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -9007,162 +8850,162 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "Arkiverte bøker"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9170,11 +9013,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9182,110 +9025,108 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "Metadata ble oppdatert"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identifikatorer"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "Dekke"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
 "investigation."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9293,157 +9134,157 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Vis forfattervalg"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "Vurderinger"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "Vis forfattervalg"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9451,102 +9292,101 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Vis forfattervalg"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9554,44 +9394,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Konverter bokformat:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9599,990 +9439,972 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Aktiver offentlig registrering"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Vis forfattervalg"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Aktiver offentlig registrering"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Aktiver offentlig registrering"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Slett formater:"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Hent metadata"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Vurdering"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Next"
 msgstr "Admin side"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr ""
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Rediger en hylle"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Rediger en hylle"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr ""
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, fuzzy
 msgid "Add to archive"
 msgstr "Rediger en hylle"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "Rediger en hylle"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "I biblioteket"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "Databaseinnstillinger oppdatert"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "Vurdering: Ingen"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, fuzzy, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "Sletting av bok %(index)s mislyktes: %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr ""
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, fuzzy
 msgid "Description:"
 msgstr "Beskrivelse"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "Send til E-Reader E-postadresse"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "Send til E-Reader E-postadresse"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "Lag en hylle"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "Slett formater:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "Kunne ikke opprette bane for dekning"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "Kunne ikke opprette bane for dekning"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr ""
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Slett bok"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "Vis best rangerte bøker"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "Slett"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Slett bok"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 msgid "Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "Detaljer"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "redigere metadata"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "Merket ble ikke funnet"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr ""
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Slett formater:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 msgid "The following books will be permanently deleted:"
 msgstr ""
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "Uleste bøker"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 msgid "The following book will be kept:"
 msgstr ""
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 msgid "The following books will be merged into it (and then deleted):"
 msgstr ""
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr ""
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr ""
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr ""
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr ""
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr ""
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr ""
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr ""
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr ""
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "SMTP Password"
 msgstr "Passord"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr ""
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Save and Send Test Email"
 msgstr "Send til E-Reader E-postadresse"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr ""
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr ""
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Enter domainname"
 msgstr "Skriv inn kommentarer"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr ""
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr ""
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "Lag en hylle"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "Søkefeil!"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "Se bok på Lagre"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "Lag en hylle"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "Laster inn..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
@@ -10590,1466 +10412,1458 @@ msgid ""
 msgstr ""
 "Er du sikker på at du vil endre den valgte rollen for den(e) valgte brukeren?"
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "Kunne ikke opprette bane for dekning"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr ""
 "Er du sikker på at du vil endre den valgte rollen for den(e) valgte brukeren?"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "Lag en hylle"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "Kunne ikke opprette bane for dekning"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "E-postserveren er ikke konfigurert, kontakt administratoren din!"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 #, fuzzy
 msgid "Create Issue"
 msgstr "Lag en hylle"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr ""
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 #, fuzzy
 msgid "Logout User"
 msgstr "Rediger brukere"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "Rediger en hylle"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Show this shelf in your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "Vis alt"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "Offentlig hylle"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Rediger en hylle"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr ""
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Toggle Navigation"
 msgstr "Loggfilkonfigurasjon"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Search Library"
 msgstr "I biblioteket"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Calibre-Web test e-post"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr ""
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "Vurderinger"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "I biblioteket"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Ingen utgivelsesinformasjon tilgjengelig"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Calibre-Web test e-post"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Slett bok"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Please do not refresh the page"
 msgstr "Oppdaterer, vennligst ikke last inn denne siden på nytt"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Lag en hylle"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr ""
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Book Details"
 msgstr "Detaljer"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Er du sikker på at du vil slå av?"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Last opp format"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Slett formater:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Slett bok"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Merket ble ikke funnet"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 msgid "Scroll to top"
 msgstr ""
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfigurasjon"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Rediger en hylle"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Slett bok"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Slett bok"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Lag en hylle"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Tilkoblingsfeil"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr ""
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr ""
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "Passord"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr ""
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 #, fuzzy
 msgid "Forgot Password?"
 msgstr "Passord"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr ""
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 msgid "Log in with SSO"
 msgstr ""
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr ""
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Calibre-Web Log: "
 msgstr "Calibre-Web test e-post"
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr ""
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Show Access Log: "
 msgstr "Aktiver tilgangslogg"
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Download Calibre-Web Log"
 msgstr "Aktiver tilgangslogg"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Download Access Log"
 msgstr "Aktiver tilgangslogg"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 msgid "Share with Everyone (Public)"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Enter Tag"
 msgstr "Tast inn "
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Choose File Location"
 msgstr "Vis valg av filformater"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "name"
 msgstr "Brukernavn"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Parent Directory"
 msgstr "Caliber Database Directory"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr ""
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Calibre-Web test e-post"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 #, fuzzy
 msgid "epub Reader"
 msgstr "Send til E-Reader"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "Vurderinger"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr ""
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr ""
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Admin side"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr ""
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 #, fuzzy
 msgid "Default"
 msgstr "Slett"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr ""
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr ""
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 #, fuzzy
 msgid "KaiTi"
 msgstr "Venter"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 #, fuzzy
 msgid "Arial"
 msgstr "E-post"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 #, fuzzy
 msgid "Spread"
 msgstr "redusere"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 #, fuzzy
 msgid "Two columns"
 msgstr "Ugyldig lesekolonne"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 #, fuzzy
 msgid "One column"
 msgstr "Ugyldig lesekolonne"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr ""
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr ""
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr ""
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Next Page"
 msgstr "Admin side"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page Display"
 msgstr "Admin side"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr ""
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr ""
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr ""
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr ""
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Rotate Right"
 msgstr "Startet"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Rotate Left"
 msgstr "Startet"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr ""
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page"
 msgstr "Admin side"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr ""
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr ""
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr ""
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr ""
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Height"
 msgstr "Nattlig"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Native"
 msgstr "Lagre"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Rotate"
 msgstr "Startet"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr ""
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr ""
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr ""
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Direction"
 msgstr "Beskrivelse"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr ""
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr ""
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr ""
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 msgid "Remember Position"
 msgstr ""
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr ""
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Show"
 msgstr "Vis alt"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr ""
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr ""
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 #, fuzzy
 msgid "txt Reader"
 msgstr "Send til E-Reader"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr ""
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 #, fuzzy
 msgid "Choose a username"
 msgstr "Bruk e-post som brukernavn"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 #, fuzzy
 msgid "Your Email"
 msgstr "Fra e-post"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr ""
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr ""
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr ""
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 #, fuzzy
 msgid "Generate Series Cover Thumbnails"
 msgstr "Generer serieomslagsminiatyrbilder"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 #, fuzzy
 msgid "No Results Found"
 msgstr "Merket ble ikke funnet"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 #, fuzzy
 msgid "Search Term:"
 msgstr "Søkefeil!"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 #, fuzzy
 msgid "Results for:"
 msgstr "Merket ble ikke funnet"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Published Date From"
 msgstr "Publisert etter "
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Published Date To"
 msgstr "Publisert etter "
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr ""
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Exclude Tags"
 msgstr "Skriv inn Språk"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Exclude Series"
 msgstr "Gå inn i serien"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Exclude Shelves"
 msgstr "Skriv inn Språk"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Exclude Languages"
 msgstr "Skriv inn Språk"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr ""
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr ""
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Rating Above"
 msgstr "Vurdering: Ingen"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Rating Below"
 msgstr "Vurdering: Ingen"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr ""
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr ""
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Delete this Shelf"
 msgstr "Lag en hylle"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr ""
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Se bøker"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr ""
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr ""
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr ""
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, python-format
 msgid "Add %(count)s"
 msgstr ""
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Token ikke funnet"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Lag en hylle"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Rediger en hylle"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "I biblioteket"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "I biblioteket"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr ""
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr ""
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Bruker ikke funnet"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Hidden Book"
 msgstr "Se bøker"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 #, fuzzy
 msgid "Library Statistics"
 msgstr "Statistikk"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr ""
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr ""
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr ""
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr ""
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 #, fuzzy
 msgid "System Statistics"
 msgstr "Statistikk"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr ""
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 #, fuzzy
 msgid "Installed Version"
 msgstr "ikke installert"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr ""
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Actions"
 msgstr "Vurderinger"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "Startet"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
 msgstr ""
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "{} brukere ble slettet"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Calibre-Web test e-post"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "Fra e-post"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "Vurderinger"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr ""
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "Serverkonfigurasjon"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "Send til E-Reader E-postadresse"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "Skriv inn Språk"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Language of Books"
 msgstr "Språk"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "Ikke oppgitt gyldig bokspråk"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "OAuth Settings"
 msgstr "Vis forfattervalg"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr ""
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr ""
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr ""
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 msgid "Expose only books in selected shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "Vis forfattervalg"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr ""
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "Vis nyere bøker"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "Offentlig hylle"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 #, fuzzy
 msgid "Delete User"
 msgstr "Kan ikke slette gjestebruker"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12057,165 +11871,165 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Passord"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Passord"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Lag en hylle"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr ""
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Select..."
 msgstr "Slett"
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Fjern valg"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit User"
 msgstr "Rediger brukere"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Username"
 msgstr "Brukernavn"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Email"
 msgstr "Test e-post"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email"
 msgstr "Send til E-Reader E-postadresse"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email"
 msgstr "Send til E-Reader E-postadresse"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "Send til E-Reader E-postadresse"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "Send til E-Reader E-postadresse"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr ""
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Visible Book Languages"
 msgstr "Ikke oppgitt gyldig bokspråk"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr ""
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Allowed Tags"
 msgstr "Aktiver opplastinger"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr ""
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Denied Tags"
 msgstr "Tast inn "
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Change Password"
 msgstr "Passord"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Public Shelves"
 msgstr "Offentlig hylle"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 msgid "Expose selected Shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Read/Unread Section"
 msgstr "Vis serieutvalg"

--- a/cps/translations/pl/LC_MESSAGES/messages.po
+++ b/cps/translations/pl/LC_MESSAGES/messages.po
@@ -22,40 +22,40 @@ msgstr ""
 "Generated-By: Babel 2.13.1\n"
 "X-Generator: Poedit 3.9\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Statystyki"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 "Baza danych Calibre jest niedostępna. Skonfiguruj ponownie ścieżkę do "
 "biblioteki."
 
-#: cps/admin.py:208
+#: cps/admin.py
 msgid "Server restarted, please reload page."
 msgstr "Serwer uruchomiony ponownie, proszę odświeżyć stronę."
 
-#: cps/admin.py:210
+#: cps/admin.py
 msgid "Performing Server shutdown, please close window."
 msgstr "Wyłączanie serwera, proszę zamknąć okno."
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "Sukces! Połączono ponownie z bazą danych"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Nieznane polecenie"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 "Sukces! Książki zakolejkowane do kopii zapasowej metadanych, sprawdź "
 "Zadania, aby zobaczyć wynik"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
@@ -63,7 +63,7 @@ msgstr ""
 "Błąd: synchronizacja z Hardcover jest wyłączona. Włącz ją w Podstawowej "
 "Konfiguracji lub za pomocą zmiennej HARDCOVER_SYNC_ENABLED."
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
@@ -71,48 +71,48 @@ msgstr ""
 "Błąd: brak dostępnego tokenu Hardcover. Ustaw zmienną środowiskową "
 "HARDCOVER_TOKEN lub skonfiguruj ją w Podstawowej Konfiguracji."
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 "Sukces! Rozpoczęto zadanie automatycznego pobierania z Hardcover. Postęp "
 "sprawdzisz w panelu Zadania."
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 "Błąd podczas uruchamiania zadania automatycznego pobierania z Hardcover: "
 "%(error)s"
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr "Przejrzyj dopasowania Hardcover"
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr "Błąd podczas wczytywania kolejki do przeglądu: %(error)s"
 
-#: cps/admin.py:414
+#: cps/admin.py
 msgid "Hardcover ID applied successfully"
 msgstr "Identyfikator Hardcover został pomyślnie zastosowany"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr "Dopasowanie: %(action)s"
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr "Brak oczekujących dopasowań do odrzucenia"
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr "Odrzuconych dopasowań: %(count)s"
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
@@ -120,117 +120,115 @@ msgstr ""
 "Rozpoczęto odświeżanie pamięci podręcznej miniatur dla książek: {}. Może to "
 "potrwać kilka minut."
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr "Nie znaleziono książek z okładkami do przetworzenia."
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr "Nie udało się rozpocząć odświeżania miniatur: {}"
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Panel administratora"
 
-#: cps/admin.py:653
+#: cps/admin.py
 msgid "Hardcover token expires"
 msgstr "Token Hardcover wygasa"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Konfiguracja Podstawowa"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Konfiguracja Interfejsu"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 "Kolumna niestandardowa nr %(column)d nie istnieje w bazie danych Calibre"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Edytuj Użytkowników"
 
 # ???
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Wszystko"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Nie znaleziono użytkownika"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} użytkowników usuniętych pomyślnie"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Pokaż wszystkie"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Nieprawidłowo sformułowane żądanie"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "Nazwa gościa nie może być zmieniona"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "Gość nie może pełnić tej roli"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr "Nie pozostał żaden administrator, nie można usunąć roli administratora"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "Wartość musi być prawdziwa lub fałszywa"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Nieprawidłowa rola"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "Gość nie może tego zobaczyć"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "Nieprawidłowy widok"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 "Lokalizacja gościa jest określana automatycznie i nie można jej ustawić"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Nie podano prawidłowej lokalizacji"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Nie podano obowiązującego języka książki"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Nie znaleziono parametru"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "Baza danych ustawień nie jest zapisywalna"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
@@ -239,54 +237,54 @@ msgstr ""
 "istniejącej biblioteki nie powiodła się — książki mogą zachować poprzednią "
 "kolejność do czasu ponownej próby lub edycji."
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Nieprawidłowa kolumna odczytu"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Nieprawidłowa kolumna z ograniczeniami"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr "Konfiguracja Calibre-Web NextGen została zaktualizowana"
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Czy na pewno chcesz usunąć Token Kobo?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "Czy naprawdę chcesz usunąć tę domenę?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "Czy naprawdę chcesz usunąć tego użytkownika?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Czy na pewno chcesz usunąć półkę?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr ""
 "Czy na pewno chcesz zmienić ustawienia lokalne wybranego użytkownika(ów)?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "Czy na pewno chcesz zmienić widoczne języki książek dla wybranego "
 "użytkownika (użytkowników)?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 "Czy na pewno chcesz zmienić wybraną rolę dla wybranego użytkownika "
 "(użytkowników)?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
@@ -294,7 +292,7 @@ msgstr ""
 "Czy na pewno chcesz zmienić wybrane ograniczenia dla wybranego "
 "użytkownika(ów)?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -302,25 +300,25 @@ msgstr ""
 "Czy na pewno chcesz zmienić wybrane ograniczenia widoczności dla wybranego "
 "użytkownika(ów)?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "Czy na pewno chcesz zmienić zachowanie synchronizacji półek dla wybranego "
 "użytkownika(ów)?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
 msgstr ""
 "Czy na pewno chcesz zmienić udostępnianie półek przez OPDS dla wybranego "
 "użytkownika(ów)?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Czy na pewno chcesz zmienić lokalizację biblioteki Calibre?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
@@ -328,7 +326,7 @@ msgstr ""
 "Calibre-Web NextGen wyszuka zaktualizowane okładki i odświeży ich miniatury, "
 "może to chwilę potrwać. Kontynuować?"
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
@@ -336,29 +334,25 @@ msgstr ""
 "Czy na pewno chcesz usunąć bazę danych synchronizacji Calibre-Web NextGen, "
 "aby wymusić pełną synchronizację z czytnikiem Kobo?"
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Zabroń"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Zezwalaj"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "Usunięto {} wpisów synchronizacji"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, python-brace-format
 msgid "Book {} not found"
 msgstr "Nie znaleziono książki {}"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
@@ -367,7 +361,7 @@ msgstr ""
 "Wyczyszczono stan synchronizacji książki {0} (użytkownik {1}); urządzenie "
 "ponownie otrzyma tę książkę przy następnej synchronizacji"
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
@@ -377,74 +371,73 @@ msgstr ""
 "zaktualizowano last_modified, aby urządzenie otrzymało ją przy następnej "
 "synchronizacji"
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Nie znaleziono tagu"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Nieprawidłowe działanie"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json nie został skonfigurowany dla aplikacji webowej"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Lokalizacja pliku dziennika jest nieprawidłowa, wprowadź poprawną ścieżkę"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Lokalizacja pliku dziennika dostępu jest nieprawidłowa, wprowadź poprawną "
 "ścieżkę"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 "Wprowadź dostawcę LDAP, port, nazwę wyróżniającą i identyfikator obiektu "
 "użytkownika"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Proszę wprowadzić konto i hasło usługi LDAP"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "Proszę wprowadzić konto usługi LDAP"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr "Filtr obiektów grupy LDAP musi mieć jeden identyfikator formatu \"%s\""
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "Filtr obiektów grupy LDAP ma niedopasowany nawias"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Filtr obiektów użytkownika LDAP musi mieć jeden identyfikator formatu \"%s\""
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "Filtr obiektów użytkownika LDAP ma niedopasowany nawias"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Filtr użytkownika członka LDAP musi mieć jedno \"%s\" identyfikator formatu"
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "Filtr użytkownika członka LDAP ma niedopasowane nawiasy"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -452,29 +445,24 @@ msgstr ""
 "Lokalizacja certyfikatu CA LDAP, certyfikatu lub klucza jest nieprawidłowa, "
 "wprowadź poprawną ścieżkę"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Dodaj nowego użytkownika"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Zmień ustawienia SMTP"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "Sukces! Konto Gmail zostało zweryfikowane."
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Błąd bazy danych: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -482,49 +470,49 @@ msgstr ""
 "Testowy e-mail zakolejkowany do wysłania do %(email)s, sprawdź Zadania aby "
 "zobaczyć wynik"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Wystąpił błąd podczas wysyłania e-maila testowego: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Najpierw skonfiguruj swój adres e-mail..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Zaktualizowano ustawienia serwera poczty e-mail"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 msgid "Email Your Users"
 msgstr "Wyślij e-mail do użytkowników"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Najpierw skonfiguruj serwer e-mail w Edytuj ustawienia serwera e-mail."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr "Podaj temat wiadomości e-mail z ogłoszeniem."
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr "Podaj treść wiadomości e-mail z ogłoszeniem."
 
-#: cps/admin.py:2060
+#: cps/admin.py
 msgid "Please set an email address on your own account first..."
 msgstr "Najpierw ustaw adres e-mail na swoim własnym koncie..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 msgid "Please select at least one recipient."
 msgstr "Wybierz co najmniej jednego odbiorcę."
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr "Brak prawidłowych odbiorców — nic nie zostało wysłane."
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -532,7 +520,7 @@ msgstr ""
 "Testowy e-mail z ogłoszeniem zakolejkowany do %(email)s — sprawdź Zadania, "
 "aby zobaczyć wynik."
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -541,161 +529,159 @@ msgstr ""
 "E-mail z ogłoszeniem zakolejkowany dla odbiorców: %(num)s — sprawdź Zadania, "
 "aby zobaczyć stan dostarczenia."
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr "Pominięto adresów: %(num)s jako nieprawidłowe lub zduplikowane."
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "Edytuj ustawienia zaplanowanych zadań"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "Podano nieprawidłowy czas rozpoczęcia zadania"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "Podano nieprawidłowy czas trwania zadania"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "Zaktualizowano ustawienia zaplanowanych zadań"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Wystąpił nieznany błąd. Spróbuj ponownie później."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 msgid "title"
 msgstr "tytuł"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Edytuj użytkownika %(nick)s"
 
 # ???
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Sukces! Hasło użytkownika %(user)s zostało zresetowane"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Ups! Proszę skonfigurować ustawienia poczty SMTP."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Przeglądanie dziennika"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Żądanie o pakiet aktualizacji"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Pobieranie pakietu aktualizacji"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Rozpakowywanie pakietu aktualizacji"
 
 # ???
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Zastępowanie plików"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Połączenia z bazą danych zostały zakończone"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Zatrzymywanie serwera"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Aktualizacja zakończona, proszę nacisnąć OK i odświeżyć stronę"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Aktualizacja nieudana:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "Błąd HTTP"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Błąd połączenia"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Przekroczono limit czasu podczas nawiązywania połączenia"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Błąd ogólny"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr "Plik aktualizacji nie mógł zostać zapisany w katalogu tymczasowym"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "Nie można zastąpić plików podczas aktualizacji"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "Nie udało się wyodrębnić przynajmniej jednego użytkownika LDAP"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Błąd przy tworzeniu przynajmniej jednego użytkownika LDAP"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Błąd: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Błąd. LDAP nie zwrócił żadnego użytkownika"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "Co najmniej jeden użytkownik LDAP nie został znaleziony w bazie danych"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} Użytkownik pomyślnie zaimportowany"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr "Ścieżka do książek jest nieprawidłowa"
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "Lokalizacja bazy danych jest nieprawidłowa, wprowadź poprawną ścieżkę"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "Baza danych nie jest zapisywalna"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "Lokalizacja pliku klucza jest nieprawidłowa, wprowadź poprawną ścieżkę"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Lokalizacja pliku certyfikatu jest nieprawidłowa, wprowadź poprawną ścieżkę"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
@@ -703,13 +689,13 @@ msgstr ""
 "Nie można włączyć automatycznego tworzenia użytkowników bez włączenia "
 "uwierzytelniania przez reverse proxy"
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 "Automatyczne tworzenie użytkowników wymaga podania prawidłowej nazwy "
 "nagłówka reverse proxy"
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
@@ -717,7 +703,7 @@ msgstr ""
 "Nieprawidłowy format hosta przekierowania OAuth. Podaj pełny adres URL wraz "
 "z protokołem (np. https://twoja-domena.pl)"
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
@@ -725,74 +711,74 @@ msgstr ""
 "Host przekierowania OAuth nie powinien zawierać ścieżki. Użyj samego adresu "
 "bazowego (np. https://twoja-domena.pl)"
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr "Długość hasła musi wynosić od 1 do 40 znaków"
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "Zaktualizowano ustawienia bazy danych"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "Konfiguracja bazy danych"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Ups! Proszę wypełnić wszystkie pola."
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "E-mail nie pochodzi z prawidłowej domeny"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Dodaj nowego użytkownika"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Użytkownik '%(user)s' został utworzony"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "Znaleziono istniejące konto dla tego adresu e-mail lub nazwy."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Użytkownik '%(nick)s' został usunięty"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "Nie można usunąć użytkownika gościa"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "Nie pozostał żaden administrator, nie można usunąć użytkownika"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "Adres e-mail nie może być pusty i musi być prawidłowy"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Użytkownik '%(nick)s' został zaktualizowany"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr "Połączenie udane! Punkt wykrywania OIDC jest dostępny.%(endpoints)s"
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
@@ -800,12 +786,12 @@ msgstr ""
 "Połączenie nieudane: nie znaleziono punktu wykrywania OIDC (404). Sprawdź, "
 "czy adres bazowy jest poprawny."
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr "Połączenie nieudane: Serwer zwrócił kod statusu %(code)s"
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
@@ -813,14 +799,14 @@ msgstr ""
 "Połączenie nieudane: nie można połączyć się z serwerem. Sprawdź adres URL i "
 "połączenie sieciowe."
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 "Połączenie nieudane: przekroczono limit czasu żądania. Serwer może działać "
 "wolno lub być niedostępny."
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
@@ -828,12 +814,12 @@ msgstr ""
 "Połączenie nieudane: serwer zwrócił nieprawidłowy JSON. To może nie być "
 "punkt końcowy OIDC."
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Połączenie nieudane: %(error)s"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
@@ -842,31 +828,31 @@ msgstr ""
 "W metadanych brakuje wymaganych pól OIDC: %(fields)s. To może nie być "
 "prawidłowy punkt końcowy metadanych OIDC."
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 "Adres URL metadanych jest prawidłowy! Znaleziono punktów końcowych OAuth: "
 "%(count)s."
 
-#: cps/admin.py:3322
+#: cps/admin.py
 msgid " User info endpoint is available."
 msgstr " Punkt końcowy informacji o użytkowniku jest dostępny."
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 " Uwaga: nie znaleziono punktu informacji o użytkowniku — może to powodować "
 "problemy z uwierzytelnianiem."
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 "Nie znaleziono adresu URL metadanych (404). Sprawdź, czy adres URL jest "
 "poprawny."
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
@@ -874,51 +860,51 @@ msgstr ""
 "Połączenie nieudane: nie można połączyć się z adresem URL metadanych. "
 "Sprawdź adres URL i połączenie sieciowe."
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr "Połączenie nieudane: Przekroczono limit czasu żądania."
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr "Połączenie nieudane: Nieprawidłowy JSON w odpowiedzi."
 
-#: cps/admin.py:3340
+#: cps/admin.py
 msgid "An unknown error occurred."
 msgstr "Wystąpił nieznany błąd."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 msgid "Restore already in progress."
 msgstr "Przywracanie jest już w toku."
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 "Przywracanie nie powiodło się: nie skonfigurowano ścieżki do biblioteki "
 "Calibre."
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 "Przywracanie nie powiodło się: nie znaleziono pliku metadata.db w %(path)s"
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr "Przywracanie nie powiodło się: nie znaleziono pliku app.db w %(path)s"
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Przywracanie nie powiodło się: %(err)s"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 "Przywracanie zakończone, ale czyszczenie pliku app.db nie powiodło się. "
 "Szczegóły w dzienniku."
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
@@ -927,463 +913,453 @@ msgstr ""
 "Przywracanie zakończone. Kopie zapasowe i dziennik przywracania zapisano w "
 "%(dir)s. Wszystkie dane powiązane z książkami zostały zresetowane."
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr "Importuj adnotacje z Kobo"
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 msgid "No file uploaded."
 msgstr "Nie przesłano żadnego pliku."
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr "Plik przekracza %(max)d MB."
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr "Przesłany plik nie jest bazą danych SQLite."
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr "Adnotacje: %(title)s"
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr "Czeski"
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr "Niemiecki"
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr "Grecki"
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr "Hiszpański"
 
-#: cps/constants.py:265
+#: cps/constants.py
 msgid "Finnish"
 msgstr "Fiński"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr "Francuski"
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr "Galicyjski"
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr "Węgierski"
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr "Indonezyjski"
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr "Włoski"
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr "Japoński"
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr "Khmerski"
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr "Koreański"
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr "Holenderski"
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr "Norweski"
 
-#: cps/constants.py:276
+#: cps/constants.py
 msgid "Polish"
 msgstr "Polski"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr "Portugalski"
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr "Portugalski (Brazylia)"
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr "Rosyjski"
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr "Słowacki"
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr "Słoweński"
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr "Szwedzki"
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr "Turecki"
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr "Ukraiński"
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr "Wietnamski"
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr "Chiński (uproszczony, Chiny)"
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr "Chiński (tradycyjny, Tajwan)"
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "nie zainstalowane"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Brak uprawnień do wykonywania pliku"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr "Wróć do edycji metadanych"
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr "Wróć do książki"
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, python-format
 msgid "Change cover — %(title)s"
 msgstr "Zmień okładkę — %(title)s"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr "Okładka tej książki jest zablokowana. Najpierw ją odblokuj."
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr "Podaj adres URL okładki."
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr "Ta książka nie ma osadzonej okładki, którą można wyodrębnić."
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 msgid "Unknown cover source."
 msgstr "Nieznane źródło okładki."
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr "Nie udało się zapisać stanu blokady."
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr "Podgląd jest dostępny tylko dla adresów URL http(s)."
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr "Nie udało się wyrenderować podglądu na czytniku."
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr "Nie udało się wczytać obrazu źródłowego do podglądu."
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr "Nie udało się zapisać okładki."
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr "Zmiana motywu jest tymczasowo wyłączona do wersji v5.0.0"
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 "Odświeżanie biblioteki 🔄 Sprawdzanie pominiętych książek, proszę czekać..."
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 "Nieprawidłowe wyrażenie cron dla skanowania duplikatów. Zmiany nie zostały "
 "zapisane."
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr "Ustawienia użytkownika Calibre-Web NextGen"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr "Znacznik czasu"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Book ID"
 msgstr "ID książki"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Tytuł książki"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Book Author"
 msgstr "Autor książki"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr "Typ wyzwalacza"
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Filepath"
 msgstr "Ścieżka pliku"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Filename"
 msgstr "Nazwa pliku"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr "Ręcznie?"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr "Liczba poprawek"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr "Oryginał zarchiwizowany?"
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr "Zastosowane poprawki"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr "Oryginalny format"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "End Format"
 msgstr "Format końcowy"
 
 # ???
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 msgid "Unknown User"
 msgstr "Nieznany użytkownik"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr "Statystyki i aktywność Calibre-Web NextGen"
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr "Calibre-Web NextGen - Pełna historia wymuszania"
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr "Calibre-Web NextGen - Pełna historia wymuszania (ze ścieżkami)"
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr "Calibre-Web NextGen - Pełna historia importu"
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr "Calibre-Web NextGen - Pełna historia konwersji"
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 "Calibre-Web NextGen - Pełna historia naprawy EPUB (bez ścieżek i poprawek)"
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 "Calibre-Web NextGen - Pełna historia naprawy EPUB (ze ścieżkami i poprawkami)"
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr "✅ Wszystkie usługi monitorowania działają prawidłowo! 👍"
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr "🔴 Usługa importu działa, ale detektor zmian metadanych nie działa"
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr "🔴 Detektor zmian metadanych działa, ale usługa importu nie działa"
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr "⛔ Ani usługa importu, ani detektor zmian metadanych nie działają"
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr "Wystąpił błąd"
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr "Calibre-Web NextGen - Konwertuj bibliotekę"
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr "Calibre-Web NextGen - Usługa naprawy EPUB"
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 "Naprawa pojedynczej książki EPUB nie jest obsługiwana w bibliotekach na "
 "Google Drive."
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 msgid "Invalid book selection."
 msgstr "Nieprawidłowy wybór książki."
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr "Nie znaleziono książki."
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 msgid "Selected book has no EPUB format."
 msgstr "Wybrana książka nie ma formatu EPUB."
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 msgid "EPUB file not found on disk."
 msgstr "Nie znaleziono na dysku pliku EPUB."
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 msgid "EPUB Fixer started for selected book."
 msgstr "Rozpoczęto naprawę EPUB dla wybranej książki."
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr "Nie udało się uruchomić naprawy EPUB dla wybranej książki."
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr "Musisz być administratorem, aby uzyskać dostęp do tej strony."
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr "Wymagana jest zarówno nazwa użytkownika, jak i dane obrazu."
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr "Nieprawidłowy format danych obrazu. Musi to być prawidłowy obraz."
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr "Nieobsługiwany typ obrazu. Dozwolone są tylko PNG i JPEG."
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr "Obraz jest zbyt duży. Użyj obrazu mniejszego niż 500 KB."
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr "Nieprawidłowe dane obrazu Base64."
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 msgid "Invalid image data format."
 msgstr "Nieprawidłowy format danych obrazu."
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr "Błąd podczas sprawdzania poprawności danych obrazu."
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr "Zdjęcie profilowe zostało pomyślnie zaktualizowane."
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr "Zarządzanie zdjęciem profilowym Calibre-Web NextGen (w budowie)"
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Brak"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 msgid "Duplicate Books"
 msgstr "Zduplikowane książki"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr "Grupa duplikatów została już odrzucona"
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 msgid "Duplicate group dismissed"
 msgstr "Grupa duplikatów odrzucona"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 msgid "Duplicate group restored"
 msgstr "Grupa duplikatów przywrócona"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr "Grupa duplikatów nie została odrzucona"
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 msgid "Duplicate scan queued"
 msgstr "Skanowanie duplikatów zakolejkowane"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr "Skanowanie duplikatów zakończone (tryb zapasowy)"
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 msgid "Invalid resolution strategy"
 msgstr "Nieprawidłowa strategia rozwiązywania"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
@@ -1391,96 +1367,93 @@ msgstr ""
 "Brak uprawnień do zapisu w folderze importu. Sprawdź uprawnienia woluminu /"
 "cwa-book-ingest."
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr "Brakujące lub nieprawidłowe ID książki do wysłania formatu"
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr "Nie można przesłać formatu: książka nie istnieje już w bibliotece"
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Wysyłanie zakończone, przetwarzanie, proszę czekać…"
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 msgid "Failed to queue upload for processing"
 msgstr "Nie udało się dodać wysyłania do kolejki przetwarzania"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Brak formatu źródłowego lub docelowego do konwersji"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr ""
 "Książka została pomyślnie umieszczona w zadaniach do konwersji "
 "%(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Podczas konwersji książki wystąpił błąd: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "Ten typ pliku nie jest dozwolony do wysłania na ten serwer"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr ""
 "Rozszerzenie pliku '%(ext)s' nie jest dozwolone do wysłania na ten serwer"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "Plik do wysłania musi mieć rozszerzenie"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr "Błąd otwierania e-booka. Plik nie istnieje lub jest niedostępny"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "Użytkownik nie ma uprawnień do wysłania okładki"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 "Okładka jest zablokowana. Najpierw odblokuj ją na stronie wyboru okładki."
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 "W identyfikatorach nie jest rozróżniana wielkość liter, nadpisywanie starego "
 "identyfikatora"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "'%(langname)s' nie jest prawidłowym językiem"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Metadane zostały pomyślnie zaktualizowane"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "Błąd podczas edycji książki: {}"
 
 # ???
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Nieznany"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1488,77 +1461,77 @@ msgstr ""
 "Wysłana książka prawdopodobnie istnieje w bibliotece, rozważ zmianę przed "
 "przesłaniem nowej: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "Nie można zapisać pliku %(filename)s w katalogu tymczasowym"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Nie udało się przenieść pliku okładki %(file)s:%(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Plik książki w wybranym formacie został usunięty"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Książka została usunięta"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "Brak uprawnień do usuwania książek"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "edytuj metadane"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "Indeks serii: %(seriesindex)s nie jest poprawną liczbą, pomijanie"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr "Użytkownik nie ma uprawnień do wysyłania dodatkowych formatów plików"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Nie udało się utworzyć łącza %(path)s (Odmowa dostępu)."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Nie można zapisać pliku %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Format pliku %(ext)s dodany do %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 msgid "Book not found"
 msgstr "Nie znaleziono książki"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 "Książka nie ma na dysku żadnych formatów plików, z których można wczytać "
 "ponownie"
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "Nie znaleziono na dysku pliku książki: %(path)s"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr "Nie udało się odczytać metadanych z pliku %(format)s: %(err)s"
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
@@ -1566,23 +1539,23 @@ msgstr ""
 "Nie udało się zmienić nazwy folderu książki zgodnie z ponownie wczytanymi "
 "metadanymi: %(err)s"
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr "Nie udało się zapisać ponownie wczytanych metadanych: %(err)s"
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr "Ponownie wczytano pól: %(n)d z pliku %(fmt)s na dysku"
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 "Metadane na dysku są zgodne z bieżącymi — żadne pole nie zostało "
 "zaktualizowane"
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1590,7 +1563,7 @@ msgstr ""
 "Konfiguracja Google Drive nie została zakończona, spróbuj dezaktywować i "
 "ponownie aktywować Google Drive"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1598,89 +1571,88 @@ msgstr ""
 "Zwrotna domena nie jest zweryfikowana, proszę zweryfikowania domenę w "
 "konsoli deweloperskiej google"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 "Ta wiadomość e-mail została wysłana za pośrednictwem Calibre-Web NextGen."
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr "E-mail z ogłoszeniem do %(email)s"
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "Nie znaleziono formatu %(format)s dla id książki: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "Nie znaleziono %(format)s na Google Drive: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s nie znaleziono: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "Wyślij na czytnik e-booków"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "Konwersja przekroczyła limit czasu dla id książki: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "Konwersja nie powiodła się dla id książki: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr "Testowa wiadomość e-mail Calibre-Web NextGen"
 
-#: cps/helper.py:387
+#: cps/helper.py
 msgid "Test Email"
 msgstr "E-mail testowy"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr "Rozpocznij pracę z Calibre-Web NextGen"
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "E-mail rejestracyjny dla użytkownika: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Konwertuj %(orig)s do %(format)s i wyślij na czytnik e-booków"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Wyślij %(format)s na czytnik e-booków"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s wysłano na czytnik e-booków"
 
 # ???
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "Żądany plik nie mógł zostać odczytany. Może brakuje uprawnień?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "Nie można ustawić statusu przeczytania: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
@@ -1688,12 +1660,12 @@ msgstr ""
 "Usuwanie folderu książki dla książki %(id)s nie powiodło się, ścieżka ma "
 "podfoldery: %(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "Usuwanie książki %(id)s zakończyło się błędem: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1702,7 +1674,7 @@ msgstr ""
 "Usuwanie książki %(id)s tylko z bazy danych, ścieżka w bazie nieprawidłowa: "
 "%(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
@@ -1710,65 +1682,65 @@ msgstr ""
 "Zmiana nazwy autora z: \"%(src)s\" na \"%(dest)s\" zakończyła się błędem: "
 "%(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Nie znaleziono pliku %(file)s na Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Zmiana nazwy tytułu z: \"%(src)s\" na \"%(dest)s\" zakończyła się błędem: "
 "%(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Nie znaleziono ścieżki %(path)s do książki na Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr "Znaleziono istniejące konto dla tego adresu e-mail"
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Nazwa użytkownika jest już zajęta"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr "Nieprawidłowy format adresu e-mail"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr "Hasło nie spełnia wymagań polityki haseł"
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 "Moduł Python 'advocate' nie jest zainstalowany, ale jest wymagany do "
 "wysyłania okładek"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Błąd przy pobieraniu okładki"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr "Obraz okładki przekracza maksymalny rozmiar %(size)s MB"
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr ""
 "Plik okładki nie jest poprawnym plikiem obrazu lub nie mógł zostać zapisany"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Błędny format okładki"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
@@ -1776,35 +1748,35 @@ msgstr ""
 "Nie masz uprawnień do dostępu do localhost ani sieci lokalnej w celu "
 "wysyłania okładek"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Nie udało się utworzyć ścieżki dla okładki"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "Jako plik okładki obsługiwane są tylko pliki jpg/jpeg/png/webp/bmp"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "Nieprawidłowa zawartość pliku okładki"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Jako plik okładki dopuszczalne są jedynie pliki jpg/jpeg"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr "Okładka"
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "Plik wykonywalny programu unrar nie znaleziony"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr "Błąd wykonywania UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
@@ -1813,37 +1785,37 @@ msgstr ""
 "Wykryto nieobsługiwaną architekturę: %(arch)s. Calibre-Web NextGen jest "
 "zoptymalizowane pod kątem x86_64 i aarch64."
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr "Nie można znaleźć określonego katalogu"
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr "Proszę podać katalog, a nie plik"
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr "Pliki binarne Calibre nie są dostępne"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr "Brakujące pliki binarne Calibre: %(missing)s"
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Brak uprawnień do wykonywania: %(missing)s"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr "Błąd wykonywania Calibre"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr "Dodaj wszystkie książki do kolejki kopii zapasowej metadanych"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
@@ -1851,37 +1823,37 @@ msgstr ""
 "Aby uzyskać prawidłowy api_endpoint dla urządzenia Kobo, uzyskaj dostęp do "
 "Calibre-Web NextGen z adresu innego niż localhost"
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Konfiguracja Kobo"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr "Ostatnio dodane"
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr "Wysoko oceniane"
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr "Obecnie czytane"
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr "Do przeczytania"
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr "Ostatnie publikacje"
 
 # ???
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Zarejestruj się %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
@@ -1891,13 +1863,13 @@ msgstr ""
 "spowodowane niezgodnością konfiguracji zakresów (scope). Sprawdź "
 "konfigurację zakresów OAuth lub skontaktuj się z administratorem."
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 "Logowanie nie powiodło się: token OAuth wygasł. Spróbuj zalogować się "
 "ponownie."
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
@@ -1906,7 +1878,7 @@ msgstr ""
 "informacji o użytkowniku dostawcy OAuth. Spróbuj ponownie lub skontaktuj się "
 "z administratorem."
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
@@ -1914,7 +1886,7 @@ msgstr ""
 "Logowanie nie powiodło się: dostawca OAuth zwrócił nieprawidłowe dane "
 "profilu użytkownika. Skontaktuj się z administratorem."
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1925,38 +1897,38 @@ msgstr ""
 "pól: %(fields)s. Sprawdź konfigurację OAuth lub skontaktuj się z "
 "administratorem."
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr "Nie udało się połączyć konta OAuth. Spróbuj ponownie."
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 "Logowanie nie powiodło się: Twoje konto nie ma dostępu do tej aplikacji."
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 "Błąd OAuth: dostawca zwrócił nieprawidłowe informacje o użytkowniku. Spróbuj "
 "ponownie."
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr "To konto %(oauth)s jest już powiązane z innym użytkownikiem"
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "Sukces! Jesteś teraz zalogowany jako: %(nickname)s"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Łączenie z %(oauth)s zakończono sukcesem"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1967,58 +1939,58 @@ msgstr ""
 "Twoim kontem %(provider)s. Skontaktuj się z administratorem, aby utworzyć "
 "konto lub powiązać istniejące."
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 "Uwierzytelnianie OAuth nie powiodło się. Spróbuj ponownie lub skontaktuj się "
 "z administratorem."
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 msgid "OAuth system error. Please contact administrator."
 msgstr "Błąd systemu OAuth. Skontaktuj się z administratorem."
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "Rozłączanie z %(oauth)s zakończono sukcesem"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Rozłączanie z %(oauth)s zakończono porażką"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "Nie połączono z %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Nie udało się zalogować za pomocą GitHub."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Nie udało się pobrać informacji o użytkowniku z GitHub."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Nie udało się zalogować z Google."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Nie udało się pobrać informacji o użytkowniku z Google."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 msgid "Failed to log in with Generic OAuth."
 msgstr "Nie udało się zalogować za pomocą ogólnego OAuth."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 "Uwierzytelnianie OAuth nie powiodło się: błąd weryfikacji tokenu. Spróbuj "
 "ponownie."
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
@@ -2026,7 +1998,7 @@ msgstr ""
 "Uwierzytelnianie OAuth nie powiodło się z powodu nieoczekiwanego błędu. "
 "Skontaktuj się z administratorem."
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
@@ -2036,204 +2008,197 @@ msgstr ""
 "się, skonfiguruj ustawienie \"Host przekierowania OAuth\" w Panel "
 "administratora > Podstawowa konfiguracja > OAuth."
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "Błąd GitHub Oauth, proszę spróbować później."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "Błąd GitHub Oauth: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Błąd Google Oauth, proszę spróbować później."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Błąd Google Oauth: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr "Błąd OAuth: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "Książki alfabetyczne"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "Książki uporządkowane alfabetycznie"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Najpopularniejsze"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "Popularne publikacje z tego katalogu bazujące na pobranych."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Najwyżej ocenione"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Popularne publikacje z tego katalogu bazujące na ocenach."
 
-#: cps/opds.py:182
+#: cps/opds.py
 msgid "Recently added Books"
 msgstr "Ostatnio dodane książki"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Ostatnie książki"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Losowe książki"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Pokazuj losowe książki"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Przeczytane"
 
-#: cps/opds.py:201
+#: cps/opds.py
 msgid "Books currently being read"
 msgstr "Aktualnie czytane książki"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Nieprzeczytane"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Autorzy"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Książki sortowane według autorów"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Wydawcy"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Książki sortowane według wydawców"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Kategorie"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Książki sortowane według kategorii"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Cykle"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Książki sortowane według cyklu"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Języki"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Ksiązki sortowane według języka"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Oceny"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Książki sortowane według oceny"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Formaty plików"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Ksiązki sortowane według formatu"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Półki"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "Książki ułożone na półkach"
 
-#: cps/opds.py:260
+#: cps/opds.py
 msgid "Magic Shelves"
 msgstr "Magiczne Półki"
 
-#: cps/opds.py:261
+#: cps/opds.py
 msgid "Books organized in magic shelves"
 msgstr "Książki uporządkowane na magicznych półkach"
 
-#: cps/opds.py:317
+#: cps/opds.py
 msgid "description"
 msgstr "opis"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} Gwiazdek"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Szukaj"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Zaloguj się"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Nie znaleziono tokenu"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Token wygasł"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Sukces! Wróć do swojego urządzenia"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
@@ -2242,111 +2207,110 @@ msgstr ""
 "importach i zmianach metadanych będzie można uruchamiać szybkie sprawdzanie "
 "duplikatów. "
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Książki"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Pokaż menu ostatnio dodanych książek"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Pokaż menu najpopularniejszych książek"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Pobrane książki"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Pokaż pobrane książki"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Pokaż menu najwyżej ocenionych książek"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 msgid "Show Read and Unread"
 msgstr "Pokaż przeczytane i nieprzeczytane"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Pokaż nieprzeczytane"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Odkrywaj"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Category Section"
 msgstr "Pokaż sekcję kategorii"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Series Section"
 msgstr "Pokaż sekcję serii"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Author Section"
 msgstr "Pokaż sekcję autorów"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Publisher Section"
 msgstr "Pokaż sekcję wydawców"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Language Section"
 msgstr "Pokaż sekcję języków"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Ratings Section"
 msgstr "Pokaż sekcję ocen"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show File Formats Section"
 msgstr "Pokaż sekcję formatów plików"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Zarchiwizowane książki"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Archived Books"
 msgstr "Pokaż zarchiwizowane książki"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr "Ulubione"
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr "Pokaż ulubione"
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Lista książek"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Pokaż listę książek"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr "Duplikaty"
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 msgid "Show Duplicate Books"
 msgstr "Pokaż zduplikowane książki"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 "Dostępna jest wersja Calibre-Web NextGen %(latest)s — obecnie używasz "
 "%(current)s."
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
@@ -2355,391 +2319,390 @@ msgstr ""
 "Pomóż ulepszyć tłumaczenie Calibre-Web NextGen na język %(language)s — w "
 "Twoim języku wciąż wymaga przetłumaczenia ciągów: %(count)s."
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Opublikowane po "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Opublikowane przed "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Ocena <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Ocena >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Status przeczytania = '%(status)s'"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 "Błąd podczas wyszukiwania kolumn niestandardowych, proszę zrestartować "
 "Calibre-Web"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Wyszukiwanie"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Podano niewłaściwą półkę"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "Przepraszamy, nie masz uprawnień do dodania książki do tej półki"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "Książka jest już dodana do półki: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr "%(book_id)s to nieprawidłowe ID książki. Nie można dodać do półki"
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "Książka została dodana do półki: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "Nie masz uprawnień do dodania książki do półki"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Książki są już dodane do półki: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "Książki zostały dodane do półki %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Nie można dodać książek do półki: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 msgid "Invalid series specified"
 msgstr "Podano nieprawidłowy cykl"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Cykl nie ma żadnych widocznych dla Ciebie książek: %(name)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Wszystkie książki z cyklu '%(name)s' są już na półce: %(sname)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "Dodano do półki %(sname)s książek z cyklu '%(name)s': %(count)d"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "Książka została usunięta z półki: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "Przepraszamy, nie masz uprawnień do usunięcia książki z tej półki"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Utwórz półkę"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Przepraszamy, nie masz uprawnień do edycji tej półki"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Edytuj półkę"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "Błąd podczas usuwania półki"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "Półka została pomyślnie usunięta"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Zmieniono kolejność półki: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "Przepraszamy, nie masz uprawnień do tworzenia publicznej półki"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Półka %(title)s została utworzona"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Półka %(title)s została zmieniona"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Wystąpił błąd"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "Publiczna półka o nazwie '%(title)s' już istnieje."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "Prywatna półka o nazwie '%(title)s' już istnieje."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Półka: \"%(name)s\""
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Błąd otwierania półki. Półka nie istnieje lub jest niedostępna"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr "Nieprawidłowy tryb sortowania: %(mode)s"
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr "Nieprawidłowe dane: 'order' musi być listą"
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr "Nie udało się zapisać kolejności"
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 msgid "Reorder Shelves"
 msgstr "Zmień kolejność półek"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr "Nazwa (A → Z)"
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr "Nazwa (Z → A)"
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr "Liczba książek (malejąco)"
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr "Liczba książek (rosnąco)"
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr "Data utworzenia (od najnowszych)"
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr "Data utworzenia (od najstarszych)"
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr "Data modyfikacji (od najnowszych)"
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr "Data modyfikacji (od najstarszych)"
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr "Ręcznie (przeciągnij poniżej)"
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr "Czytaj teraz"
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr "Otwórz szczegóły \"{title}\""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr "Czytaj \"{title}\""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr "Standardowe (nazwa użytkownika / hasło)"
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr "LDAP"
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr "OAuth / OpenID Connect"
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Anonim"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Nieuwierzytelniony"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr "Proste (konto usługi)"
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr "Kolejność w cyklu"
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr "Kolejność w cyklu (odwrotna)"
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr "Dodaj tag"
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr "Nowy tag"
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr "Usuń tag"
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr "Usuń tag \"{name}\""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr "Zmień nazwę tagu \"{name}\""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr "Nazwa tagu"
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr "Nazwa tagu nie może być pusta"
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr "Zapisz nazwę tagu"
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr "Wybierz format"
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr "Nie udało się zmienić nazwy tagu"
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr "Zmieniono nazwę tagu na \"{name}\""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr "Musisz być zalogowany"
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr "Nie masz uprawnień do edycji metadanych"
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr "Tag o tej nazwie już istnieje"
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr "Nazwa tagu musi być tekstem"
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr "Nazwa tagu nie może zawierać przecinków"
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr "Podaj prawidłową nazwę tagu"
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr "Nie udało się wczytać tej strony"
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr "Nie znaleziono strony"
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr "Wyczyść ocenę"
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr "Brak oceny"
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Tak"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Nie"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr "Treść wiadomości e-mail"
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr "Ocena {rating} na 5"
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr "Więcej od \"{name}\""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
@@ -2748,313 +2711,301 @@ msgstr ""
 "Połączyć {n} książek w pierwszą zaznaczoną? Pozostałe zostaną usunięte po "
 "skopiowaniu ich formatów."
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr "Zastosuj do książek: {n}"
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr "Warunek dopasowania"
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr "Pole reguły"
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr "Operator reguły"
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr "Nie udało się wczytać reguł inteligentnej półki."
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr "Ma okładkę"
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr "Indeks w cyklu"
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Status odczytu"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr "Ma identyfikator Hardcover"
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr "W ciągu ostatnich N dni"
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr "Nie w ciągu ostatnich N dni"
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr "jest przed / mniejsze niż"
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr "jest w tym dniu lub wcześniej / co najwyżej"
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr "jest po / większe niż"
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr "jest w tym dniu lub później / co najmniej"
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr "jest pomiędzy"
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr "nie jest pomiędzy"
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr "nie zaczyna się od"
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr "nie kończy się na"
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr "jest puste"
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr "nie jest puste"
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr "Wygląd"
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Motyw"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr "Systemowy"
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Jasny"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Ciemny"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "Sepia"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr "Wysoki kontrast"
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr "Północ (AMOLED)"
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr "Dopasuj do jasnego lub ciemnego ustawienia urządzenia"
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr "Motyw zapisany."
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr "Nie udało się zapisać motywu."
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr "Domyślny motyw dla nowych kont"
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 "Dotyczy kont tworzonych od teraz. Każdy może wybrać własny w Konto → Motyw."
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr "Dodaj format"
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr "Dodaj regułę"
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Dodaj do półki"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr "Dodaj własny"
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr "Etykieta hasła aplikacji"
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr "Hasła aplikacji"
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Autor"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr "Autorzy (oddziel znakiem &)"
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr "Wróć do logowania"
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr "Niebieski"
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr "Zawartość książki"
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Przeglądaj"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr "Zmień hasło"
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Zamknij"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr "Zamknij menu"
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr "Spis treści"
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr "Konwersja nie powiodła się."
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr "Konwertuj na"
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr "Konwertuj do formatu"
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr "Kopiuj"
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr "Nie udało się zmienić hasła."
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr "Nie udało się utworzyć."
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr "Nie udało się pobrać okładki."
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr "Nie udało się wczytać metadanych."
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr "Nie udało się wczytać pliku książki ({status})"
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr "Nie udało się wczytać Twojego konta."
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr "Nie udało się zapisać."
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr "Adres URL obrazu okładki"
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr "Aktualizacja okładki nie powiodła się."
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr "Okładka zaktualizowana."
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr "Utwórz inteligentną półkę"
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr "Utwórz swoje konto"
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr "Ciemny motyw"
 
 # ???
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Usuń"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr "Usuń książkę"
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
@@ -3063,487 +3014,480 @@ msgstr ""
 "Usunąć \"{title}\"? Spowoduje to trwałe usunięcie książki i wszystkich jej "
 "plików z biblioteki. Tej operacji nie można cofnąć."
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr "Usuwanie…"
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr "Nie udało się usunąć tej książki."
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 "Usunąć plik {fmt}? Książka pozostanie; usunięty zostanie tylko ten format."
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr "Usuń {fmt}"
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr "Usunąć książek: {n}? Tej operacji nie można cofnąć."
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr "Opis zawiera"
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr "Odznacz \"{title}\""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr "Edytuj metadane"
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr "Edytuj \"{title}\""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr "Wyświetlany jest domyślny widok biblioteki."
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr "Pokaż wszystkie książki"
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr "Edytuj widok domyślny"
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr "Nie udało się wczytać książek."
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr "Nie udało się otworzyć książki."
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr "Generuj"
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr "Zielony"
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr "Pomoc"
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr "Kolor podświetlenia"
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr "Importuj z Kobo"
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr "Język interfejsu"
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr "Nieprawidłowa nazwa użytkownika lub hasło."
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr "Czcionka tekstu interfejsu"
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr "Czcionka nagłówków interfejsu"
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr "Domyślna (Optima / bezszeryfowa)"
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr "Domyślna (szeryfowa, książkowa)"
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr "Systemowa bezszeryfowa"
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr "Szeryfowa, książkowa"
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr "O stałej szerokości"
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr "Etykieta (np. KOReader na telefonie)"
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr "Języki (oddzielone przecinkami)"
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr "Jasny motyw"
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr "Logowanie nie powiodło się."
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr "Oznacz jako przeczytane"
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr "Oznacz jako nieprzeczytane"
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Połącz"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr "Zastosowano metadane do książek: {n}."
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 "Nowe hasło dla “{label}” — skopiuj je teraz, nie zostanie ono ponownie "
 "wyświetlone:"
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr "Nowe hasła nie są zgodne."
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr "Brak książek."
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr "Brak wyników dla \"{q}\"."
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr "Brak sugestii"
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr "Brak książek w kategorii \"{filter}\"."
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr "Hasło zostało zmienione."
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr "Wklej adres URL"
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr "Prywatna półka"
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr "Profil"
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr "Profil zapisany."
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr "Publiczna półka"
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Wydawca"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr "Wydawcy (oddzieleni przecinkami)"
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Przeczytane"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr "Postęp czytania"
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr "Czerwony"
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr "Rejestracja nie powiodła się."
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr "Usuń \"{name}\""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr "Żądanie nie powiodło się."
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr "Resetuj"
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr "Zresetuj hasło"
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr "Odwołaj \"{label}\""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr "Zapisz zmiany"
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr "Zapis nie powiódł się."
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr "Zapisz profil"
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr "Zapisano."
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr "Zapisywanie…"
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr "Wyszukiwanie nie powiodło się."
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr "Wyszukaj metadane"
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr "Dostawcy metadanych"
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr "Wczytywanie dostawców…"
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr "Nie udało się wczytać dostawców."
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr "Nie udało się zaktualizować dostawcy."
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr "{provider}: {state}"
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr "Włączone"
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr "Wyłączone"
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr "Wyniki wyszukiwania"
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr "Przeszukaj bibliotekę"
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr "Zaznacz \"{title}\""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr "Motyw sepia"
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr "Pozycja w cyklu {n}"
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr "{series} #{n}"
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr "Zaloguj się"
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr "Logowanie nie powiodło się. Spróbuj ponownie."
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr "Przejdź do treści"
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr "Niektórych pól nie udało się zapisać."
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr "Spis treści"
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr "Tagi (oddzielone przecinkami)"
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Tytuł"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr "Nieprzeczytane"
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr "Zaktualizuj hasło"
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Wysyłanie"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr "Wybierz książki do przesłania"
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr "Przesyłanie nie powiodło się."
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr "Prześlij obraz"
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr "Przesyłanie…"
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr "Żółty"
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr "np. MOBI"
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr "Czytnik {format}"
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr "Klucz API {name}"
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr "Dodano do półki książek: {n}."
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr "Usunięto książek: {n}."
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr "Oznaczono jako przeczytane: {n}."
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr "Oznaczono jako nieprzeczytane: {n}."
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr "Wybrano: {n}"
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr "Przeczytano {pct}%"
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr "Co nowego"
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr "Pomoc — dostępne nowe aktualizacje"
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr "Najnowsze funkcje i poprawki w Calibre-Web NextGen — od najnowszych."
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr "{n} aktualizacja"
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr "{n} aktualizacji"
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 "Brak jeszcze informacji o wydaniu — sprawdź ponownie po następnej "
 "aktualizacji."
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
@@ -3551,254 +3495,251 @@ msgstr ""
 "Interfejs jest przetłumaczony na Twój język; te informacje o aktualizacji są "
 "napisane w języku angielskim."
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr "Czytanie"
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr "Widok siatki"
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr "Biblioteka"
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr "Widok listy"
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr "Synchronizacja"
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Konto"
 
 # ???
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Panel administratora"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr "Pod maską"
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr "Otwórz swoją bibliotekę"
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr "Przeglądaj tagi"
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr "Otwórz widok tabeli"
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr "Przejrzyj duplikaty"
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr "Otwórz swoje półki"
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr "Zarządzaj synchronizacją i hasłami aplikacji"
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr "Sprawdź adres czytnika e-booków"
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr "Utwórz hasło aplikacji"
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr "Przeglądaj cykle"
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr "Przeglądaj autorów"
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr "Przeglądaj języki"
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr "Otwórz widok tabeli"
 
 # ???
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr "Otwórz panel administratora"
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr "Otwórz ustawienia konta"
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr "Przeglądaj Odkrywaj"
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr "Poznaj swoją bibliotekę"
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr "Przejdź do przesyłania"
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr "Otwórz wyszukiwanie"
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr "Wydania"
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr "Wróć do nowego interfejsu"
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr "Wróć do wyników"
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr "Nie znaleziono wydań tej książki."
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr "Zobacz wszystkie szczegóły"
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr "Szczegóły wyniku"
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Data publikacji"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr "Format"
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Źródło"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr "Dostosuj"
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr "Dostosuj panel boczny"
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr "Dostosuj nawigację"
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr "Gotowe"
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr "Przywróć domyślne"
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr "Zawsze widoczne"
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 "Edytowanie panelu bocznego. Zmień kolejność lub ukryj sekcje, a następnie "
 "dotknij Gotowe."
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr "Edycja anulowana."
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 "Przeciągnij, aby zmienić kolejność. Kliknij ✕, aby ukryć sekcję. Klawisze "
 "strzałek przesuwają zaznaczony element."
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr "Panel boczny zapisany."
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr "Panel boczny przywrócono do ustawień domyślnych."
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr "\"{label}\" przeniesiono na pozycję {pos} z {total}"
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 "Zmień kolejność \"{label}\" (pozycja {pos} z {total}). Użyj klawiszy "
 "strzałek, aby przesunąć."
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr "Usuń \"{label}\""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr "Przywróć \"{label}\""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr "\"{label}\" ukryto"
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr "\"{label}\" przywrócono"
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr "Nie udało się zapisać panelu bocznego. Spróbuj ponownie."
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr "Odśwież bibliotekę"
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr "<"
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr "="
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ">"
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
@@ -3806,42 +3747,41 @@ msgstr ""
 "Wymagane jest jednorazowe pełne skanowanie duplikatów. Uruchom je w "
 "ustawieniach CWA, a następnie wróć tutaj."
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr "Data dodania"
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr "Odrzuć wiadomość o wsparciu na Ko-fi"
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr "Odrzuć ogłoszenie pomocy"
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr "Otwórz Ko-fi →"
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr "Data publikacji"
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr "Wesprzyj nas na Ko-fi!"
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
@@ -3849,89 +3789,89 @@ msgstr ""
 "Te odnośniki otwierają pełne strony konfiguracji. Zmiany tam wprowadzone "
 "dotyczą całego serwera."
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr "zaczyna się od"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr "zawiera"
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr "nie zawiera"
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr "kończy się na"
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr "w ciągu ostatnich N dni"
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr "nie jest"
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr "jest"
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr "nie w ciągu ostatnich N dni"
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr "w tym dniu lub później"
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr "w tym dniu lub wcześniej"
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr "≤"
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr "≥"
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr "(zamień okładkę)"
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr "2:3 (okładka wydawcy — bez dopełnienia dla typowych okładek)"
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr "3:4 (ogólny)"
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 "Skanowanie duplikatów jest już uruchomione. Ta lista zaktualizuje się po "
 "jego zakończeniu."
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr "Kilka losowych propozycji z Twojej biblioteki"
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
@@ -3939,173 +3879,169 @@ msgstr ""
 "Wymagane jest jednorazowe pełne skanowanie duplikatów. Użyj powyższego "
 "przycisku “Skanuj w poszukiwaniu duplikatów“, aby je uruchomić."
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr "Klucze API"
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "Informacje"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr "Ustawienia konta"
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr "Konto: {name}"
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr "Dodaj identyfikator"
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr "Dodaj do ulubionych"
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr "Grupa administratorów"
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr "Zaawansowane"
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr "Wyszukiwanie zaawansowane"
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr "Wszystkie półki"
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr "Zezwól na logowanie zdalne (magic link)"
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr "Dozwolone grupy (oddzielone przecinkami)"
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr "Dowolny"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr "Dowolny format"
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr "Dowolny język"
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr "Dowolny cykl"
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr "Dowolne tagi"
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr "Zastosuj wybrane"
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 "Zastosuj do wszystkich zaznaczonych (zmieniają się tylko wypełnione pola; "
 "zastępuje istniejące wartości):"
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr "Stosowanie…"
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr "Archiwizuj"
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Zarchiwizowane"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr "Zapytaj na Discordzie"
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr "Uwierzytelnianie"
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr "Uwierzytelnianie i bezpieczeństwo"
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr "Autor A–Z"
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr "Autor Z–A"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr "Autoryzowano — logowanie…"
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr "Adres URL autoryzacji"
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr "Automatyczne tworzenie użytkowników"
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr "Automatycznie twórz użytkowników przy pierwszym logowaniu"
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr "Wróć do biblioteki"
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr "Wróć do widoku klasycznego"
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr "Podstawowa DN"
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr "Podstawowa konfiguracja"
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr "Domyślne dla książki"
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr "Zagęszczenie książek"
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr "Książka {number}"
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr "Liczba książek na stronie"
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
@@ -4114,492 +4050,478 @@ msgstr ""
 "następnie usunięte z urządzenia przy kolejnej synchronizacji. Pozostają "
 "jednak w Twojej bibliotece tutaj."
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr "Wbudowani dostawcy (pozostaw puste, aby wyłączyć):"
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr "Działania zbiorcze"
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr "Ścieżka certyfikatu CA"
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr "Ustawienia CWA (import/konwersja)"
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr "Może przesyłać książki"
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr "Anuluj zmianę nazwy"
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr "Anuluj edycję tytułu"
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr "Anuluj \"{task}\""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr "Ścieżka pliku certyfikatu"
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr "Ścieżka certyfikatu"
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr "Zmień okładkę"
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr "Sprawdzanie…"
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr "Wybierz okładkę"
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr "Wybierz obraz okładki do przesłania"
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr "Wybierz obraz…"
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr "Wybierz pola"
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr "Wybierz swój motyw"
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr "Wyczyść domyślne"
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr "Wyczyść zaznaczenie"
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr "Identyfikator klienta"
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr "Sekret klienta"
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr "Sekret klienta (pozostaw puste, aby zachować)"
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr "Zamknij czytnik"
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr "Kolumny"
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr "Komfortowe"
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr "Kompaktowe"
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr "Skonfigurowano"
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr "Potwierdź nowe hasło"
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "Konwertuj"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr "Konwertuj przed wysłaniem"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr "Konwertuj z"
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr "Skopiowano do schowka"
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr "Kopiuj link"
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr "Nie udało się utworzyć półki."
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr "Nie udało się utworzyć półki."
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr "Nie udało się usunąć półki."
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr "Nie udało się wczytać kandydatów."
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr "Nie udało się wczytać duplikatów."
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr "Nie udało się wczytać zakreśleń."
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr "Nie udało się wczytać statystyk."
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr "Nie udało się wczytać zadań."
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr "Nie udało się wczytać tego pliku tekstowego."
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr "Nie udało się wczytać użytkowników."
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr "Nie udało się odczytać tego archiwum komiksu."
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr "Nie udało się ponownie wczytać metadanych"
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr "Nie udało się zmienić nazwy półki."
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr "Nie udało się zresetować hasła."
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr "Nie udało się zapisać kolejności."
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr "Nie udało się zapisać ustawień czytnika."
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr "Nie udało się zapisać domyślnego filtra biblioteki."
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr "Nie udało się zapisać półki."
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr "Nie udało się zapisać tytułu."
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr "Nie udało się uruchomić skanowania duplikatów."
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr "Nie udało się zaktualizować półki."
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr "Nie udało się zaktualizować ustawienia Twojego konta."
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr "Nie udało się utworzyć magic linku. Spróbuj ponownie."
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr "Okładka zablokowana"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr "Okładka niedostępna"
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr "Zaktualizowano okładkę na podstawie wybranego wyniku."
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr "Utwórz"
 
 # | msgid "Create a Shelf"
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr "Utwórz konto"
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr "Utwórz konto"
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr "Tworzenie nie powiodło się."
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr "Utwórz półkę i dodaj książkę"
 
 # | msgid "Create a Shelf"
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr "Utwórz użytkownika"
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr "Utworzono \"{name}\"."
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr "Tworzenie…"
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr "Bieżący"
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr "Bieżąca okładka"
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr "Obecne hasło"
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr "Obecnie czytane"
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr "Niestandardowy kolor obramowania"
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr "Niestandardowe kolumny"
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr "Ścieżka bazy danych i biblioteki"
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr "Data dodania"
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr "Domyślna (systemowa bezszeryfowa)"
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr "Domyślny język książek"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr "Domyślny język interfejsu"
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr "Wyczyszczono domyślny filtr biblioteki."
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr "Zapisano domyślny filtr biblioteki."
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr "Domyślne role dla nowych użytkowników OAuth:"
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 "Ustawienia domyślne znajdują się w Panel administratora → Konfiguracja → "
 "Synchronizacja Kobo."
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr "Usuń książki"
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr "Usuwanie nie powiodło się."
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr "Usunąć półkę \"{name}\"? Tej operacji nie można cofnąć."
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr "Usunąć tę inteligentną półkę? Twoje książki nie zostaną naruszone."
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 "Usunąć użytkownika \"{name}\"? Jego półki i dane czytania również zostaną "
 "usunięte."
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr "Usuń \"{name}\""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr "Usunięto \"{name}\"."
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr "Gęste"
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Opis"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr "Wyłącz standardowe logowanie hasłem"
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr "Zaktualizowano propozycje w Odkrywaj."
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr "Odkrywaj — losowe propozycje"
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr "Odrzuć"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr "Odrzuć tę grupę"
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr "Dokumentacja"
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr "Zakończono zmianę kolejności"
 
 # ???
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Pobieranie"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr "Upuść pliki tutaj lub kliknij, aby wybrać"
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr "Duplikat"
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr "Zduplikowane książki"
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr "Ustawienia wykrywania duplikatów"
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
@@ -4607,289 +4529,285 @@ msgstr ""
 "Rozpoczęto skanowanie duplikatów. Działa ono w tle — ta lista zaktualizuje "
 "się po jego zakończeniu."
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr "Podgląd na czytniku e-booków"
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr "Każdy typ (isbn, amazon, google, doi…) może wystąpić tylko raz."
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr "Rozmyta krawędź — miękkie obramowanie bokeh"
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr "Odbicie krawędzi — rozszerz grafikę (zalecane)"
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Edycja"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr "Edytuj publiczne półki"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr "Edytuj inteligentną półkę"
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr "Edytuj tytuł \"{title}\""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "E-mail"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr "Serwer e-mail (SMTP)"
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr "E-mail (opcjonalnie)"
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr "Roszczenie (claim) e-mail"
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr "Wyślij mi link resetujący"
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr "Ustawienia e-mail zapisane."
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Włącz synchronizację Kobo"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr "Wygasa za"
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr "Udostępniaj przez OPDS tylko wybrane półki"
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr "Nie udało się wczytać półek."
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr "Wczytywanie nie powiodło się."
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr "Ulubione"
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr "Dodano do ulubionych"
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr "Pobierz"
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr "Pobierz metadane z internetu"
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr "Pliki"
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 "Pliki zostaną umieszczone w kolejce do przetworzenia i pojawią się po "
 "zaimportowaniu."
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr "Styl wypełnienia"
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr "Filtruj: {items}"
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr "Filtruj: {items}…"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr "Rodzina czcionek"
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr "Rozmiar czcionki"
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr "Nie pamiętasz hasła?"
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr "Format oczekuje w kolejce — pojawi się po przetworzeniu."
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr "Formaty"
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr "Formaty — wyklucz"
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr "Formaty — uwzględnij"
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr "Adres nadawcy"
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr "Pełna tabela użytkowników i ograniczenia"
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr "Wygeneruj nowy link"
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr "Nadaj nazwę swojej inteligentnej półce."
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr "Przejdź do swojej biblioteki"
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr "Gradient — przejście góra/dół dopasowane do palety"
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr "Roszczenie (claim) grupy"
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr "Pole członków grupy"
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr "Nazwa grupy"
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr "Filtr obiektu grupy"
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr "HTML jest dozwolony i jest oczyszczany przy wyświetlaniu."
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr "Nazwa nagłówka"
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr "Pomoc i wsparcie"
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr "Menu pomocy"
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr "Ukryte"
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "Ukryj"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr "Ukryj sekcję Odkrywaj"
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr "Ukryj pola"
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr "Ukryj hasło"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr "Zakreślenie"
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr "Zakreślenia"
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr "Popularne"
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr "Popularne — najczęściej pobierane"
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr "Ikona"
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr "Typ identyfikatora"
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr "Wartość identyfikatora"
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Identyfikatory"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr "Zaimportowano jako"
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr "W Twojej książce"
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
@@ -4897,338 +4815,337 @@ msgstr ""
 "Czytanie w przeglądarce obecnie obsługuje format EPUB. W przypadku innych "
 "formatów użyj pobierania lub klasycznego czytnika."
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr "Wystawca / adres bazowy"
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 "Mogła zostać przeniesiona lub nadal znajduje się w klasycznym interfejsie."
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr "Postęp KOReader"
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr "Ścieżka pliku klucza"
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr "Ścieżka klucza"
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr "Kobo Libra Color / Libra 2 (1264×1680)"
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr "Synchronizacja Kobo włączona"
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Język"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr "Języki — uwzględnij"
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr "Ostatnio zmodyfikowano"
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr "Ostatnio zsynchronizowano"
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr "Ustawienia biblioteki"
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr "Wysokość linii"
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr "Wczytaj więcej"
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr "Wczytywanie"
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr "Wczytywanie nowych propozycji w Odkrywaj."
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr "Wczytywanie…"
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr "Zablokuj okładkę"
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr "Tekst przycisku logowania"
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr "Metoda logowania"
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr "Zaloguj się przez"
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr "Dzienniki"
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr "Wygląda dobrze"
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr "Niska rozdzielczość"
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr "Magic link"
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr "Kod QR magic link"
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr "Ustaw jako prywatną"
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr "Ustaw jako publiczną"
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr "Ustaw to jako mój domyślny widok biblioteki"
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr "Zarządzaj rolą administratora na podstawie grupy OAuth"
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr "Zarządzaj półkami"
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr "Oznacz jako przeczytane"
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr "Oznacz jako nieprzeczytane"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr "Dopasowanie"
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr "Maks."
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr "Maksymalna liczba pokazywanych autorów"
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr "Maksymalna ocena"
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr "Filtr użytkownika członka"
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr "Adres URL metadanych (automatyczne wykrywanie OIDC)"
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr "Min."
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr "Minimalna ocena"
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr "Więcej opcji okładek (dostawcy wyszukiwania, podgląd na czytniku)"
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr "Więcej konfiguracji serwera"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr "Przenieś w dół"
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr "Przenieś w górę"
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr "Moje konto"
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr "Nazwa"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr "Chcesz zgłosić problem? Wypróbuj nowy"
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr "Nowe"
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr "Nowe hasło"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr "Nazwa nowej półki"
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr "Nazwa nowej półki…"
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr "Nowa półka…"
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr "Nowa inteligentna półka"
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr "Nowy użytkownik"
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr "Najnowsze"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr "Najnowsze wydania"
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr "Następna strona"
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr "Żadna książka nie spełnia obecnie kryteriów tej inteligentnej półki."
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr "Żadna książka nie spełnia tych kryteriów."
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 "Nie znaleziono jeszcze kandydatów. Spróbuj innego wyszukiwania lub odśwież."
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr "Nie znaleziono zawartości."
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr "Nie znaleziono grup duplikatów."
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr "Brak wykluczonych tagów"
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 "Brak jeszcze zakreśleń. Zakreślaj podczas czytania lub zaimportuj z "
 "urządzenia Kobo."
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr "Brak wyników \"{items}\" dla \"{query}\"."
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr "Nie znaleziono stron w tym komiksie."
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr "Brak jeszcze półek — utwórz jedną poniżej."
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr "Brak jeszcze półek. Utwórz jedną powyżej, aby zacząć zbierać książki."
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr "Żadne źródło nie wymaga klucza."
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr "Brak uruchomionych zadań."
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr "Brak jeszcze \"{items}\"."
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr "Nieskonfigurowane"
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr "Nie ustawiono"
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr "Najstarsze"
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr "Najstarsze wydania"
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
@@ -5236,56 +5153,56 @@ msgstr ""
 "Na innym urządzeniu, na którym jesteś już zalogowany, zeskanuj ten kod lub "
 "otwórz poniższy link, aby autoryzować to urządzenie."
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr "Otwórz konto"
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr "Otwórz klasyczny czytnik"
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr "Otwórz nawigację"
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr "Otwórz czytnik"
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr "Otwórz klasyczny interfejs"
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr "Otwórz poniższy link na zalogowanym urządzeniu."
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr "Serwer OpenLDAP"
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr "Otwiera się w widoku klasycznym"
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr "Czytnik PDF"
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr "Marginesy strony"
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr "Motyw strony"
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr "Strona {number}"
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
@@ -5293,17 +5210,16 @@ msgstr ""
 "Strony oznaczone poniżej otwierają się w widoku klasycznym. Zmiany tam "
 "wprowadzone dotyczą całego serwera."
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Hasło"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr "Hasło (pozostaw puste, aby zachować)"
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
@@ -5311,161 +5227,156 @@ msgstr ""
 "Wybierz okładkę z dowolnego obsługiwanego źródła, wklej adres URL, prześlij "
 "plik lub użyj okładki osadzonej w samej książce."
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 "Podniesiono \"{label}\". Przeciągnij, aby zmienić kolejność, i puść, aby "
 "upuścić."
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr "Przygotowywanie magic linku…"
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr "Poprzednia strona"
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Postęp"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr "Publiczna"
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr "Opublikowano po"
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr "Opublikowano przed"
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr "Wyświetlana liczba losowych książek"
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Ocena"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr "Ocena (gwiazdki)"
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr "Status przeczytania"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr "Filtr statusu przeczytania"
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr "Ustawienia czytnika zapisane."
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr "Wygląd czytania"
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr "Odbiorca(y)"
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr "Host przekierowania (pełny adres URL)"
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr "Odśwież"
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr "Rejestrowanie…"
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr "Odśwież"
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr "Wczytaj ponownie metadane z dysku"
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr "Wczytywanie ponowne…"
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr "Zapamiętaj mnie"
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr "Usuń z ulubionych"
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr "Usuń z półki"
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr "Usuń zakreślenie"
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr "Usuń identyfikator"
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr "Usuń regułę"
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr "Zmień nazwę"
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr "Zmień kolejność"
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr "Zamienić okładkę na tę?"
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr "Zamienić okładkę?"
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr "Zgłoś problem na Discordzie"
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr "Zgłoś problem na GitHubie"
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr "Wymagaj przynależności do grupy"
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr "Zresetuj hasło dla \"{name}\""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
@@ -5474,373 +5385,371 @@ msgstr ""
 "Zresetować hasło dla \"{name}\"? Obecne hasło przestanie działać, a nowe "
 "zostanie wysłane e-mailem."
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr "Logowanie przez nagłówek reverse proxy"
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr "Liczba wierszy na wczytanie"
 
 # ???
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr "Czas działania"
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr "Serwer SMTP"
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Zapisz"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr "Zapisz ustawienia e-mail"
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr "Zapisz nazwę"
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr "Zapisz ustawienia bezpieczeństwa"
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr "Zapisz ustawienia"
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 "Zapisano. Uruchom ponownie serwer, aby zmiany logowania zaczęły obowiązywać."
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr "Skanuj w poszukiwaniu duplikatów"
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr "Zadania zaplanowane"
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr "Zakresy (scopes)"
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr "Szukaj tytułu, autora…"
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr "Przeszukiwanie każdego źródła…"
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr "Wyszukiwanie…"
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr "Ustawienia bezpieczeństwa zapisane."
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 "Zobacz, jak każda okładka wygląda z dopełnieniem dla Twojego urządzenia"
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "Wybierz"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr "Wybierz wiele"
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr "Wyślij"
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr "Wysyłanie nie powiodło się."
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr "Wyślij na czytnik e-booków"
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr "E-mail do wysyłania na czytnik e-booków"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr "Wysyłanie…"
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr "Indeks w cyklu"
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr "Widok cykli"
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr "Cykle — uwzględnij"
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr "Udostępniaj przez HTTPS"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr "SSL / HTTPS serwera"
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr "Ogłoszenie serwera (widoczne dla wszystkich użytkowników)"
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr "Host serwera"
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr "Konto usługi (DN)"
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr "Hasło usługi"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr "Hasło usługi (pozostaw puste, aby zachować)"
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 "Ustaw adres URL metadanych, aby automatycznie uzupełnić poniższe punkty "
 "końcowe, lub wprowadź je ręcznie."
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr "Ustawienia zapisane."
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr "Nazwa półki"
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr "Nie znaleziono półki."
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr "Pokaż sekcję Odkrywaj"
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr "Pokaż widok tabeli"
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr "Pokaż wszystkie tagi ({count})"
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr "Pokaż wszystkie \"{items}\""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr "Pokaż książki w języku"
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr "Pokaż podgląd na czytniku dla każdego kandydata"
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr "Pokaż mniej tagów"
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr "Pokaż ukryte książki"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr "Pokaż hasło"
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr "Wymieszaj propozycje"
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr "Zaloguj się za pomocą magic linku"
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr "Wyloguj się"
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr "Logowanie…"
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr "Tytuł strony"
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr "Nie znaleziono inteligentnej półki."
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr "Inteligentne półki"
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr "Jednolity: średni kolor okładki"
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr "Jednolity: kolor niestandardowy"
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr "Jednolity: najczęstszy kolor na okładce"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr "Niektóre źródła wymagają klucza dla lepszych okładek"
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr "Coś poszło nie tak"
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr "Coś poszło nie tak. Spróbuj ponownie."
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr "Kolejność sortowania"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr "Szczegóły źródła"
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr "Rozpoczęto czytanie"
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr "Rozpoczynanie skanowania…"
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr "Panel statystyk"
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Status"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr "Wesprzyj na Ko-fi →"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr "Synchronizuj tylko moje wybrane półki"
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr "Synchronizuj z Kobo tylko wybrane półki"
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr "Widok tabeli"
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr "Tag"
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Etykiety"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr "Tagi — wyklucz"
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr "Tagi — uwzględnij"
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr "Docelowe proporcje obrazu"
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Zadanie"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Zadania"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr "Szczegóły techniczne"
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr "Ten adres URL nie jest prawidłowym obrazem."
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr "Ten format otwiera się w czytniku pełnoekranowym."
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr "Ten magic link wygasł. Wygeneruj nowy, aby spróbować ponownie."
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr "Ta strona tutaj nie istnieje."
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
@@ -5848,76 +5757,75 @@ msgstr ""
 "Na tej stronie wystąpił błąd i nie można jej wyświetlić. Z Twoją biblioteką "
 "wszystko w porządku — ponowne wczytanie zwykle to naprawia."
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr "Ta półka jest pusta. Dodawaj książki ze strony dowolnej książki."
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr "Tytuł A–Z"
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr "Tytuł Z–A"
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr "Tytuł, autor lub ISBN"
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr "Adres URL tokenu"
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr "Najwyżej oceniane"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr "Ufaj nagłówkowi uwierzytelniania"
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr "Konfiguracja interfejsu / wyświetlania"
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr "Przywróć z archiwum"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr "Odkryj"
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr "Odblokuj powyższą okładkę, aby zastosować nową."
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr "Odblokuj okładkę, aby ją zmienić"
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr "Bez tytułu"
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr "Aktualizacja nie powiodła się."
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr "Prześlij jako okładkę"
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr "Prześlij książki"
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
@@ -5925,68 +5833,65 @@ msgstr ""
 "Użyj ich do łączenia czytników OPDS lub synchronizacji KOReader bez "
 "podawania głównego hasła."
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr "Użyj tej okładki"
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Użytkownik"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr "Administracja użytkownikami"
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr "Filtr obiektu użytkownika"
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr "Adres URL informacji o użytkowniku"
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr "Roszczenie (claim) nazwy użytkownika"
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr "Wersje"
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Zobacz"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr "Ustawienia widoku"
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr "Przeglądarka"
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr "Oczekiwanie na autoryzację…"
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr "Gdy okładka jest zablokowana, pobieranie metadanych jej nie nadpisze."
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr "Kiedy postęp czytania został po raz pierwszy zsynchronizowany"
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
@@ -5996,190 +5901,189 @@ msgstr ""
 "samo oznaczenie tej półki nic nie zmieni. Przełącz swoje konto na "
 "synchronizację tylko wybranych półek, aby to zadziałało."
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr "Twoja biblioteka"
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr "Twoja przeglądarka nie obsługuje odtwarzania tego formatu audio."
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr "Twoja osobista cyfrowa biblioteka"
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 "Wyświetlany jest zapisany adres czytnika e-booków — zmień go tylko na "
 "potrzeby tej wysyłki."
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr "wszystkie reguły"
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr "dowolna reguła"
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr "książki"
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr "pasujące książki"
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr "kopie"
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr "czytnik e-booków"
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr "np. Nieprzeczytane sci-fi"
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr "Temat e-maila do czytnika e-booków"
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr "udostępniono"
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr "do"
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr "typ (isbn, amazon, doi…)"
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr "wartość"
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr "Ty"
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr "{count} książka"
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr "{count} książek"
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr "{count} plik oczekuje w kolejce do importu"
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr "{count} plik odrzucony"
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr "{count} plików oczekuje w kolejce do importu"
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr "{count} plików odrzuconych"
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr "{count} wynik"
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr "{count} wyników"
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr "{count} wyników dla \"{query}\""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr "{field} (oddzielone przecinkami)"
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr "znaleziono: {n}"
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr "odpowiedziało źródeł: {ok} z {total}"
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr "…lub wklej adres URL obrazu"
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr "← Wróć do książki"
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr "← Wróć do logowania"
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr "← Biblioteka"
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Oczekiwanie"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Nieudane"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Rozpoczynanie"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Zakończone"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "Zakończone"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "Anulowane"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Ststus nieznany"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Nieoczekiwane dane podczas odczytywania informacji o aktualizacji"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr "Brak dostępnej aktualizacji. Masz już zainstalowaną najnowszą wersję"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6187,16 +6091,16 @@ msgstr ""
 "Dostępna jest nowa aktualizacja. Kliknij przycisk poniżej, aby zaktualizować "
 "do najnowszej wersji."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Nie można pobrać informacji o aktualizacji"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr ""
 "Kliknij przycisk poniżej, aby zaktualizować do najnowszej stabilnej wersji."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6205,104 +6109,104 @@ msgstr ""
 "Dostępna jest nowa aktualizacja. Kliknij przycisk poniżej, aby zaktualizować "
 "do wersji: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Brak dostępnych informacji o wersji"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Odkrywaj (losowe książki)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Najpopularniejsze książki (najczęściej pobierane)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "Książki pobrane przez %(user)s"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Autor: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Wydawca: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Cykl: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "Ocena: Brak"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Ocena: %(rating)s gwiazdek"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Format pliku: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Kategoria: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Język: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 msgid "Favorite Books"
 msgstr "Ulubione książki"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 msgid "Hidden Books"
 msgstr "Ukryte książki"
 
-#: cps/web.py:1193
+#: cps/web.py
 msgid "Error loading magic shelf"
 msgstr "Błąd podczas wczytywania magicznej półki"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr "Magiczna półka&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr "Nie podano żadnych reguł"
 
-#: cps/web.py:1400
+#: cps/web.py
 msgid "Invalid rules format"
 msgstr "Nieprawidłowy format reguł"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr "Błąd podczas przetwarzania reguł"
 
-#: cps/web.py:1426
+#: cps/web.py
 msgid "Invalid request"
 msgstr "Nieprawidłowe żądanie"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr "Wymagane są zarówno nazwa, jak i reguły"
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr "Nazwa półki jest zbyt długa (maks. 100 znaków)"
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
@@ -6311,47 +6215,47 @@ msgstr ""
 "nie dotrze do Twojego Kobo, dopóki opcja \"Synchronizuj Magiczne Półki z "
 "Kobo\" nie zostanie włączona w Ustawieniach CWA."
 
-#: cps/web.py:1521
+#: cps/web.py
 msgid "Error creating shelf"
 msgstr "Błąd podczas tworzenia półki"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 msgid "Create Magic Shelf"
 msgstr "Utwórz magiczną półkę"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr "Brak uprawnień do zmiany statusu publicznego"
 
-#: cps/web.py:1587
+#: cps/web.py
 msgid "Shelf name is required"
 msgstr "Nazwa półki jest wymagana"
 
-#: cps/web.py:1647
+#: cps/web.py
 msgid "Error updating shelf"
 msgstr "Błąd podczas aktualizowania półki"
 
-#: cps/web.py:1652
+#: cps/web.py
 msgid "Edit Magic Shelf"
 msgstr "Edytuj magiczną półkę"
 
-#: cps/web.py:1668
+#: cps/web.py
 msgid "Shelf not found"
 msgstr "Nie znaleziono półki"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr "Odmowa dostępu"
 
-#: cps/web.py:1704
+#: cps/web.py
 msgid "Shelf duplicated successfully"
 msgstr "Półka została pomyślnie zduplikowana"
 
-#: cps/web.py:1710
+#: cps/web.py
 msgid "Error duplicating shelf"
 msgstr "Błąd podczas duplikowania półki"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
@@ -6359,102 +6263,100 @@ msgstr ""
 "Półek systemowych nie można usunąć. Możesz je ukryć w ustawieniach swojego "
 "profilu użytkownika."
 
-#: cps/web.py:1755
+#: cps/web.py
 msgid "Error deleting shelf"
 msgstr "Błąd podczas usuwania półki"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 "Nie możesz ukryć własnych półek. Jeśli ich nie chcesz, usuń je zamiast tego."
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr "Półka jest już ukryta"
 
-#: cps/web.py:1795
+#: cps/web.py
 msgid "Error hiding shelf"
 msgstr "Błąd podczas ukrywania półki"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr "Półka nie była ukryta"
 
-#: cps/web.py:1818
+#: cps/web.py
 msgid "Error unhiding shelf"
 msgstr "Błąd podczas odkrywania półki"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "DLS"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Lista formatów"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Proszę najpierw skonfigurować ustawienia poczty SMTP..."
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 "Ups! Proszę zaktualizować profil o prawidłowy adres e-mail czytnika e-booków."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "Książka została umieszczona w kolejce do wysłania do %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Wystąpił błąd podczas wysyłania tej książki: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr "Nie wybrano adresów e-mail"
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr "Dodatkowe adresy e-mail są wyłączone dla Twojego konta."
 
-#: cps/web.py:2500
+#: cps/web.py
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "Sukces! Książka została zakolejkowana do wysłania na wybrane adresy!"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr "Poczekaj minutę, aby zarejestrować następnego użytkownika"
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Zarejestruj się"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr "Błąd połączenia z backendem limitera, skontaktuj się z administratorem"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr ""
 "Ups! Serwer e-mail nie jest skonfigurowany, skontaktuj się z administratorem."
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "Ups! Ten adres e-mail jest niedozwolony."
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr ""
 "Wiadomość e-mail z potwierdzeniem została wysłana na Twoje konto e-mail."
 
-#: cps/web.py:2624
+#: cps/web.py
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
@@ -6462,7 +6364,7 @@ msgstr ""
 "Wykryto pętlę uwierzytelniania. Jeśli występują problemy z logowaniem, "
 "skontaktuj się z administratorem."
 
-#: cps/web.py:2704
+#: cps/web.py
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
@@ -6470,28 +6372,28 @@ msgstr ""
 "Uwierzytelnianie OAuth nie jest prawidłowo skonfigurowane. Skontaktuj się z "
 "administratorem."
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr "Nie można aktywować uwierzytelniania LDAP"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr "Standardowe logowanie jest wyłączone."
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr "Poczekaj minutę przed następną próbą logowania"
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr "Nazwa użytkownika nie może być pusta"
 
-#: cps/web.py:2756
+#: cps/web.py
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "jesteś teraz zalogowany jako: '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
@@ -6500,7 +6402,7 @@ msgstr ""
 "Witamy! Twoje konto zostało utworzone automatycznie. Jesteś teraz zalogowany "
 "jako: '%(nickname)s'"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
@@ -6508,7 +6410,7 @@ msgstr ""
 "Uwierzytelnianie powiodło się, ale utworzenie konta nie powiodło się. "
 "Skontaktuj się z administratorem."
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
@@ -6516,7 +6418,7 @@ msgstr ""
 "Uwierzytelnianie powiodło się, ale nie znaleziono lokalnego konta. "
 "Skontaktuj się z administratorem, aby utworzyć konto."
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6525,589 +6427,560 @@ msgstr ""
 "Logowanie awaryjne jako: '%(nickname)s', serwer LDAP niedostępny lub "
 "użytkownik nieznany"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr "Nie można się zalogować: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 msgid "Wrong Username or Password"
 msgstr "Nieprawidłowa nazwa użytkownika lub hasło"
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr "Nowe hasło zostało wysłane na Twój adres e-mail"
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr "Wystąpił nieznany błąd. Spróbuj ponownie później."
 
-#: cps/web.py:2838
+#: cps/web.py
 msgid "Please enter valid username to reset password"
 msgstr "Wprowadź prawidłową nazwę użytkownika, aby zresetować hasło"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "Jesteś teraz zalogowany jako: '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 msgid "Success! Profile Updated"
 msgstr "Sukces! Profil zaktualizowany"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "Ups! Znaleziono istniejące konto dla tego adresu e-mail."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr "Etykieta hasła aplikacji musi mieć od 1 do 64 znaków."
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr "Hasło aplikacji '%(label)s' zostało odwołane."
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr "Nieprawidłowe ID książki."
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr "Wtyczka synchronizacji KOReader"
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "Nie znaleziono poprawnego pliku gmail.json z informacjami OAuth"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr "Synchronizowanie adnotacji z usługami czytania"
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr "Synchronizacja adnotacji"
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr "Automatyczne pobieranie identyfikatorów Hardcover"
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 msgid "Preparing to send to eReader..."
 msgstr "Przygotowywanie do wysłania na czytnik e-booków..."
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr "Sprawdzanie dostępnych formatów..."
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 msgid "Sending to eReader..."
 msgstr "Wysyłanie na czytnik e-booków..."
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 msgid "Auto-send completed successfully"
 msgstr "Automatyczne wysyłanie zakończone pomyślnie"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr "Automatyczne wysyłanie"
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr "Usuń zawartość folderu tymczasowego"
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s wysłano na czytnik e-booków"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Nie znaleziono narzędzia calibre %(tool)s do konwertowania"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "Nie znaleziono na dysku formatu %(format)s"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "Konwertowanie ebooka zakończyło się niepowodzeniem z nieznanego powodu"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Kepubify-converter spowodowało błąd: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "Konwertowany plik nie został znaleziony, lub więcej niż jeden plik w "
 "folderze %(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre zakończyło się błędem: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Konwertowanie nie powiodło się: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Ponowne łączenie z bazą danych Calibre"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr "Czyszczenie odwołań do zarchiwizowanych książek"
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan"
 msgstr "Skanowanie duplikatów"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr "Pominięto skanowanie duplikatów: trwa import"
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr "Budowanie indeksu duplikatów"
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr "Budowanie indeksu duplikatów: %(processed)s/%(total)s książek"
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr "Budowanie indeksu duplikatów: brak książek"
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 msgid "Finding duplicate groups"
 msgstr "Wyszukiwanie grup duplikatów"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 msgid "Updating duplicate cache"
 msgstr "Aktualizowanie pamięci podręcznej duplikatów"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Skanowanie duplikatów oczekuje: wymagane skanowanie ręczne"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr "Skanowanie duplikatów zakończone: grup %(count)s"
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr "Skanowanie duplikatów zakończone: nowych grup %(count)s"
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 "Skanowanie duplikatów zakończone: automatycznie rozwiązano grup %(count)s"
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr "Synchronizowanie dodań na półkach z Hardcover"
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 msgid "Hardcover Sync"
 msgstr "Synchronizacja Hardcover"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "E-mail"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr "Tworzenie kopii zapasowej metadanych"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr "Konwersja biblioteki – pełne uruchomienie"
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 msgid "Convert Library"
 msgstr "Konwertuj bibliotekę"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr "Naprawa EPUB – pełne uruchomienie"
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr "Naprawa EPUB"
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "Wygenerowano %(count)s miniatur okładek"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "Miniatury okładek"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "Wygenerowano {0} miniatur cykli"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "Czyszczenie pamięci podręcznej miniatur okładek"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 msgid "Book organizer"
 msgstr "Organizator książek"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 msgid "Change sort order"
 msgstr "Zmień kolejność sortowania"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 msgid "Select multiple books"
 msgstr "Wybierz wiele książek"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 msgid "Display settings"
 msgstr "Ustawienia wyświetlania"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 msgid "Cover Settings"
 msgstr "Ustawienia okładek"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr "Ukryj znaczniki półek na okładkach"
 
 # ???
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 msgid "Selection actions"
 msgstr "Akcje zaznaczenia"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 msgid "Add to Shelf"
 msgstr "Dodaj do półki"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(publiczna)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr "Oznacz"
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 msgid "Downloads, fewest first"
 msgstr "Pobrania, od najmniejszej liczby"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 msgid "Downloads, most first"
 msgstr "Pobrania, od największej liczby"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 msgid "Date added, newest first"
 msgstr "Data dodania, najnowsze jako pierwsze"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 msgid "Date added, oldest first"
 msgstr "Data dodania, najstarsze jako pierwsze"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr "Tytuł A → Z"
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr "Tytuł Z → A"
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 msgid "Author A → Z"
 msgstr "Autor A → Z"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 msgid "Author Z → A"
 msgstr "Autor Z → A"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 msgid "Published, newest first"
 msgstr "Data wydania, najnowsze jako pierwsze"
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 msgid "Published, oldest first"
 msgstr "Data wydania, najstarsze jako pierwsze"
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr "Numer w cyklu, rosnąco"
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr "Numer w cyklu, malejąco"
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 msgid "Added to shelf, newest first"
 msgstr "Data dodania do półki, najnowsze jako pierwsze"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 msgid "Added to shelf, oldest first"
 msgstr "Data dodania do półki, najstarsze jako pierwsze"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr "Użytkownicy&nbsp;&nbsp;👤"
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "Adres e-mail czytnika e-booków"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 msgid "Send to eReader Subject"
 msgstr "Temat wysyłki na czytnik e-booków"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Przeglądanie"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Półka publiczna"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr "Zarządzaj zdjęciami profilowymi"
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "Importuj użytkowników LDAP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Ustawienia serwera e-mail&nbsp;&nbsp;📬"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "Adres serwera SMTP"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "Port serwera SMTP"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "Nazwa użytkownika SMTP"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Wyślij z adresu e-mail"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr "Usługa e-mail"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail przez Oauth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr "Konfiguracja&nbsp;&nbsp;⚙️"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Folder bazy danych Calibre"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Poziom dziennika"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Port zewnętrzny"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Liczba książek na stronie"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Wysyłanie"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Anonimowe przeglądanie"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Publiczna rejestracja"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Zdalne logowanie (Magic Link)"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Logowanie reverse proxy"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Nazwa nagłowka reverse proxy"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr "Ustawienia NextGen"
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Edytuj podstawową konfigurację"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Edytuj konfigurację interfejsu"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Edytuj konfigurację bazy danych Calibre"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "Zaplanowane zadania&nbsp;&nbsp;⌛"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "Czas rozpoczęcia"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "Maksymalny czas trwania"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr "Zaplanowane odświeżanie miniatur"
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "Generuj miniatury okładek cykli"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Ponownie połącz z bazą danych Calibre"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr "Generuj pliki kopii zapasowej metadanych"
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "Odśwież pamięć podręczną miniatur"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr "Funkcje administracyjne NextGen&nbsp;&nbsp;⚡"
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr "Pokaż statystyki NextGen"
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr "Sprawdź stan NextGen"
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 msgid "Setup KOReader Sync"
 msgstr "Skonfiguruj synchronizację KOReader"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr "Usługa konwersji biblioteki NextGen"
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr "Usługa naprawy EPUB NextGen"
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr "GitHub NextGen"
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr "Serwer Discord NextGen"
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr "Uruchom automatyczne pobieranie z Hardcover"
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Administracja&nbsp;&nbsp;🚀"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
@@ -7115,88 +6988,87 @@ msgstr ""
 "Oczyszczone: bezpieczne do dołączenia do publicznego zgłoszenia na GitHubie. "
 "Hasła, tokeny, adresy IP i ścieżki instalacji zostały usunięte."
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr "Pobierz pakiet wsparcia"
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 "Pełny, nieocenzurowany pakiet. Tylko do użytku administracyjnego/prywatnego "
 "— zawiera dane poufne i adresy IP."
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Pobierz pakiet Debug"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Podgląd dziennika"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Uruchom ponownie Calibre Web"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Zatrzymaj Calibre Web"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "Informacje o wersji&nbsp;&nbsp;📜"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Wersja"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Szczegóły"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 msgid "Update available"
 msgstr "Dostępna aktualizacja"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 msgid "Update now"
 msgstr "Zaktualizuj teraz"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Bieżąca wersja"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Sprawdź aktualizacje"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Wykonaj aktualizację"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Na pewno chcesz uruchomić ponownie Calibre Web?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Na pewno chcesz zatrzymać Calibre Web?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Aktualizowanie, proszę nie odświeżać strony"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7208,7 +7080,7 @@ msgstr ""
 "tej bibliotece zostaną dodane do Twojego konta; książki wgrane ręcznie, "
 "których nie ma w bibliotece, zostaną pominięte."
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
@@ -7216,184 +7088,171 @@ msgstr ""
 "Plik jest przetwarzany w pamięci i usuwany po zakończeniu importu. Nigdy nie "
 "jest przechowywany na serwerze."
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr "KoboReader.sqlite"
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr "Importuj"
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr "Podsumowanie importu"
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr "zaimportowano nowych zakreśleń"
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr "już zaimportowane (pominięto)"
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 msgid "for books not in this library (skipped)"
 msgstr "dla książek spoza tej biblioteki (pominięto)"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr "ukryte na urządzeniu (pominięto)"
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr "łącznie przeanalizowanych wpisów"
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Wysyłanie…"
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 msgid "Import failed."
 msgstr "Import nie powiódł się."
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 msgid "Network error."
 msgstr "Błąd sieci."
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr "Eksportuj Markdown"
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr "Eksportuj CSV"
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr "Eksportuj JSON"
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr "Otwórz książkę"
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr "Zakreśleń: %(count)d"
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr "Notatka:"
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr "Postęp rozdziału: %(pct)d%%"
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Source: %(s)s"
 msgstr "Źródło: %(s)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr "Brak jeszcze adnotacji do tej książki."
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "przez"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "W Bibliotece"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "zwiń"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Więcej według"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Usuń książkę"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Usuń formaty:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Konwertuj format książki:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Konwertuj z:"
 
 # ???
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr "wybierz opcję"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Konwertuj na:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Konwertuj książkę"
 
 # ???
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Błąd"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Wyślij format"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "ID cyklu"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Data publikacji"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Rodzaj identyfikatora"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Wartość identyfikatora"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Usuń"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Dodaj identyfikator"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
@@ -7401,53 +7260,53 @@ msgstr ""
 "Wybierz okładkę z dowolnego źródła, wklej adres URL, prześlij plik lub użyj "
 "okładki osadzonej."
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Pobierz okładkę z linku (JPEG - obraz zostanie pobrany i zapisany w bazie)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Wyślij okładkę z dysku lokalnego"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 msgid "Hardcover Sync Blacklist"
 msgstr "Czarna lista synchronizacji Hardcover"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr "Wyklucz adnotacje z synchronizacji z Hardcover"
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr "Wyklucz postęp czytania z synchronizacji z Hardcover"
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Po zapisaniu wyświetl szczegóły książki"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Uzyskaj metadane"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Słowo kluczowe"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "Szukaj słowa kluczowego"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr "Wybrane pola metadanych zostały zastosowane w formularzu edycji."
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr "Klucze API"
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
@@ -7457,177 +7316,168 @@ msgstr ""
 "poprawia jakość okładek i odblokowuje usługi z limitem zapytań. Klucze są "
 "przechowywane raz, dla całej instancji — tylko dla administratorów."
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Ładowanie..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr "Sortuj według:"
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr "Kolejność dostawców (domyślna)"
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr "Rozmiar okładki — od największej"
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr "Rozmiar okładki — od najmniejszej"
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr "Zastosuj"
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Błąd wyszukiwania!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "Nie znaleziono! Spróbuj użyć innego słowa kluczowego."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "To pole jest wymagane"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr " Zamień autora i tytuł"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 msgid "Select all"
 msgstr "Zaznacz wszystko"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr "Wyczyść wszystko"
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 msgid "Update Title Sort automatically  "
 msgstr "Automatycznie aktualizuj sortowanie tytułów  "
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Automatycznie aktualizuj sortowanie autorów"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Wpisz tytuł"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Wprowadź tytuł sortowania"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Tytuł sortowania"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Wpisz autora sortowania"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Autor sortowania"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Wpisz autorów"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Wprowadź kategorie"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Wpisz serię"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Wprowadź języki"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Data publikacji"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Wpisz Wydawnictwa"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Wprowadź komentarze"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Comments"
 msgstr "Komentarze"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 msgid "Archived?"
 msgstr "Zarchiwizowane?"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 msgid "Read?"
 msgstr "Przeczytane?"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "Wprowadź "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Czy jesteś pewny?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "Książki z tytułem zostaną połączone z:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "Do książki z tytułem:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr "Następujące książki zostaną usunięte:"
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr "Następujące książki zostaną zarchiwizowane:"
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr "Następujące książki zostaną przywrócone z archiwum:"
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr "Następujące książki zostaną oznaczone jako przeczytane:"
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr "Następujące książki zostaną oznaczone jako nieprzeczytane:"
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Edytuj metadane"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr "Edytuj pola, które chcesz zmienić. Puste pola będą ignorowane:"
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
@@ -7635,32 +7485,31 @@ msgstr ""
 "Dla pól Autorzy, Tagi/Kategorie, Języki i Wydawcy obsługiwanych jest wiele "
 "wartości. Podaj je oddzielone przecinkami (np. \"Nazwa1, Nazwa2\")."
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 msgid "Select a Shelf"
 msgstr "Wybierz półkę"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr "Wybierz półkę, do której chcesz dodać wybrane książki:"
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr "-- Wybierz półkę --"
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Dodaj"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr ""
 "Serwer e-mail nie jest jeszcze skonfigurowany, więc ogłoszeń nie można "
 "wysłać."
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
@@ -7668,21 +7517,21 @@ msgstr ""
 "Utwórz wiadomość i wyślij ją e-mailem do swoich użytkowników. Wiadomości są "
 "kolejkowane i wysyłane w tle — status dostarczenia sprawdzisz w Zadaniach."
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr "Temat"
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr "Wiadomość"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 "Napisz tutaj swoje ogłoszenie. Dozwolony jest HTML (linki, pogrubienie, "
 "listy)."
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
@@ -7691,48 +7540,48 @@ msgstr ""
 "korzystający z klientów pocztowych obsługujących tylko tekst automatycznie "
 "otrzymają wersję tekstową."
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr "Użyj tekstu bieżącego banera ogłoszenia"
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr "Odbiorcy"
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 msgid "Select all users with an email address"
 msgstr "Zaznacz wszystkich użytkowników z adresem e-mail"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 "Żaden użytkownik nie ma ustawionego adresu e-mail, więc nie ma jeszcze do "
 "kogo wysłać."
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr "Wyślij ogłoszenie"
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 msgid "Send test to me"
 msgstr "Wyślij test do mnie"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Wróć"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr "Wysłać to ogłoszenie do odbiorców: __NUM__?"
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr "Rozwiązywanie problemów z bazą danych"
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
@@ -7742,18 +7591,18 @@ msgstr ""
 "zamontowaniem bazy danych Calibre (metadata.db) lub, mniej prawdopodobnie, "
 "problem z plikiem app.db."
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr "Częste przyczyny to:"
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 "NextGen i Calibre korzystają jednocześnie z tej samej bazy danych lub "
 "biblioteki."
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
@@ -7762,7 +7611,7 @@ msgstr ""
 "NextGen, lub jego część, działa na udziale sieciowym bez włączonego "
 "%(network_share_mode)s w konfiguracji Docker Compose."
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
@@ -7771,23 +7620,23 @@ msgstr ""
 "NextGen działa na %(unionfs)s lub %(mergerfs)s bez włączonego "
 "%(network_share_mode)s."
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr "Ścieżka do bazy danych Calibre uległa zmianie lub jest nieprawidłowa."
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr "Plik bazy danych Calibre (metadata.db) jest brakujący lub uszkodzony."
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr "Uprawnienia do plików uniemożliwiają dostęp do bazy danych Calibre."
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr "Aby rozwiązać te problemy, upewnij się, że:"
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
@@ -7795,7 +7644,7 @@ msgstr ""
 "Żadna inna aplikacja, w tym Calibre, nie korzysta z tej samej bazy danych "
 "Calibre, gdy działa NextGen."
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
@@ -7804,14 +7653,14 @@ msgstr ""
 "Jeśli używasz udziału sieciowego, unionfs lub mergerfs, włącz "
 "%(network_share_mode)s w konfiguracji Docker Compose."
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 "Ścieżka do bazy danych Calibre (metadata.db) jest prawidłowa i dostępna dla "
 "NextGen."
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
@@ -7819,11 +7668,11 @@ msgstr ""
 "Plik bazy danych Calibre (metadata.db) istnieje i nie jest uszkodzony. "
 "Spróbuj otworzyć go w Calibre, aby sprawdzić jego integralność."
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr "NextGen ma uprawnienia do dostępu do pliku bazy danych Calibre."
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
@@ -7831,7 +7680,7 @@ msgstr ""
 "Jeśli problem utrzymuje się po sprawdzeniu wszystkich powyższych punktów, "
 "przywróć bazę danych Calibre z kopii zapasowej lub utwórz nową."
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
@@ -7839,11 +7688,11 @@ msgstr ""
 "Możesz również użyć opcji Przywracanie ostateczne na dole tej strony, aby "
 "spróbować odbudować bazę danych Calibre na podstawie plików OPF w bibliotece."
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Lokalizacja bazy danych Calibre (plik metadata.db)"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7870,7 +7719,7 @@ msgstr ""
 "        <a href=\"https://github.com/crocodilestick/Calibre-Web-Automated/"
 "wiki/Configuration#database-configuration\">znajdziesz tutaj</a>!"
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
@@ -7878,7 +7727,7 @@ msgstr ""
 "Dlatego podczas konfigurowania pliku docker-compose dla NextGen <b>NIE "
 "ZMIENIAJ ŚCIEŻEK W SEKCJI VOLUMES PO PRAWEJ STRONIE DWUKROPKÓW!</b>"
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7895,7 +7744,7 @@ msgstr ""
 "        biblioteki, skorzystaj z opcji <b>Oddziel pliki książek od "
 "biblioteki poniżej i podaj tam ścieżkę do reszty biblioteki</b>"
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7911,11 +7760,11 @@ msgstr ""
 "wprowadzić <code>/books</code> w polu, które pojawi się poniżej po "
 "zaznaczeniu opcji <b>Oddziel pliki książek od biblioteki</b>."
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr "Funkcja rozdzielenia biblioteki"
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
@@ -7925,32 +7774,32 @@ msgstr ""
 "powinien pozostać w <code>/calibre-library</code>, jednak pliki biblioteki "
 "mogą być w dowolnym miejscu"
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Użyć dysku Google?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Uwierzytelnij Dysk Google"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Folder Calibre na Google Drive"
 
 # ???
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "ID kanału monitorowania metadanych"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Unieważnij"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Ostateczność: przywróć bazę danych Calibre (eksperymentalne)"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7968,91 +7817,91 @@ msgstr ""
 "zapasowej w /config/backup przed jakąkolwiek destrukcyjną operacją.</b> "
 "Dziennik przywracania zostanie zapisany razem z kopiami zapasowymi."
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 msgid "Are you sure? This cannot be undone."
 msgstr "Czy na pewno? Tej operacji nie można cofnąć."
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Przywróć bazę danych Calibre (ostateczność)"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr ""
 "Nowa lokalizacja bazy danych jest nieprawidłowa, proszę podać prawidłową "
 "ścieżkę"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Użyj standardowego uwierzytelnienia"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Użyj uwierzytelniania LDAP"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Uzyj OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Konfiguracja serwera"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Port serwera"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "Lokalizacja certyfikatu SSL (pozostaw puste jeśli bez SSL)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "Lokalizacja klucza SSL (pozostaw puste jeśli bez SSL)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Kanał aktualizacji"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Wersje stabilne"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Wydania nocne"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "Zaufane hosty (oddzielone przecinkami)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Konfiguracja dziennika"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "Lokalizacja i nazwa pliku dziennika (domyślnie /dev/stdout)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Włącz dziennik dostępu (access log)"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "Lokalizacja i nazwa pliku dziennika dostepu (domyślnie access.log)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 msgid "Feature Configuration"
 msgstr "Konfiguracja funkcji"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 "Konwertuj znaki inne niż angielskie w tytule i autorze podczas zapisywania "
 "na dysk"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
@@ -8060,39 +7909,39 @@ msgstr ""
 "Osadzaj metadane w pliku e-booka podczas pobierania/konwersji/e-maila "
 "(wymaga plików binarnych Calibre/Kepubify)"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Włącz wysyłanie"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr "(Upewnij się, że użytkownicy mają również uprawnienia do wysyłania)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Dozwolone formaty przesyłania"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Włącz anonimowe przeglądanie"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Włącz publiczną rejestrację"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "Użyj e-maila jako nazwy użytkownika"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Włącz zdalne logowanie (\"Magic Link\")"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr "Zezwól użytkownikom na ukrywanie książek w ich osobistej bibliotece"
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -8105,44 +7954,44 @@ msgstr ""
 "własnego indeksu/wyszukiwania/OPDS bez wpływu na innych użytkowników. "
 "Odzyskanie odbywa się przez stronę profilu (link Ukryte książki)."
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Nieznane żądania proxy do Kobo Store"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Zewnętrzny port serwera (dla połączeń API przekierowanych przez port)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 "Synchronizuj adnotacje Kobo z Hardcover (wymaga klucza API dla użytkownika)"
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr "Dopasuj okładki książek do proporcji ekranu Kobo za pomocą dopełnienia"
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
@@ -8153,60 +8002,60 @@ msgstr ""
 "stosowane po stronie serwera; oryginalne pliki okładek na dysku pozostają "
 "bez zmian."
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr "Kobo Libra Color / Libra 2 (1264x1680)"
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr "2:3 (okładka wydawcy, bez dopełnienia dla typowych okładek)"
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr "Jednolity: najczęstszy kolor na okładce"
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr "Jednolity: średni kolor okładki"
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr "Jednolity: kolor niestandardowy"
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr "Niestandardowy kolor obramowania (hex)"
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 "Używane tylko, gdy styl wypełnienia to \"Jednolity: kolor niestandardowy\". "
 "Format: #RRGGBB."
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Użyj Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Klucz API Goodreads"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 msgid "Enable Hardcover Sync"
 msgstr "Włącz synchronizację Hardcover"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 "Steruje automatycznym pobieraniem z Hardcover i synchronizacją postępu "
 "czytania za pomocą jednego ustawienia."
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
@@ -8214,11 +8063,11 @@ msgstr ""
 "Zarządzane przez zmienną HARDCOVER_SYNC_ENABLED; zmień tę zmienną "
 "środowiskową, aby włączyć lub wyłączyć synchronizację z Hardcover."
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr "Klucz API Hardcover"
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
@@ -8226,7 +8075,7 @@ msgstr ""
 "Darmowy klucz z https://hardcover.app/account/api — wymagany do uzyskiwania "
 "wyników metadanych z Hardcover."
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
@@ -8234,7 +8083,7 @@ msgstr ""
 "Obecnie aktywny jest token ze zmiennej środowiskowej HARDCOVER_TOKEN. Nie "
 "jest on tutaj wyświetlany; klucz wpisany w tym polu go nadpisze."
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
@@ -8242,31 +8091,31 @@ msgstr ""
 "Obecnie aktywny jest token z pliku wskazanego przez HARDCOVER_TOKEN_FILE. "
 "Nie jest on tutaj wyświetlany; klucz wpisany w tym polu go nadpisze."
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr "Stan tokenu: nieskonfigurowany."
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr "Stan tokenu: prawidłowy."
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 msgid "Token status: rejected or expired."
 msgstr "Stan tokenu: odrzucony lub wygasły."
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr "Stan tokenu: obecny; weryfikacja jest chwilowo niedostępna."
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr "Wygaśnięcie: nie podane przez ten token."
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 msgid "Google Books API Key"
 msgstr "Klucz API Google Books"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8278,11 +8127,11 @@ msgstr ""
 "Darmowy klucz uzyskasz na https://console.cloud.google.com — włącz \"Books "
 "API\" i utwórz klucz API."
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Zezwalaj na uwierzytelnianie reverse proxy"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
@@ -8292,11 +8141,11 @@ msgstr ""
 "uwierzytelniania. Jest to metoda uwierzytelniania odrębna od poniższego "
 "ustawienia bezpieczeństwa HTTPS."
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr "Używaj przez HTTPS"
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
@@ -8305,11 +8154,11 @@ msgstr ""
 "TYLKO, jeśli łączysz się z serwerem przez HTTPS, w przeciwnym razie stracisz "
 "dostęp."
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr "Automatycznie twórz użytkowników na podstawie reverse proxy"
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
@@ -8319,79 +8168,79 @@ msgstr ""
 "reverse proxy. Włącz tylko wtedy, gdy uwierzytelnianie reverse proxy jest "
 "odpowiednio zabezpieczone."
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Rodzaj logowania"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr "Użyj OAuth (wymaga HTTPS)"
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "Nazwa hosta lub adres IP serwera LDAP"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "Port serwera LDAP"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "Szyfrowanie LDAP"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Ścieżka certyfikatu urzędu certyfikacji LDAP (wymagana tylko dla "
 "uwierzytelniania certyfikatu klienta)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Ścieżka certyfikatu LDAP (potrzebna tylko do uwierzytelniania certyfikatem "
 "klienta)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Ścieżka pliku klucza LDAP (wymagana tylko dla uwierzytelniania certyfikatem "
 "klienta)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "Uwierzytelnianie LDAP"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Proste"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "Nazwa administratora LDAP"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "Hasło administratora LDAP"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "LDAP Distinguished Name (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "LDAP User Object Filter"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "Serwer LDAP to OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr "Automatycznie twórz użytkowników na podstawie LDAP"
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
@@ -8399,43 +8248,43 @@ msgstr ""
 "Automatycznie twórz konta użytkowników, gdy uwierzytelnianie LDAP dla nowych "
 "użytkowników się powiedzie. Zalecane w środowiskach firmowych."
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr "Następujące ustawienia są niezbędne dla zaimportowania użytkowników"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "Filtr obiektów grupy LDAP"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "Nazwa grupy LDAP"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "Pola członków grupy LDAP"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "Wykrywanie filtra użytkownika członka LDAP"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "Autodetekcja"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "Filtr niestandardowy"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "Filtr użytkownika członka LDAP"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr "Ważne:"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
@@ -8443,28 +8292,28 @@ msgstr ""
 "Uwierzytelnianie OAuth wymaga dostępu do tego serwera przez HTTPS. Jeśli "
 "używasz HTTP, logowanie się nie powiedzie."
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr "Ogólny dostawca OAuth"
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr "URL metadanych OAuth (do automatycznego wykrywania)"
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 msgid "Test Metadata"
 msgstr "Testuj metadane"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr "Pozostaw puste, aby użyć ręcznej konfiguracji poniżej"
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 "Użyj ręcznych adresów URL punktów końcowych (nadpisz automatyczne wykrywanie)"
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
@@ -8472,43 +8321,43 @@ msgstr ""
 "Zaznacz, aby ręcznie skonfigurować poszczególne punkty końcowe OAuth zamiast "
 "automatycznego wykrywania"
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 msgid "Manual Endpoint Configuration"
 msgstr "Ręczna konfiguracja punktów końcowych"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr "Podstawowy URL OAuth"
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr "Punkt końcowy autoryzacji"
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 msgid "Token Endpoint"
 msgstr "Punkt końcowy tokenu"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr "Punkt końcowy informacji o użytkowniku"
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 msgid "Test Connection"
 msgstr "Testuj połączenie"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 msgid "OAuth Scopes"
 msgstr "Zakresy OAuth"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr "Lista zakresów OAuth oddzielonych spacjami"
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr "Host przekierowania OAuth"
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
@@ -8518,7 +8367,7 @@ msgstr ""
 "\"nieprawidłowy identyfikator URI przekierowania\". Podaj wraz z protokołem "
 "(https://). Pozostaw puste, aby użyć automatycznego wykrywania."
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
@@ -8527,39 +8376,39 @@ msgstr ""
 "się za reverse proxy lub pojawiają się błędy \"nieprawidłowy identyfikator "
 "URI przekierowania\"."
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 msgid "OAuth Client Id"
 msgstr "Identyfikator klienta OAuth"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 msgid "OAuth Client Secret"
 msgstr "Sekret klienta OAuth"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 msgid "Field Mapping Configuration"
 msgstr "Konfiguracja mapowania pól"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 msgid "Username Field"
 msgstr "Pole nazwy użytkownika"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr "Pole JWT do wyodrębnienia nazwy użytkownika"
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 msgid "Email Field"
 msgstr "Pole adresu e-mail"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr "Pole JWT do wyodrębnienia adresu e-mail"
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 msgid "OAuth Group Claim"
 msgstr "Roszczenie (claim) grupy OAuth"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
@@ -8567,11 +8416,11 @@ msgstr ""
 "Roszczenie (claim) OIDC zawierające nazwy grup. Roszczenie może być listą "
 "lub ciągiem oddzielonym przecinkami lub spacjami."
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr "Wymagaj przynależności do grupy OAuth"
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
@@ -8579,11 +8428,11 @@ msgstr ""
 "Gdy włączone, użytkownicy ogólnego OAuth muszą należeć do co najmniej jednej "
 "dozwolonej grupy, zanim zostanie utworzone konto lub nastąpi zalogowanie."
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr "Dozwolone grupy OAuth"
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
@@ -8592,11 +8441,11 @@ msgstr ""
 "przez ogólne OAuth. Pozostaw puste tylko wtedy, gdy przynależność do grupy "
 "nie jest wymagana."
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr "Grupa OAuth dla administratora"
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
@@ -8606,46 +8455,46 @@ msgstr ""
 "wyłączyć zarządzanie administratorami na podstawie grup, lub użyj ustawienia "
 "globalnego w Ustawieniach bezpieczeństwa, aby mieć większą kontrolę."
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Domyślne uprawnienia dla nowych użytkowników ogólnego OAuth"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Zezwalaj na pobieranie"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Zezwalaj na przeglądanie e-booków"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Zezwalaj na wysyłanie"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Zezwalaj na edycję"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Zezwalaj na usuwanie książek"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Zezwalaj na zmianę hasła"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Zezwalaj na edycję półek publicznych"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
@@ -8656,54 +8505,54 @@ msgstr ""
 "uprawnienia administratora, gdy włączone jest zarządzanie administratorami "
 "na podstawie grup OAuth. Istniejący użytkownicy nie ulegają zmianie."
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr "Tekst przycisku logowania"
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Uzyskaj %(provider)s OAuth Credential"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "%(provider)s OAuth Client Id"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "%(provider)s OAuth Client Secret"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Zewnętrzne pliki"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr "Ścieżka do plików binarnych Calibre"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 msgid "Calibre E-Book Converter Settings"
 msgstr "Ustawienia konwertera e-booków Calibre"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Ścieżka do konwertera Kepubify"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 msgid "Location of Unrar binary"
 msgstr "Lokalizacja pliku binarnego Unrar"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 msgid "Security Settings"
 msgstr "Ustawienia zabezpieczeń"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr "Wyłącz standardowe logowanie (nazwa użytkownika/hasło)"
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
@@ -8712,11 +8561,11 @@ msgstr ""
 "OAuth lub LDAP. Przed włączeniem upewnij się, że masz działającą "
 "alternatywną metodę logowania."
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr "Włącz zarządzanie rolą administratora na podstawie grup OAuth"
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8728,89 +8577,89 @@ msgstr ""
 "zarządzać rolami administratora w panelu zarządzania użytkownikami, co "
 "zapobiegnie nadpisywaniu lokalnych przypisań ról przez logowania OAuth."
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr "Ogranicz nieudane próby logowania"
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr "Konfiguruj backend dla limitera"
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr "Opcje backendu limitera"
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 "Sprawdź czy rozszerzenia plików zgadzają się z zawartością podczas wysyłania"
 
 # ???
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 msgid "Session protection"
 msgstr "Ochrona sesji"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr "Podstawowa"
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr "Silna"
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 msgid "User Password policy"
 msgstr "Polityka haseł użytkowników"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr "Minimalna długość hasła"
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr "Wymagaj cyfry"
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr "Wymagaj małych liter"
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr "Wymagaj wielkich liter"
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr "Wymagaj znaków (potrzebne dla znaków chińskich/japońskich/koreańskich)"
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr "Wymagaj znaków specjalnych"
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Konfiguracja widoku"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr "Tytuł wyświetlany na karcie przeglądarki i pasku nawigacji."
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr "Liczba książek wyświetlanych na stronę w widokach listy (1–200)."
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Liczba losowych książek do pokazania"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr "Liczba losowych książek wyświetlanych na stronie głównej (1–30)."
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr "Liczba autorów do pokazania przed ukryciem (0=wyłącza ukrywanie)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
@@ -8818,15 +8667,15 @@ msgstr ""
 "Maksymalna liczba autorów pokazywanych w szczegółach książki przed "
 "obcięciem. Ustaw 0, aby wyłączyć."
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 msgid "Default Theme"
 msgstr "Motyw domyślny"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "Motyw caliBlur! Dark"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
@@ -8834,42 +8683,42 @@ msgstr ""
 "Domyślny motyw dla nowych użytkowników i przeglądania anonimowego. "
 "Użytkownicy mogą wybrać własny preferowany motyw w swoim profilu."
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Wyrażenie regularne dla ignorowanych kolumn"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 "Wzorzec wyrażenia regularnego ukrywający kolumny niestandardowe przed "
 "wyświetleniem w interfejsie."
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Połącz status przeczytane/nieprzeczytane z kolumną Calibre"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr ""
 "Synchronizuj status przeczytane/nieprzeczytane z logiczną kolumną "
 "niestandardową Calibre."
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Ograniczenie przeglądania w oparciu o kolumnę Calibre"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 "Ogranicz widoczność książek na podstawie wartości w tekstowej kolumnie "
 "niestandardowej Calibre."
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Wyrażenie regularne dla tytułu sortującego"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
@@ -8877,15 +8726,15 @@ msgstr ""
 "Wyrażenie regularne usuwające przedrostki z tytułów w celu prawidłowego "
 "sortowania (np. \"The\", \"A\", \"An\")."
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 msgid "Site Customization"
 msgstr "Dostosowanie witryny"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr "Baner ogłoszenia serwera"
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
@@ -8893,7 +8742,7 @@ msgstr ""
 "Pozostaw puste, aby ukryć baner. Wyświetlany jest na górze każdej strony, "
 "dopóki każdy użytkownik go nie odrzuci."
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
@@ -8902,16 +8751,16 @@ msgstr ""
 "użytkownik odrzuca baner niezależnie; edycja tekstu ponownie wyświetla go "
 "wszystkim."
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 msgid "Custom CSS"
 msgstr "Niestandardowy CSS"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr "np. .navbar { background: #2b2b2b; }"
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
@@ -8920,53 +8769,53 @@ msgstr ""
 "nadpisuje wbudowane motywy. Dotyczy wszystkich użytkowników. Pozostaw puste, "
 "aby wyłączyć."
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Domyślne ustawienia dla nowych użytkowników"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 "Te ustawienia zostaną zastosowane do wszystkich nowo tworzonych kont "
 "użytkowników."
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 msgid "Permissions"
 msgstr "Uprawnienia"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Użytkownik z uprawnieniami administratora"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 msgid "Language & Display"
 msgstr "Język i wyświetlanie"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "Domyślny język"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 msgid "Default interface language for new users."
 msgstr "Domyślny język interfejsu dla nowych użytkowników."
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "Domyślnie widoczne języki książek"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 msgid "Default book language filter for new users."
 msgstr "Domyślny filtr języka książek dla nowych użytkowników."
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr "Domyślny język OPDS dla klientów anonimowych"
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr "(brak — powrót do angielskiego)"
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
@@ -8976,38 +8825,38 @@ msgstr ""
 "nagłówka Accept-Language, a żądanie nie zawiera nadpisania ?lang=. "
 "Uwierzytelnieni użytkownicy zachowują swój wybrany język."
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Domyślne ustawienia widoku dla nowych użytkowników"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 "Wybierz, które sekcje panelu bocznego są domyślnie widoczne dla nowych "
 "użytkowników."
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Pokaz losowe książki w widoku szczegółowym"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Dodaj dozwolone/zabronione etykiety"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Dodaj dozwolone/zabronione wartości własnych kolumn"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr "Użyj adresu URL"
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 msgid "Upload a file"
 msgstr "Prześlij plik"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
@@ -9017,11 +8866,11 @@ msgstr ""
 "jakość okładek i odblokowuje usługi z limitem zapytań. Klucze są "
 "przechowywane raz, dla całej instancji — tylko dla administratorów."
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr "Pokaż, jak każda okładka wyglądałaby na Twoim czytniku e-booków"
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
@@ -9029,60 +8878,55 @@ msgstr ""
 "Dostosuj tutaj podgląd okładek. Ustawienia domyślne znajdują się w Panel "
 "administratora → Konfiguracja → Synchronizacja Kobo."
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr "Kandydaci"
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr "Wczytywanie kandydatów…"
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr "Zamienić okładkę na tego kandydata?"
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr "Renderowanie podglądów na czytniku:"
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run Archive"
 msgstr "Uruchom archiwizację"
 
 # ???
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 msgid "Download Log"
 msgstr "Pobierz log"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Rozpocznij"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr "Zaplanuj co 5 min"
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr "Zaplanuj co 15 min"
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr "Pomyślnie zaplanowano konwersję biblioteki"
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr "Błąd podczas planowania konwersji biblioteki"
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -9091,14 +8935,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -9106,86 +8950,85 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr "Uruchom na pojedynczej książce"
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr "Szukaj według tytułu/autora"
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on selected book"
 msgstr "Uruchom na wybranej książce"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer scheduled successfully"
 msgstr "Pomyślnie zaplanowano naprawę EPUB"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error scheduling EPUB Fixer"
 msgstr "Błąd podczas planowania naprawy EPUB"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 msgid "No matches found"
 msgstr "Nie znaleziono dopasowań"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 msgid "Enter a search term"
 msgstr "Wprowadź szukaną frazę"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 msgid "Failed to search library"
 msgstr "Nie udało się przeszukać biblioteki"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 msgid "Select a book first"
 msgstr "Najpierw wybierz książkę"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer started for selected book"
 msgstr "Rozpoczęto naprawę EPUB dla wybranej książki"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error starting EPUB Fixer"
 msgstr "Błąd podczas uruchamiania naprawy EPUB"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Włącz/wyłącz usługi Calibre-Web NextGen"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr "Włącz automatyczną konwersję NextGen"
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -9198,11 +9041,11 @@ msgstr ""
 "        <em>Z WYJĄTKIEM</em> tych, które poniżej wyraźnie wskazałeś NextGen "
 "do zignorowania."
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr "Włącz usługę automatycznego wymuszania okładek i metadanych NextGen"
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -9221,11 +9064,11 @@ msgstr ""
 "EPUB \n"
 "        lub AZW3."
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr "Włącz naprawę EPUB dla Kindle w NextGen"
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -9242,7 +9085,7 @@ msgstr ""
 "swoje urządzenia Kindle i napotykali problemy z \n"
 "        odrzucaniem plików lub formatowaniem."
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
@@ -9252,11 +9095,11 @@ msgstr ""
 "kindle-epub-fix.netlify.app/\">kindle-epub-fix.netlify.app</a> stworzonego "
 "przez <a href=\"https://github.com/innocenat\">innocenat</a>."
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr "Włącz synchronizację KOReader (wtyczka NextGen)"
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
@@ -9266,7 +9109,7 @@ msgstr ""
 "metadata.db sumy kontrolne zgodne z KOReader, do synchronizacji postępu. "
 "Wymaga wtyczki KOReader na Twoim urządzeniu."
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
@@ -9276,11 +9119,11 @@ msgstr ""
 "kontrolnych, która może tymczasowo blokować metadata.db. Aby zatrzymać "
 "trwające uzupełnianie, po wyłączeniu uruchom ponownie kontener."
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr "Włącz tryb agresywnej naprawy EPUB (bardziej ryzykowny)"
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
@@ -9289,11 +9132,11 @@ msgstr ""
 "konwersji kodowania o mniejszej pewności. Dla większości bibliotek zalecany "
 "jest tryb bezpieczny."
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 msgid "Enable Archived Book Cleanup"
 msgstr "Włącz czyszczenie zarchiwizowanych książek"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
@@ -9302,116 +9145,116 @@ msgstr ""
 "książka nie istnieje już w bibliotece Calibre. Pomaga utrzymać dokładność "
 "liczników archiwum."
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr "Harmonogram czyszczenia:"
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr "Częste interwały"
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr "Co 15 minut"
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr "Co 30 minut"
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr "Co godzinę"
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr "Co 2 godziny"
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr "Co 4 godziny"
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr "Co 6 godzin"
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr "Co 12 godzin"
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr "Codziennie/co tydzień/co miesiąc"
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr "Codziennie o określonej godzinie"
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr "Co tydzień, w określonym dniu"
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr "Co miesiąc, w określonym dniu"
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr "Domyślnie: codziennie o 03:00"
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr "Dzień tygodnia:"
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr "Poniedziałek"
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr "Wtorek"
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr "Środa"
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr "Czwartek"
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr "Piątek"
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr "Sobota"
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr "Niedziela"
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr "Dzień miesiąca:"
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr "(1–28)"
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr "Godzina:"
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr "(Strefa czasowa serwera: %(tz)s)"
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr "Włącz automatyczne pobieranie metadanych dla nowych książek"
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9424,11 +9267,11 @@ msgstr ""
 "Pomaga to poprawić jakość informacji o książkach, zwłaszcza w przypadku "
 "słabych lub brakujących metadanych."
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr "Włącz inteligentne stosowanie metadanych"
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9440,11 +9283,11 @@ msgstr ""
 "rozdzielczości). Gdy wyłączone, pobrane metadane zastąpią istniejące dane "
 "bezpośrednio danymi z preferowanego dostawcy."
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 msgid "Metadata Fields to Update"
 msgstr "Pola metadanych do aktualizacji"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
@@ -9454,25 +9297,23 @@ msgstr ""
 "pobierania. Niezaznaczone pola nigdy nie zostaną zmienione podczas "
 "automatycznego pobierania metadanych, co zachowa Twoje istniejące dane."
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr "Tagi/Gatunki"
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identyfikatory (ISBN itd.)"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 msgid "Cover Image"
 msgstr "Obraz okładki"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr "Wskazówka"
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
@@ -9483,15 +9324,15 @@ msgstr ""
 "wybranych pól, podczas gdy tryb bezpośredni zastąpi wszystkie wybrane pola "
 "danymi od dostawcy."
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr "Maksymalny rozmiar pliku okładki (MB):"
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr "Zakres: 1–200 MB (domyślnie: 15)"
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
@@ -9499,11 +9340,11 @@ msgstr ""
 "Ogranicza maksymalny rozmiar obrazów okładek pobieranych od dostawców "
 "metadanych lub z adresów URL, aby zapobiec wolnym lub zablokowanym zapisom."
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr "Limit czasu przetwarzania importu"
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
@@ -9513,19 +9354,19 @@ msgstr ""
 "przekroczeniem limitu. Pliki, które przekroczą limit, są przenoszone do "
 "folderu nieudanych kopii zapasowych do analizy."
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr "Limit czasu (minuty):"
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr "Zakres: 5-120 minut (domyślnie: 15)"
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr "Czyszczenie nieaktualnych plików tymczasowych"
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
@@ -9536,27 +9377,27 @@ msgstr ""
 "wartości na 0 wyłącza czyszczenie. Zmiany obowiązują od następnego cyklu "
 "czyszczenia."
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr "Wiek nieaktualnych plików tymczasowych (minuty):"
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr "Zakres: 0–10080 minut (domyślnie: 120)"
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr "Interwał czyszczenia nieaktualnych plików tymczasowych (sekundy):"
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr "Zakres: 0–86400 sekund (domyślnie: 600)"
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr "Opóźnienie automatycznego wysyłania nowych książek"
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9568,19 +9409,19 @@ msgstr ""
 "metadanych i innego przetwarzania przed wysłaniem. Dotyczy tylko "
 "użytkowników, którzy włączyli automatyczne wysyłanie w swoim profilu."
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr "Opóźnienie (minuty):"
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr "Zakres: 1–60 minut (domyślnie: 5)"
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr "Hierarchia dostawców automatycznego pobierania metadanych"
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
@@ -9590,25 +9431,25 @@ msgstr ""
 "automatycznego pobierania metadanych dla nowych książek. Przeciągnij i "
 "upuść, aby zmienić kolejność dostawców. Używani będą tylko włączeni dostawcy."
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 "Dostawcy są sprawdzani w kolejności od góry do dołu. Przeciągnij, aby "
 "zmienić kolejność."
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr "Włączeni dostawcy metadanych"
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr "Niezaznaczeni dostawcy są wyłączeni globalnie."
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Ustawienia automatycznego pobierania z Hardcover"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
@@ -9619,11 +9460,11 @@ msgstr ""
 "postępu czytania i adnotacji z Hardcover.app podczas korzystania z "
 "kompatybilnych czytników e-booków."
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr "Wymagany token Hardcover"
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
@@ -9634,14 +9475,14 @@ msgstr ""
 "globalny token w Podstawowej konfiguracji. Bez prawidłowego tokenu ta "
 "funkcja pozostanie wyłączona."
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 "Synchronizacja z Hardcover jest włączona. Poniższy harmonogram steruje "
 "automatycznym pobieraniem identyfikatorów."
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
@@ -9649,7 +9490,7 @@ msgstr ""
 "Synchronizacja z Hardcover jest wyłączona. Włącz ją raz w Podstawowej "
 "konfiguracji lub ustaw HARDCOVER_SYNC_ENABLED=true."
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
@@ -9660,25 +9501,25 @@ msgstr ""
 "automatycznie; dopasowania o niskiej pewności trafiają do kolejki ręcznego "
 "przeglądu."
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr "Harmonogram uruchamiania:"
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 "Jak często automatycznie uruchamiać zadanie pobierania identyfikatorów "
 "Hardcover"
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr "Minimalny próg pewności:"
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr "Zakres: 0,50–1,00 (domyślnie: 0,85)"
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
@@ -9688,15 +9529,15 @@ msgstr ""
 "Niższe wyniki trafiają do kolejki ręcznego przeglądu. Wyższe wartości = "
 "mniej automatycznych dopasowań, ale wyższa dokładność."
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr "Rozmiar partii:"
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr "Zakres: 10–200 książek na uruchomienie (domyślnie: 50)"
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
@@ -9705,15 +9546,15 @@ msgstr ""
 "partie zmniejszają obciążenie API; większe partie przetwarzają bibliotekę "
 "szybciej."
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr "Opóźnienie limitu zapytań (sekundy):"
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr "Zakres: 0–60 sekund (domyślnie: 5,0)"
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
@@ -9722,7 +9563,7 @@ msgstr ""
 "limitu zapytań i chroni klucz API. Przy błędach stosowane jest wykładnicze "
 "wydłużanie odstępów."
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
@@ -9733,15 +9574,15 @@ msgstr ""
 "dopasowania wymagające ręcznego zatwierdzenia sprawdzisz na stronie "
 "Statystyk NextGen."
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 msgid "Web UI Settings"
 msgstr "Ustawienia interfejsu Web"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr "Włącz powiadomienia o aktualizacjach NextGen"
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
@@ -9749,11 +9590,11 @@ msgstr ""
 "Gdy aktywne, będziesz otrzymywać powiadomienia w interfejsie webowym, gdy "
 "zostanie wydana nowa wersja NextGen"
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 msgid "Automatic updates"
 msgstr "Automatyczne aktualizacje"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9766,22 +9607,21 @@ msgstr ""
 "mały towarzyszący program o nazwie Watchtower: wypatruje nowego obrazu i "
 "bezpiecznie podmienia NextGen, nie ruszając pozostałych kontenerów."
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
-"Dodaj te dwie usługi do pliku docker-compose i uruchom \"docker compose up -"
-"d\". Od tej pory aktualizacje odbywają się automatycznie — bez klikania "
+"Dodaj te dwie usługi do pliku docker-compose i uruchom \"docker compose up "
+"-d\". Od tej pory aktualizacje odbywają się automatycznie — bez klikania "
 "żadnego przycisku."
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr "Skopiowano!"
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
@@ -9791,7 +9631,7 @@ msgstr ""
 "Interwał 86400 to sprawdzanie raz dziennie; \"cleanup\" usuwa stary obraz po "
 "każdej aktualizacji."
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
@@ -9799,11 +9639,11 @@ msgstr ""
 "Używasz zamiast tego Podmana? Natywne \"podman auto-update\" również działa "
 "— przewodnik konfiguracji pojawi się po zweryfikowaniu go z tym obrazem."
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr "Włącz powiadomienia o tłumaczeniach"
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -9813,11 +9653,11 @@ msgstr ""
 "podczas używania języka innego niż angielski, jeśli tłumaczenia dla "
 "wybranego języka nie są kompletne."
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Synchronizuj Magiczne Półki z Kobo"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
@@ -9826,11 +9666,11 @@ msgstr ""
 "jako kolekcje. Uwaga: musisz również włączyć synchronizację Kobo w "
 "Podstawowej konfiguracji."
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Włącz rozmyte tła na urządzeniach mobilnych (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -9838,15 +9678,15 @@ msgstr ""
 "Gdy aktywne, efekt rozmytego tła okładki jest również renderowany na małych "
 "ekranach. Wyłącz, jeśli zauważysz opóźnienia przewijania lub animacji."
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 msgid "Automatic Backup Settings"
 msgstr "Ustawienia automatycznych kopii zapasowych"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr "Włącz automatyczne kopie zapasowe importu NextGen"
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -9854,11 +9694,11 @@ msgstr ""
 "Gdy aktywne, kopia wszystkich zaimportowanych plików będzie przechowywana w "
 "<i>/config/processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr "Włącz automatyczne kopie zapasowe konwersji NextGen"
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -9866,11 +9706,11 @@ msgstr ""
 "Gdy aktywne, oryginały zaimportowanych plików, które przeszły konwersję, "
 "będą przechowywane w /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr "Włącz automatyczne kopie zapasowe naprawy EPUB NextGen"
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
@@ -9879,11 +9719,11 @@ msgstr ""
 "dla Kindle NextGen będą przechowywane w /config/processed_books/"
 "fixed_originals"
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr "Włącz automatyczne kopie zapasowe ZIP w NextGen"
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9895,11 +9735,11 @@ msgstr ""
 "z danego dnia. Pomaga to utrzymać porządek w podkatalogach /config/"
 "processed_books i minimalizować wykorzystanie miejsca na dysku."
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr "Docelowy format automatycznej konwersji NextGen - domyślnie EPUB"
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -9909,11 +9749,11 @@ msgstr ""
 "książki będą automatycznie konwertowane do formatu wybranego tutaj (z "
 "wyjątkiem formatów wybranych na liście ignorowanych poniżej)"
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 msgid "Choose a target format:"
 msgstr "Wybierz format docelowy:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
@@ -9923,11 +9763,11 @@ msgstr ""
 "pliki w formacie EPUB lub AZW3. Pliki w innych formatach zostaną po prostu "
 "zignorowane przez tę usługę"
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr "Automatyczna konwersja NextGen - ignorowane formaty"
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
@@ -9936,11 +9776,11 @@ msgstr ""
 "NextGen, gdy jest ona aktywna, co oznacza, że zostaną zaimportowane bez "
 "zmian."
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr "Automatyczna konwersja NextGen - zachowywane formaty"
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9952,21 +9792,21 @@ msgstr ""
 "liście \"Automatyczny import NextGen - ignorowane formaty\", nie zostanie "
 "zaimportowany. Zauważ, że format docelowy jest zawsze zachowywany."
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr "Automatyczne scalanie importu NextGen"
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "Calibre może wykrywać zduplikowane tytuły książek podczas importu i w "
 "zależności od"
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr "automatycznego łączenia"
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -9974,23 +9814,23 @@ msgstr ""
 "ustawienia. Można ustawić usunięcie jednej z kopii zduplikowanej książki lub "
 "zachowanie obu (domyślnie)."
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Odrzuca zduplikowany import, zachowuje kopię z biblioteki"
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr "Nadpisuje kopię z biblioteki nowo zaimportowanym plikiem"
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Tworzy zduplikowany rekord, zachowując obie kopie"
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr "Automatyczny import NextGen - ignorowane formaty"
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
@@ -10000,11 +9840,11 @@ msgstr ""
 "NextGen, co oznacza, że pliki w tych formatach nie zostaną dodane do "
 "biblioteki przez NextGen podczas procesu importu"
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr "System wykrywania duplikatów NextGen"
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
@@ -10012,33 +9852,33 @@ msgstr ""
 "Włącz lub wyłącz system wykrywania duplikatów. Gdy wyłączony, skanowanie "
 "duplikatów nie będzie uruchamiane i żadne powiadomienia nie będą wyświetlane."
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Detection"
 msgstr "Włącz wykrywanie duplikatów"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 "Gdy włączone, NextGen będzie skanował w poszukiwaniu zduplikowanych książek "
 "po każdym imporcie"
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr "Metoda wykrywania duplikatów"
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr "Hybrydowa (wstępne filtrowanie SQL + walidacja Python)"
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr "Tylko Python (najwolniejsza, najbardziej niezawodna)"
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr "Tylko starsze SQL (eksperymentalne)"
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
@@ -10047,11 +9887,11 @@ msgstr ""
 "kandydatów, a następnie stosuje solidną logikę Python do uzyskania "
 "ostatecznych wyników."
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 msgid "Automatic Duplicate Scanning"
 msgstr "Automatyczne skanowanie duplikatów"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
@@ -10059,27 +9899,27 @@ msgstr ""
 "Skonfiguruj skanowanie duplikatów w tle. Uruchamia się ono automatycznie, "
 "nie blokując interfejsu."
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr "Włącz automatyczne skanowanie duplikatów"
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr "Skanowanie po imporcie"
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr "Uruchamiaj po każdym imporcie (z opóźnieniem grupującym)"
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr "Tylko ręczne"
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr "Opóźnienie grupujące po imporcie (sekundy)"
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
@@ -10087,15 +9927,15 @@ msgstr ""
 "Odczekaj tyle sekund po ostatnim imporcie przed rozpoczęciem skanowania w "
 "tle."
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr "Zaplanowane skanowania (wyrażenie cron)"
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr "Pozostaw puste, aby wyłączyć zaplanowane skanowania. Przykład:"
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
@@ -10104,15 +9944,15 @@ msgstr ""
 "być uruchamiane razem. Użyj opcji \"Tylko ręczne\", aby wyłączyć skanowania "
 "po imporcie, zachowując harmonogramy cron."
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr "Następne zaplanowane skanowanie:"
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr "Kryteria wykrywania duplikatów NextGen"
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
@@ -10122,31 +9962,31 @@ msgstr ""
 "duplikatami. Aby zostać uznane za duplikaty, książki muszą spełniać "
 "WSZYSTKIE wybrane kryteria."
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr "Uwzględniaj tytuły książek przy wykrywaniu duplikatów"
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr "Uwzględniaj autorów książek przy wykrywaniu duplikatów"
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr "Uwzględniaj język książek przy wykrywaniu duplikatów"
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr "Uwzględniaj cykl książek przy wykrywaniu duplikatów"
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr "Uwzględniaj wydawcę książek przy wykrywaniu duplikatów"
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr "Uwzględniaj format pliku przy wykrywaniu duplikatów"
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
@@ -10154,11 +9994,11 @@ msgstr ""
 "Musi być wybrane co najmniej jedno kryterium. Jako kryteria podstawowe "
 "zalecane są Tytuł i Autor."
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr "Ranking priorytetów formatów duplikatów"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
@@ -10168,11 +10008,11 @@ msgstr ""
 "automatycznego rozwiązywania \"Format najwyższej jakości\". Przeciągnij i "
 "upuść, aby zmienić kolejność formatów według priorytetu (wyżej = lepiej)."
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr "Wskazówka:"
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
@@ -10182,11 +10022,11 @@ msgstr ""
 "zachowywane będą książki z formatami o wyższej pozycji w rankingu. Formaty o "
 "niższym priorytecie zostaną usunięte."
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr "Powiadomienia o duplikatach i automatyczne rozwiązywanie"
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
@@ -10194,11 +10034,11 @@ msgstr ""
 "Skonfiguruj sposób powiadamiania o zduplikowanych książkach i opcjonalnie "
 "włącz automatyczne rozwiązywanie."
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Notifications"
 msgstr "Włącz powiadomienia o duplikatach"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
@@ -10209,15 +10049,15 @@ msgstr ""
 "przycisku Duplikaty w panelu bocznym oraz wyskakujące powiadomienie przy "
 "logowaniu."
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Włącz automatyczne rozwiązywanie duplikatów"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr "Ostrzeżenie:"
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
@@ -10225,74 +10065,74 @@ msgstr ""
 "Spowoduje to automatyczne usunięcie książek na podstawie poniższej "
 "strategii. Oryginalne pliki zostaną zapisane w kopii zapasowej w"
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr "Strategia automatycznego rozwiązywania"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr "Zachowaj najnowszą"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr "Usuń starsze kopie, zachowaj najnowszej dodaną książkę"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr "Zachowaj najstarszą"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr "Usuń nowsze kopie, zachowaj najwcześniej dodaną"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge Formats"
 msgstr "Scal formaty"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr "Scal formaty w najnowszej książce, usuń resztę"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr "Zachowaj format najwyższej jakości"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 "Preferuj formaty na podstawie Twojego rankingu priorytetów formatów "
 "duplikatów"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep Most Metadata"
 msgstr "Zachowaj najwięcej metadanych"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr "Zachowaj książkę z najpełniejszymi informacjami"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr "Zachowaj plik o największym rozmiarze"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr "Zachowaj książkę o największym łącznym rozmiarze pliku"
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 "Wybierz, którą książkę zachować przy automatycznym rozwiązywaniu duplikatów."
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 msgid "Rate Limiting"
 msgstr "Ograniczanie liczby zapytań"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr "Okres wyciszenia (minuty)"
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
@@ -10300,7 +10140,7 @@ msgstr ""
 "Minimalny czas między automatycznymi rozwiązaniami (0, aby wyłączyć). "
 "Zapobiega gwałtownym seriom usunięć podczas importów wsadowych."
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -10309,92 +10149,84 @@ msgstr ""
 "wykryje nowe duplikaty. Odrzucone grupy duplikatów nigdy nie są rozwiązywane "
 "automatycznie."
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr "Przejrzyj oczekujące dopasowania: %(count)s"
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr "Kliknij, aby zobaczyć więcej"
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr "Zanim odejdziesz — co skłoniło Cię do powrotu?"
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 "Opcjonalne i całkowicie anonimowe. Pomaga nam to ulepszać nowy interfejs."
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr "Coś było zepsute lub działało wadliwie"
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr "Wolę klasyczny wygląd"
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr "Brakowało funkcji, z której korzystam"
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr "Zbyt inny / trudno cokolwiek znaleźć"
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr "Wydawał się wolny"
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr "Nie, dziękuję"
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Następne"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr "Chcesz coś jeszcze dodać?"
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr "Opcjonalne — wystarczy jedno lub dwa zdania."
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr "Co skłoniłoby Cię do pozostania przy nowym interfejsie?"
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr "Wyślij opinię"
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr "Dziękujemy"
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr "Twoja opinia została wysłana anonimowo. Czytamy każdą wiadomość."
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr "Nie udało się teraz wysłać"
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
@@ -10402,21 +10234,21 @@ msgstr ""
 "Nic się nie stało — Twoja opinia nie została nigdzie zapisana. Możesz to "
 "zamknąć lub spróbować ponownie."
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr "Spróbuj ponownie"
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr "Zanonimizuj moją opinię"
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 "Żadne konto, nazwa, adres IP, wersja ani informacje o urządzeniu nie są "
 "wysyłane ani przechowywane."
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
@@ -10427,7 +10259,7 @@ msgstr ""
 "IP, aby zapobiec spamowi; używamy jedynie jego jednokierunkowego skrótu "
 "przez około minutę i nigdy go nie przechowujemy."
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
@@ -10435,156 +10267,152 @@ msgstr ""
 "Ponieważ wyłączyłeś anonimizację, dołączona zostanie wersja aplikacji, aby "
 "pomóc nam odtworzyć problemy."
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Oznacz jako nieprzeczytane"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Oznacz jako przeczytane"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 msgid "Marked as read"
 msgstr "Oznaczono jako przeczytane"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 msgid "Marked as unread"
 msgstr "Oznaczono jako nieprzeczytane"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 msgid "Added to favorites"
 msgstr "Dodano do ulubionych"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 msgid "Removed from favorites"
 msgstr "Usunięto z ulubionych"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Przywróć z archiwum"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Dodaj do archiwum"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 msgid "Restored from archive"
 msgstr "Przywrócono z archiwum"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr "Ponownie wczytano metadane z dysku"
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr "Metadane na dysku są zgodne — nie ma nic do zaktualizowania"
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr "Odkryj w swojej bibliotece"
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Hide from your library"
 msgstr "Ukryj w swojej bibliotece"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr "Odkryto"
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 msgid "Rating updated"
 msgstr "Ocena zaktualizowana"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 msgid "Rating cleared"
 msgstr "Ocena wyczyszczona"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "Książka %(index)s z %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr "ID"
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr "UUID"
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr "Skopiowano UUID do schowka"
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr "Nie udało się skopiować UUID"
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr "Kopiuj UUID"
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr "Rozmiary plików"
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Opis:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 msgid "Select eReader Email Addresses"
 msgstr "Wybierz adresy e-mail czytnika"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 msgid "Choose email addresses:"
 msgstr "Wybierz adresy e-mail:"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 msgid "Select All"
 msgstr "Zaznacz wszystko"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr "Czytniki e-booków innych użytkowników:"
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr "Dodatkowe adresy e-mail:"
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr "Wprowadź dodatkowe adresy e-mail (oddzielone przecinkami):"
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr "przyklad@domena.pl, inny@domena.pl"
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr "Podaj jeden lub więcej adresów e-mail oddzielonych przecinkami"
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 msgid "Select format:"
 msgstr "Wybierz format:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 msgid "Failed to update tags"
 msgstr "Nie udało się zaktualizować tagów"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 msgid "Failed to update shelves"
 msgstr "Nie udało się zaktualizować półek"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr "Menedżer duplikatów NextGen"
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
@@ -10592,31 +10420,31 @@ msgstr ""
 "Książki o pasujących tytułach, autorach i językach. Książki w różnych "
 "językach nie są uznawane za duplikaty."
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 msgid "Run Full Duplicate Scan"
 msgstr "Uruchom pełne skanowanie duplikatów"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 msgid "Scan for Duplicates Now"
 msgstr "Skanuj w poszukiwaniu duplikatów teraz"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr "Wybierz duplikaty"
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 msgid "Select None"
 msgstr "Odznacz wszystko"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 msgid "Delete Selected"
 msgstr "Usuń zaznaczone"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr "Skanowanie duplikatów wymaga jednorazowego pełnego skanowania."
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
@@ -10626,7 +10454,7 @@ msgstr ""
 "szybkie podczas importów i zmian metadanych. Zanim będą mogły działać "
 "skanowania przyrostowe, indeks potrzebuje wstępnego punktu odniesienia."
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
@@ -10635,23 +10463,23 @@ msgstr ""
 "przypadku dużych bibliotek może to potrwać kilka minut, a w tym czasie "
 "możesz nadal korzystać z CWA."
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 msgid "Duplicate scan is running."
 msgstr "Skanowanie duplikatów jest w toku."
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr "Możesz nadal korzystać z CWA w trakcie jego działania."
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr "Zobacz zadania w tle"
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr "Automatycznie rozwiąż duplikaty"
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
@@ -10659,23 +10487,23 @@ msgstr ""
 "Automatycznie rozwiąż wszystkie grupy duplikatów, zachowując jedną książkę i "
 "usuwając pozostałe na podstawie strategii."
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr "Strategia:"
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr "Zachowaj najnowszą - usuń starsze kopie, zachowaj najnowszej dodaną"
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr "Zachowaj najstarszą - usuń nowsze kopie, zachowaj najwcześniej dodaną"
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr "Scal formaty - scal formaty w najnowszej książce, usuń resztę"
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
@@ -10683,64 +10511,64 @@ msgstr ""
 "Zachowaj format najwyższej jakości - preferuj formaty na podstawie rankingu "
 "priorytetów formatów duplikatów"
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 "Zachowaj najwięcej metadanych - zachowaj książkę z najpełniejszymi "
 "informacjami"
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 "Zachowaj plik o największym rozmiarze - zachowaj książkę o największym "
 "łącznym rozmiarze pliku"
 
 # ???
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 msgid "Preview"
 msgstr "Podgląd"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr "Wykonaj rozwiązanie"
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 "Spowoduje to trwałe usunięcie książek. Oryginalne pliki zostaną zapisane w "
 "kopii zapasowej w"
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 msgid "Merge Selected"
 msgstr "Scal zaznaczone"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr "Odrzuć tę grupę duplikatów"
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 msgid "View book details"
 msgstr "Zobacz szczegóły książki"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 msgid "Edit book metadata"
 msgstr "Edytuj metadane książki"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 msgid "Archive/delete book"
 msgstr "Archiwizuj/usuń książkę"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 msgid "No Duplicate Books Found"
 msgstr "Nie znaleziono zduplikowanych książek"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 "Twoja biblioteka nie zawiera książek ze zduplikowanymi kombinacjami tytułu i "
 "autora."
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
@@ -10748,11 +10576,11 @@ msgstr ""
 "To wyszukiwanie szuka książek o identycznych tytułach I autorach, aby "
 "uniknąć fałszywych wyników."
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr "Wykonaj automatyczne rozwiązanie"
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
@@ -10760,77 +10588,77 @@ msgstr ""
 "CWA rozwiąże grupy duplikatów, korzystając z wybranej strategii, i trwale "
 "usunie zduplikowane książki."
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 msgid "Selected strategy:"
 msgstr "Wybrana strategia:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr "Tej akcji nie można cofnąć!"
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 msgid "The following books will be permanently deleted:"
 msgstr "Następujące książki zostaną trwale usunięte:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Merge Books"
 msgstr "Scal książki"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 msgid "The following book will be kept:"
 msgstr "Następująca książka zostanie zachowana:"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "Następujące książki zostaną do niej scalone (a następnie usunięte):"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 "Uwaga: formaty plików z książek źródłowych zostaną dodane do książki "
 "docelowej."
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr "Podgląd rozwiązania"
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr "Sukces"
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr "Wybrane zduplikowane książki zostały pomyślnie usunięte!"
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr "Wystąpił błąd podczas przetwarzania żądania."
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "Wybierz typ serwera"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr "Standardowe konto e-mail"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr "Konto Gmail"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr "Skonfiguruj konto Gmail"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Cofnij dostęp do Gmaila"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "Hasło SMTP"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
@@ -10839,35 +10667,35 @@ msgstr ""
 "maili testowych. Wysyłana jako zwykły tekst, w dowolnym języku. Pozostaw "
 "puste, aby użyć wiadomości domyślnej."
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Limit rozmiaru załącznika"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 msgid "Save and Send Test Email"
 msgstr "Zapisz i wyślij testowy e-mail"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Domeny dozwolone do rejestracji (biała lista)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Dodaj domenę"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Podaj nazwę domeny"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Domeny zabronione (czarna lista)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr "(Magiczna)"
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10875,23 +10703,23 @@ msgstr ""
 "Otwórz plik .kobo/Kobo/Kobo eReader.conf w edytorze tekstu i dodaj (lub "
 "edytuj):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Token Kobo:"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "Lista"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr "Przegląd dopasowań Hardcover 🔖"
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr "Wszystko na bieżąco!"
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
@@ -10900,15 +10728,15 @@ msgstr ""
 "dopasowania pojawią się tutaj po uruchomieniu zadania automatycznego "
 "pobierania."
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr "Wróć do panelu administratora"
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr "Wymagany przegląd"
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
@@ -10918,11 +10746,11 @@ msgstr ""
 "Przejrzyj każde dopasowanie i wybierz poprawny wynik lub pomiń/odrzuć, jeśli "
 "nie ma dobrego dopasowania."
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr "Oczekujące dopasowania"
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
@@ -10932,66 +10760,60 @@ msgstr ""
 "dla swoich książek. Dopasowania o wysokiej pewności są stosowane "
 "automatycznie; te wymagają ręcznej weryfikacji."
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 msgid "Reject All Pending"
 msgstr "Odrzuć wszystkie oczekujące"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 msgid "Search Query"
 msgstr "Zapytanie wyszukiwania"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr "Kandydujące dopasowania"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr "Najlepsze: %(count)s"
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr "Pewność"
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr "Powód dopasowania"
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 msgid "View on Hardcover"
 msgstr "Zobacz na Hardcover"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr "Wybierz to dopasowanie"
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 msgid "Reject All"
 msgstr "Odrzuć wszystkie"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr "Pomiń na razie"
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 msgid "Processing..."
 msgstr "Przetwarzanie..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr "✓ Wybierz to dopasowanie"
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr "Nie udało się zastosować dopasowania"
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
@@ -10999,41 +10821,38 @@ msgstr ""
 "Czy na pewno chcesz odrzucić wszystkie dopasowania dla tej książki? Tej "
 "operacji nie można cofnąć."
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr "✗ Odrzuć wszystkie dopasowania"
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject match"
 msgstr "Nie udało się odrzucić dopasowania"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr ""
 "Czy na pewno chcesz odrzucić wszystkie oczekujące dopasowania? Tej operacji "
 "nie można cofnąć."
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Pending"
 msgstr "✗ Odrzuć wszystkie oczekujące"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject all pending matches"
 msgstr "Nie udało się odrzucić wszystkich oczekujących dopasowań"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr "→ Pomiń na razie"
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr "Nie udało się pominąć dopasowania"
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
@@ -11042,60 +10861,60 @@ msgstr ""
 "administratorem"
 
 # | msgid "Create a Shelf"
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Zgłoś błąd"
 
 # ???
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Powrót do głównego menu"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "Wyloguj użytkownika"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr "Powiadomienie mobilne"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr "Edycja Magicznej Półki działa najlepiej na komputerach i tabletach."
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr "Odśwież półkę, aby uwzględnić najnowsze zmiany"
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 msgid "Edit shelf rules"
 msgstr "Edytuj reguły półki"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr "Ukryj tę półkę w panelu bocznym"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Show this shelf in your sidebar"
 msgstr "Pokaż tę półkę w panelu bocznym"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 msgid "Show Shelf"
 msgstr "Pokaż półkę"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 msgid "Hide Shelf"
 msgstr "Ukryj półkę"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 msgid "Add Series to Shelf"
 msgstr "Dodaj cykl do półki"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr "Synchronizacja KOReader jest wyłączona."
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
@@ -11103,201 +10922,200 @@ msgstr ""
 "Włącz to w Ustawieniach NextGen, aby aktywować punkty końcowe /kosync i "
 "generowanie sum kontrolnych."
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr "Otwórz Ustawienia NextGen"
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 "Pobieranie jest dostępne po włączeniu synchronizacji KOReader w Ustawieniach "
 "NextGen."
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Główne menu"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Przełącz nawigację"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Przeszukaj bibliotekę"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Przełącz na nowy interfejs Calibre-Web NextGen"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr "Przełącz na nowy interfejs"
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Wyloguj się"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr "Wesprzyj Calibre-Web NextGen"
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 msgid "Refresh Library"
 msgstr "Odśwież bibliotekę"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr "Wsparcie"
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 msgid "New interface available"
 msgstr "Dostępny nowy interfejs"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Szybszy, przeprojektowany interfejs Calibre-Web NextGen jest gotowy."
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr "Twój widok klasyczny pozostaje domyślny, dopóki go nie zmienisz."
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr "Wypróbuj nowy interfejs"
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr "Zobacz dziennik zmian"
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 msgid "Open Duplicates"
 msgstr "Otwórz Duplikaty"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr "Wesprzyj tutaj!"
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Proszę nie odświeżać strony"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 msgid "Create Shelf"
 msgstr "Utwórz półkę"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr "Magiczne Półki ✨"
 
 # ???
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Poprzedni"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Szczegóły książki"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 msgid "This cannot be undone."
 msgstr "Tej operacji nie można cofnąć."
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 msgid "Will be deleted"
 msgstr "Zostanie usunięta"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 msgid "Formats:"
 msgstr "Formaty:"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr "Zostanie zachowana"
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr "Konflikty formatów — wybierz, co zrobić:"
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 msgid "Result will have formats:"
 msgstr "Wynik będzie miał formaty:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr "Scal i usuń źródło"
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 msgid "Duplicate Books Detected"
 msgstr "Wykryto zduplikowane książki"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr "W Twojej bibliotece znajdują się nierozwiązane zduplikowane książki"
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 msgid "Duplicate Groups Found"
 msgstr "Znalezione grupy duplikatów"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr "Przypomnij mi później"
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr "Zobacz i rozwiąż duplikaty"
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 msgid "Scroll to top"
 msgstr "Przewiń do góry"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 msgid "Top"
 msgstr "Góra"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 msgid "Confirm"
 msgstr "Potwierdź"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Dodano do \"{shelf}\" książek: {n}"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr "Dodano {ok} z {n} książek do \"{shelf}\" (reszta już tam była)"
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr "Wszystkie książki ({n}) były już na \"{shelf}\"."
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Oznaczono jako przeczytane książek: {n}"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Oznaczono jako nieprzeczytane książek: {n}"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Usunięto książek: {n}"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 msgid "Delete books?"
 msgstr "Usunąć książki?"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -11306,36 +11124,36 @@ msgstr ""
 "Spowoduje to trwałe usunięcie z biblioteki książek: {n}. Tej operacji nie "
 "można cofnąć."
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 msgid "Select at least one book first."
 msgstr "Najpierw wybierz co najmniej jedną książkę."
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Żądanie nie powiodło się: {err}"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr "Filtruj według początkowej litery"
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "Siatka"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 msgid "Show Password"
 msgstr "Pokaż hasło"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Zapamiętaj mnie"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Zapomniałeś hasło?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 msgid ""
 "Log in with Magic\n"
 "      Link"
@@ -11343,56 +11161,56 @@ msgstr ""
 "Zaloguj się za pomocą\n"
 "      magic linku"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 msgid "Log in with SSO"
 msgstr "Zaloguj się za pomocą SSO"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 "Standardowe logowanie jest wyłączone. Użyj jednej z alternatywnych metod "
 "logowania."
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Pokaż dziennik Calibre-Web: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Calibre-Web Log: "
 msgstr "Dziennik Calibre-Web: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Nie można wyświetlić wyjścia"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Pokaż dziennik dostępu: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Pobierz log Calibre-Web"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "Pobierz log dostępu"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr "Szablon systemowy"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 "To jest wstępnie skonfigurowana półka szablonowa. Możesz ją dowolnie "
 "edytować."
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 msgid "Share with Everyone (Public)"
 msgstr "Udostępnij wszystkim (publiczna)"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
@@ -11400,51 +11218,51 @@ msgstr ""
 "Inni użytkownicy mogą przeglądać tę półkę. Użytkownicy z uprawnieniem "
 "\"Edytuj publiczne półki\" mogą ją edytować/usuwać."
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Wybierz dozwolone/zabronione etykiety"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Wybierz dozwolone/zabronione wartości własnych kolumn"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Wybierz dozwolone/zabronione etykiety użytkownika"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr "Wybierz dozwolone/zabronione wartości własnych kolumn użytkownika"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Wpisz etykietę"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Dodaj ograniczenie przeglądania"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "Ten format książki zostanie trwale usunięty z bazy danych"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Książka zostanie usunięta z bazy danych Calibre"
 
 # ???
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "i z dysku twardego"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Ważne dla Kobo: usunięte książki pozostaną na każdym połączonym urządzeniu "
 "Kobo."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11452,279 +11270,279 @@ msgstr ""
 "Książki muszą najpierw zostać zarchiwizowane a urządzenie zsynchronizowane, "
 "zanim książka będzie mogła zostać bezpiecznie usunięta."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Wybierz lokalizację pliku"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "typ"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "nazwa"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "rozmiar"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "Główny katalog"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "OK"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Katalog e-booków Calibre-Web NextGen"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "Czytnik EPUB"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 msgid "Annotations"
 msgstr "Adnotacje"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr "Otwórz stronę adnotacji"
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "Czarny"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "Rozmiary czcionki"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 msgid "Text margin"
 msgstr "Margines tekstu"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr "Czcionka"
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 msgid "Default"
 msgstr "Domyślna"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr "Yahei"
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr "SimSun"
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 msgid "KaiTi"
 msgstr "KaiTi"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 msgid "Arial"
 msgstr "Arial"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 msgid "Spread"
 msgstr "Rozkładówka"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr "Dwie kolumny"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr "Jedna kolumna"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Przepływ tekstu, gdy paski boczne są otwarte."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr "Notatka"
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr "Dodaj notatkę (opcjonalnie)"
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr "Zaznacz fragment akapitu, aby go zakreślić."
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Czytnik komiksów"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Skróty klawiaturowe"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Poprzednia strona"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Następna strona"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 msgid "Single Page Display"
 msgstr "Wyświetlanie pojedynczej strony"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr "Wyświetlanie długiego paska"
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Skaluj do najlepszego"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Skaluj do szerokości"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Skaluj do wysokości"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Skaluj do wielkości oryginalnej"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Obróć w prawo"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Obróć w lewo"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Odwórć obraz"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "Wyświetlanie"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 msgid "Single Page"
 msgstr "Pojedyncza strona"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr "Długi pasek"
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Skaluj"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Najlepszy"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Szerokość"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Wysokość"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Natywnie"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Obrót"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Odwróć"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Poziomo"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Pionowo"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 msgid "Direction"
 msgstr "Kierunek"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Od lewej do prawej"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Od prawej do lewej"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr "Wróć na górę"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 msgid "Remember Position"
 msgstr "Zapamiętaj pozycję"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "Pasek przewijania"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "Pokaż"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "Czytnik DJVU"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "Czytnik PDF"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "Czytnik TXT"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Zarejestruj nowe konto"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Wybierz nazwę użytkownika"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Twój adres e-mail"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Magic Link – Autoryzuj nowe urządzenie"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "Użyj innego urządzenia, zaloguj się i odwiedź:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "Gdy to zrobisz, automatycznie zalogujesz się na tym urządzeniu."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Link wygaśnie po 10 minutach."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
@@ -11733,257 +11551,253 @@ msgstr ""
 "konserwacji. Miniatury są zawsze generowane na żądanie, niezależnie od tego "
 "ustawienia."
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "Generuj miniatury okładek cykli"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Brak wyników"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Wyszukiwano:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Wyniki dla:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Data publikacji od"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Data publikacji do"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr "Pusty"
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Wyklucz etykiety"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Wyklucz cykle"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "Z wyłączeniem półek"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Wyklucz języki"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Rozszerzenia"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Wyklucz rozszerzenia"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Ocena większa niż"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Ocena mniejsza niż"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "Od:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "Do:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Usuń tą półkę"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "Edytuj właściwości półki"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 msgid "Add Books"
 msgstr "Dodaj książki"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "Ręczne porządkowanie książek"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "Wyłączenie Zlecenie zmiany"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "Włącz polecenie zmiany"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, python-format
 msgid "%(count)s selected"
 msgstr "Wybrano: %(count)s"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, python-format
 msgid "Add %(count)s"
 msgstr "Dodaj: %(count)s"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 msgid "No books found."
 msgstr "Nie znaleziono książek."
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 msgid "Already on this shelf"
 msgstr "Już na tej półce"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr "Nie udało się dodać książek. Spróbuj ponownie."
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 msgid "Add books to"
 msgstr "Dodaj książki do"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 msgid "Search your library…"
 msgstr "Przeszukaj swoją bibliotekę…"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 msgid "Search your library"
 msgstr "Przeszukaj swoją bibliotekę"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Współdziel z wszystkimi"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "Zsynchronizuj tę półkę z urządzeniem Kobo"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr "Udostępnij tę półkę w moim kanale OPDS"
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 "Przeciągnij okładkę na nowe miejsce — kolejność zapisuje się automatycznie."
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 "Klawiatura: zaznacz okładkę klawiszem Tab, a następnie przesuń ją klawiszami "
 "strzałek."
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr "Kolejność zapisana"
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 "Nie udało się zapisać kolejności — kliknij tutaj, aby spróbować ponownie"
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr "Przeniesiono na pozycję %(num)s z %(total)s"
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 msgid "Shelf order"
 msgstr "Kolejność półek"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Ukryta książka"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr "Sortuj według"
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr "Nie masz jeszcze żadnych półek do zmiany kolejności."
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr "Przeciągnij, aby zmienić kolejność swoich półek w panelu bocznym."
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 "Kolejność zapisana. Panel boczny uwzględni nową kolejność po następnym "
 "wczytaniu strony."
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Statystyki biblioteki Calibre"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Książki"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Autorzy"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Kategorie"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Cykle w tej bibliotece"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Statystyki systemu"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "Program"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Zainstalowana wersja"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr "Przegląd zadań w tle"
 
 # ???
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Czas wykonania"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr "Akcje"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr "Nadchodzące zaplanowane wysyłki"
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr "Zaplanowany czas"
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 msgid "State"
 msgstr "Stan"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
@@ -11991,15 +11805,15 @@ msgstr ""
 "Nadchodzące wysyłki są zachowywane i trafią do kolejki zadań o zaplanowanej "
 "godzinie. Możesz anulować oczekującą wysyłkę, zanim się rozpocznie."
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr "Nadchodzące zaplanowane operacje"
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr "Typ"
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
@@ -12007,13 +11821,13 @@ msgstr ""
 "Zaplanowane tutaj uruchomienia konwersji biblioteki i naprawy EPUB będą "
 "zachowywane po ponownym uruchomieniu. Anuluj, aby zapobiec ich wywołaniu."
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 "To zadanie zostanie anulowane. Wszelki postęp tego zadania zostanie zapisany."
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
@@ -12021,19 +11835,19 @@ msgstr ""
 "Jeśli to zadanie jest zaplanowane, zostanie uruchomione ponownie w następnym "
 "zaplanowanym terminie."
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 msgid "Scheduled item cancelled successfully"
 msgstr "Pomyślnie anulowano zaplanowany element"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr "Błąd podczas anulowania zaplanowanego elementu"
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 msgid "Update Calibre-Web NextGen"
 msgstr "Zaktualizuj Calibre-Web NextGen"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
@@ -12043,39 +11857,39 @@ msgstr ""
 "Twoja biblioteka, ustawienia i postęp czytania są bezpieczne — znajdują się "
 "w zamontowanych woluminach, a nie w kontenerze."
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr "Jak uruchamiasz Calibre-Web NextGen?"
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr "Typ konfiguracji"
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr "Docker Compose"
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr "docker run"
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr "Unraid"
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr "Portainer / Synology"
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr "Uruchom to w folderze zawierającym plik compose:"
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr "Zastąp calibre-web-nextgen nazwą swojej usługi, jeśli jest inna."
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
@@ -12083,7 +11897,7 @@ msgstr ""
 "Pobierz nowy obraz, a następnie odtwórz kontener z tymi samymi opcjami, z "
 "jakimi go uruchomiono:"
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
@@ -12091,11 +11905,11 @@ msgstr ""
 "Następnie zatrzymaj i usuń stary kontener oraz uruchom nowy za pomocą "
 "zwykłego polecenia docker run. Zamontowane woluminy zachowują wszystkie dane."
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr "Otwórz kartę Docker w interfejsie webowym Unraid."
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
@@ -12103,7 +11917,7 @@ msgstr ""
 "Kliknij ikonę kontenera Calibre-Web NextGen i wybierz Wymuś aktualizację "
 "(najpierw sprawdź aktualizacje, jeśli chcesz zobaczyć, co się zmieniło)."
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
@@ -12111,11 +11925,11 @@ msgstr ""
 "Aby uzyskać bezobsługowe aktualizacje, zainstaluj wtyczkę \"CA Auto Update "
 "Applications\" z Community Applications."
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr "Portainer:"
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
@@ -12123,11 +11937,11 @@ msgstr ""
 "Images → pobierz poniższy obraz, następnie Containers → wybierz Calibre-Web "
 "NextGen → Recreate z włączoną opcją \"Re-pull image\"."
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr "Menedżer kontenerów Synology:"
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
@@ -12135,44 +11949,44 @@ msgstr ""
 "Registry → pobierz poniższy obraz (tag: latest), następnie zatrzymaj "
 "kontener → Action → Reset, aby go odtworzyć."
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr "Skonfiguruj automatyczne aktualizacje"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "Your Profile"
 msgstr "Twój profil"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "User Settings"
 msgstr "Ustawienia użytkownika"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr "Informacje o koncie"
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr "Jeśli chcesz zmienić adres e-mail lub hasło, możesz to zrobić tutaj."
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Zresetuj hasło użytkownika"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 msgid "eReader Configuration"
 msgstr "Konfiguracja czytnika e-booków"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 msgid "Send to eReader Email Address"
 msgstr "Adres e-mail do wysyłania na czytnik e-booków"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr "Użyj przecinka, aby oddzielić wiele adresów"
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
@@ -12180,11 +11994,11 @@ msgstr ""
 "Adres(y) e-mail dla Twoich czytników e-booków. Oddziel wiele adresów "
 "przecinkami."
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr "Włącz okno wysyłania na czytnik e-booków"
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
@@ -12194,7 +12008,7 @@ msgstr ""
 "użytkownikom wprowadzić dodatkowe adresy e-mail i wysyłać tylko do wybranych "
 "zapisanych adresów podczas wysyłania na czytnik."
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
@@ -12202,11 +12016,11 @@ msgstr ""
 "Gdy wyłączone, e-maile będą wysyłane do wszystkich skonfigurowanych adresów "
 "czytnika bez pytania."
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr "Automatycznie wysyłaj nowe książki na moje czytniki e-booków"
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
@@ -12214,71 +12028,71 @@ msgstr ""
 "Gdy włączone, nowo zaimportowane książki będą automatycznie wysyłane na "
 "wszystkie skonfigurowane powyżej adresy e-mail czytnika."
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr "Preferencje języka i motywu"
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 msgid "Interface Language"
 msgstr "Język interfejsu"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Pokaż książki w języku"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr "Filtruj bibliotekę, aby pokazywać tylko książki w określonym języku."
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 msgid "Book Language Filter"
 msgstr "Filtr języka książek"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr "Integracje OAuth i API"
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "Ustawienia OAuth"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Połącz"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Rozłącz"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr "Token API Hardcover"
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr "Token API do integracji z dostawcą metadanych Hardcover."
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Token Kobo Sync"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Utwórz/Przeglądaj"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "Wymuś pełną synchronizację Kobo"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr "Wyślij ponownie jedną książkę na to Kobo"
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr "Wyślij ponownie"
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
@@ -12287,36 +12101,36 @@ msgstr ""
 "pobierze ją ponownie przy następnej synchronizacji. Identyfikator książki "
 "znajdziesz w adresie URL strony szczegółów książki."
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "Synchronizuj z Kobo tylko książki z wybranych półek"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr "Udostępnianie półek przez OPDS"
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "Udostępniaj przez OPDS tylko książki z wybranych półek"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 msgid "Sidebar Display Settings"
 msgstr "Ustawienia wyświetlania panelu bocznego"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 "Wybierz, które sekcje mają być wyświetlane w nawigacji panelu bocznego."
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Dodaj dozwolone/zabronione wartości własnych kolumn"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr "Kolejność katalogu OPDS"
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
@@ -12325,7 +12139,7 @@ msgstr ""
 "żądanej kolejności. Nieznane identyfikatory są ignorowane, a brakujące wpisy "
 "są dodawane automatycznie."
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
@@ -12333,73 +12147,73 @@ msgstr ""
 "Przeciągnij, aby zmienić kolejność wpisów głównych OPDS. Brakujące wpisy są "
 "dodawane automatycznie."
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr "Uprawnienia użytkownika"
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr "Skonfiguruj, jakie czynności ten użytkownik może wykonywać."
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Order"
 msgstr "Kolejność Magicznych Półek"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr "Wybierz, jak Twoje Magiczne Półki są sortowane w panelu bocznym."
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr "Tryb sortowania"
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr "Ręczny (przeciągnij, aby zmienić kolejność)"
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr "Nazwa (A-Z)"
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr "Nazwa (Z-A)"
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr "Liczba książek (malejąco)"
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr "Liczba książek (rosnąco)"
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr "Data utworzenia (od najnowszych)"
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr "Data utworzenia (od najstarszych)"
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 msgid "Recently modified"
 msgstr "Ostatnio zmodyfikowane"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr "Najdawniej modyfikowane"
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 "Kolejność ręczna jest używana tylko wtedy, gdy tryb sortowania jest "
 "ustawiony na Ręczny."
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr "Widoczność Magicznych Półek"
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
@@ -12408,33 +12222,33 @@ msgstr ""
 "można usunąć, można je jedynie ukryć. Publiczne półki innych użytkowników "
 "również można ukryć."
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr "Domyślne półki systemowe:"
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 msgid "Public Shelves:"
 msgstr "Publiczne półki:"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr "Widocznych domyślnych półek: %(visible)s z %(total)s"
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr "Widocznych publicznych półek: %(visible)s z %(total)s"
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Usuń tego użytkownika"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr "Hasła aplikacji dla OPDS / synchronizacji KOReader"
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12447,11 +12261,11 @@ msgstr ""
 "skopiuj token wyświetlony po utworzeniu. Możesz odwołać dowolne hasło "
 "aplikacji w dowolnym momencie bez wpływu na aktywną sesję webową."
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 msgid "New app password"
 msgstr "Nowe hasło aplikacji"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
@@ -12459,139 +12273,139 @@ msgstr ""
 "Utworzono hasło aplikacji dla \"%(label)s\". Skopiuj je teraz — nie zostanie "
 "ono ponownie wyświetlone."
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr "Nowe hasło aplikacji (jawny tekst)"
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr "np. Kobo Forma, KOReader iPad"
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 msgid "Create app password"
 msgstr "Utwórz hasło aplikacji"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr "Etykieta"
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 msgid "Created"
 msgstr "Utworzono"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr "Ostatnio użyto"
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr "Nigdy"
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr "Odwołać to hasło aplikacji?"
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Generuj Kobo Auth URL"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr "Widoczne"
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Wybierz..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Usuń zaznaczone"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "Edytuj użytkownika"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "Wprowadź nazwę użytkownika"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 msgid "Enter Email"
 msgstr "Wprowadź adres e-mail"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "Enter eReader Email"
 msgstr "Wprowadź adres e-mail czytnika"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "eReader Email"
 msgstr "E-mail czytnika"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 msgid "Enter eReader Email Subject"
 msgstr "Wprowadź temat e-maila do czytnika"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 msgid "eReader Email Subject"
 msgstr "Temat e-maila do czytnika"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Ustawienia regionalne"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "Widoczne języki książek"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "Edytuj dozwolone tagi"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Dozwolone Tagi"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Edytuj zabronione etykiety"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Zabronione etykiety"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "Edycja dozwolonych wartości kolumn"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "Dozwolone wartości kolumn"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "Edycja zabronionych wartości kolumn"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "Zabronione wartości kolumn"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "Zmień hasło"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "Edytuj półki publiczne"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "Synchronizuj wybrane półki z Kobo"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 msgid "Expose selected Shelves to OPDS"
 msgstr "Udostępniaj wybrane półki przez OPDS"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 msgid "Show Read/Unread Section"
 msgstr "Pokaż sekcję przeczytane/nieprzeczytane"
 

--- a/cps/translations/pt/LC_MESSAGES/messages.po
+++ b/cps/translations/pt/LC_MESSAGES/messages.po
@@ -16,33 +16,33 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 #, fuzzy
 msgid "Server restarted, please reload page."
 msgstr "Servidor reiniciado, por favor, refresque a página"
 
-#: cps/admin.py:210
+#: cps/admin.py
 #, fuzzy
 msgid "Performing Server shutdown, please close window."
 msgstr "A encerrar o servidor, por favor, feche a janela"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "Sucesso! Base de dados religada"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Comando desconhecido"
 
-#: cps/admin.py:232
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
@@ -50,228 +50,226 @@ msgstr ""
 "Sucesso! Livros enviados para lista de espera para cópia de segurança de "
 "metadados. Por favor, verifique o resultado em Tarefas"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr ""
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 
-#: cps/admin.py:414
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover ID applied successfully"
 msgstr "{} utilizadores eliminados com sucesso"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr ""
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr ""
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr ""
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr ""
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr ""
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Página de administração"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "Configurações do OAuth"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Configuração básica"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Configuração de IU"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 "A coluna personalizada No.%(column)d não existe na base de dados do Calibre"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Editar utilizadores"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Tudo"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Utilizador não encontrado"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} utilizadores eliminados com sucesso"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Mostrar tudo"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Pedido mal construído"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "Nome do convidado não pode ser alterado"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "Convidado não pode ter esta função"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr ""
 "Nenhum utilizador administrador restante, impossível remover a função de "
 "administrador"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "Valor tem de ser verdadeiro ou falso"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Função inválida"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "O convidado não podr ter esta vista"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "Vista inválida"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 "O idioma do convidado é detetado automaticamente e não pode ser alterado"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Nenhum idioma válido fornecido"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Não foi indicado um idioma de livro válido"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Parâmetro não encontrado"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "Configuaração da DB não é gravável"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Coluna Lido é inválida"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Coluna Restrito é inválida"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Quer realmente apagar a Kobo Token?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "Quer realmente eliminar este domínio?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "Quer realmente apagar este utilizador?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Tem a certeza de que quer apagar essa estante?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr ""
 "Tem a certeza de que quer alterar o idioma dos utilizadores selecionados?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "Tem a certeza de que quer alterar os idiomas de livros visíveis para os "
 "utilizadores selecionados?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 "Tem a certeza de que quer alterar a função selecionada para os utilizadores "
 "selecionados?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
@@ -279,7 +277,7 @@ msgstr ""
 "Tem a certeza de que quer alterar as restrições selecionadas para os "
 "utilizadores selecionados?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -287,14 +285,14 @@ msgstr ""
 "Tem a certeza de de que quer alterar as restrições de visibilidade "
 "selecionadas para os utilizadores selecionados?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "Tem a certeza de que quer alterar o comportamento de sincronização da "
 "estante para os utilizadores selecionados?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
@@ -302,130 +300,125 @@ msgstr ""
 "Tem a certeza de que quer alterar o comportamento de sincronização da "
 "estante para os utilizadores selecionados?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Tem a certeza de que quer alterar a localização da biblioteca Calibre?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Negar"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Permitir"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "{} entradas de sincronização eliminadas"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Token não encontrado"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Etiqueta não encontrada"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Ação inválida"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json não está configurado para aplicação Web"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "A localização do ficheiro de historial não é válida. Por favor, digite um "
 "caminho correto"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "A localização do ficheiro de historial não é válida. Por favor, digite um "
 "caminho correto"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 "Digite um fornecedor LDAP, porta, DN e identificador de objeto do utilizador"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Por favor, digite uma conta de serviço LDAP e senha"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "Por favor, digite uma conta de serviço LDAP"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "O filtro de objeto de grupo LDAP precisa de ter um identificador de formato "
 "\"%s\""
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "Filtro de objeto de grupo LDAP tem parênteses não coincidentes"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "O filtro de objeto de utilizador LDAP precisa de ter um identificador de "
 "formato \"%s\""
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "Filtro de objeto de utilizador LDAP tem parênteses não coincidentes"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "O filtro de utilizador membro do LDAP precisa ter um identificador de "
 "formato \"%s\""
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "Filtro de utilizador de membro LDAP tem parênteses incomparáveis"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -433,29 +426,24 @@ msgstr ""
 "LDAP Certificado CA: Localização inválida de certificado ou chave. Por "
 "favor, digite um caminho correto"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Adicionar utilizador"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Editar configurações do servidor de email"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "Sucesso! Conta Gmail verificada"
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Erro de base de dados: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -463,53 +451,53 @@ msgstr ""
 "Email de teste enviado para lista de espera para envio para %(email)s. Por "
 "favor, verifique o resultado em Tarefas"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Ocorreu um erro ao enviar o email de teste: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Por favor, primeiro configure seu endereço de email..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Atualização das configurações do servidor de email"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "Editar utilizadores"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Por favor, configure primeiro as configurações de correio SMTP..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "Por favor, primeiro configure seu endereço de email..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "Nova senha foi enviada para seu endereço de email"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -517,7 +505,7 @@ msgstr ""
 "Email de teste enviado para lista de espera para envio para %(email)s. Por "
 "favor, verifique o resultado em Tarefas"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -526,937 +514,922 @@ msgstr ""
 "Email de teste enviado para lista de espera para envio para %(email)s. Por "
 "favor, verifique o resultado em Tarefas"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "Editar configurações de tarefas agendadas"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "Hora de início inválida para a tarefa especificada"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "Duração inválida para a tarefa especificada"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "Foram atualizadas as configurações de tarefas agendadas"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Ocorreu um erro desconhecido. Por favor, tente novamente mais tarde."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "Título"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Editar utilizador %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Sucesso! Senha do utilizador %(user)s redefinida"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Por favor, configure primeiro as configurações de correio SMTP..."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Visualizador do historial"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "A solicitar pacote de atualização"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "A descarregar pacote de atualização"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "A descomprimir pacote de atualização"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "A substituir ficheiros"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "As ligações à base de dados estão fechadas"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "A parar o servidor"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Atualização concluída, pressione OK e refresque a página"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Atualização falhou:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "Erro HTTP"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Erro de ligação"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Tempo limite ao estabelecer a ligação"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Erro geral"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr "Ficheiro de atualização não pode ser guardado na pasta temporária"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "Não foi possível substituir ficheiros durante a atualização"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "Falha ao extrair pelo menos um utilizador LDAP"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Falha ao criar pelo menos um utilizador LDAP"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Erro: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Erro: Nenhum utilizador devolvido na resposta do servidor LDAP"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "No mínimo um utilizador LDAP não encontrado no base de dados"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} utilizador importado com sucesso"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr ""
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "A localização da base de dados não é válida. Por favor, digite o caminho "
 "correto"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "DB não é gravável"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Localização do ficheiro de chaves não é válida. Por favor, digite o caminho "
 "correto"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Localização do ficheiro de certificados não é válida. Por favor, digite o "
 "caminho correto"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr "A dimensão da senha deve estar entre 1 e 40"
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "Configurações da base de dados atualizadas"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "Configuração da base de dados"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Por favor, preencha todos os campos!"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "O email não é de um domínio válido"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Adicionar novo utilizador"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Criado utilizador '%(user)s'"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "Já existe uma conta para este endereço de email ou nome."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Utilizador '%(nick)s' eliminado"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "Impossível eliminar convidado"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr ""
 "Nenhum utilizador administrador restante, não é possível eliminar o "
 "utilizador"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "O email não pode estar vazio e tem de ser válido"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Utilizador '%(nick)s' atualizado"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr ""
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr ""
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Erro de ligação"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr ""
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "Não existem informações disponíveis sobre o lançamento"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr ""
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr ""
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr ""
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "Ocorreu um erro desconhecido. Por favor, tente novamente mais tarde."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "Erro de ligação"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Erro de ligação"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "Ficheiro %(file)s enviado"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr ""
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr ""
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr ""
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr ""
 
-#: cps/constants.py:265
+#: cps/constants.py
 #, fuzzy
 msgid "Finnish"
 msgstr "Concluído"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr ""
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr ""
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr ""
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr ""
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr ""
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr ""
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr ""
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr ""
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr ""
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr ""
 
-#: cps/constants.py:276
+#: cps/constants.py
 #, fuzzy
 msgid "Polish"
 msgstr "Editora"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr ""
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr ""
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr ""
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr ""
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr ""
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr ""
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr ""
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr ""
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr ""
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr ""
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "não instalado"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Falta de permissões de execução"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, fuzzy, python-format
 msgid "Change cover — %(title)s"
 msgstr "Trocar autor por título"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Erro de ligação"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr ""
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Book ID"
 msgstr "Livros"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Título do livro"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "Autor"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr ""
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "Formatos de ficheiro"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filename"
 msgstr "nome"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr ""
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr ""
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "Formato de carregamento"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "Desconhecido"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr ""
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "Função inválida"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "Fundir livros selecionados"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "Formato %(format)s não encontrado no disco"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB Fixer started for selected book."
 msgstr "Fundir livros selecionados"
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr ""
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr ""
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid image data format."
 msgstr "Formato de endereço de email inválido"
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Profile picture updated successfully."
 msgstr "{} utilizadores eliminados com sucesso"
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Nenhum"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "Apagar livro"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "Apagar livro"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "Apagar livro"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "Nenhum resultado encontrado"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 #, fuzzy
 msgid "Invalid resolution strategy"
 msgstr "Função inválida"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Carregamento concluído, a processar. Por favor, aguarde ..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 #, fuzzy
 msgid "Failed to queue upload for processing"
 msgstr "Falha em criar um caminho para a capa"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Formato de origem ou destino para conversão está em falta"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr ""
 "Livro enviado com sucesso para lista de espera de conversão para "
 "%(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Ocorreu um erro ao converter este livro: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 #, fuzzy
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr ""
 "A extensão de ficheiro '%(ext)s' não pode ser enviada para este servidor"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr ""
 "A extensão de ficheiro '%(ext)s' não pode ser enviada para este servidor"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "O ficheiro a ser carregado deve ter uma extensão"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 "Oops! O Livro selecionado não está disponível. O ficheiro não existe ou não "
 "está acessível"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "Utilizador não tem permissão para carregar capas"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 "Os identificadores não diferenciam maiúsculas de minúsculas, substituindo o "
 "identificador antigo"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "%(langname)s não é um idioma válido"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Metadados atualizados com sucesso"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "Erro ao editar o livro: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1464,98 +1437,98 @@ msgstr ""
 "O livro carregado provavelmente existe na biblioteca, considere alterar "
 "antes de carregar novo: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 "O ficheiro %(filename)s não foi possível ser guardado na pasta temporária"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Falha ao mover ficheiro de capa %(file)s: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Formato de livro eliminado com sucesso"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Livro eliminado com sucesso"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "Não tem permissões para apagar livros"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "editar metadados"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "%(seriesindex)s não é um número válido, ignorando"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr ""
 "Utilizador não tem direitos para carregar formatos de ficheiro adicionais"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Falha ao criar o caminho %(path)s (Permissão negada)."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Falha ao armazenar o ficheiro %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Formato de ficheiro %(ext)s adicionado a %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Token não encontrado"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "Formato %(format)s não encontrado no disco"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1563,7 +1536,7 @@ msgstr ""
 "Configuração do Google Drive não concluída, tente desativar e ativar o "
 "Google Drive novamente"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1571,88 +1544,87 @@ msgstr ""
 "O domínio Callback não foi verificado. Por favor, siga os passos para "
 "verificar o domínio na consola de programadores do Google"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "Formato %(format)s não encontrado para o ID do livro: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(format)s não encontrado no Google Drive: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s não encontrado: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "Enviar para dispositivo de leitura"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "Formato %(format)s não encontrado para o ID do livro: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "Formato %(format)s não encontrado para o ID do livro: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 #, fuzzy
 msgid "Test Email"
 msgstr "Email de teste"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Email de registo do utilizador: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Converter %(orig)s em %(format)s e enviar para dispositivo de leitura"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Enviar %(format)s para o dispositivo de leitura"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s enviado para o dispositivo de leitura"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "Não foi possível ler o ficheiro solicitado. Talvez permissões erradas?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "Estatuto de Lido não pode ser alterado: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
@@ -1660,12 +1632,12 @@ msgstr ""
 "A eliminação da pasta de livros do livro %(id)s falhou, o caminho tem "
 "subpastas: %(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "Falha ao eliminar livro %(id)s: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1674,73 +1646,73 @@ msgstr ""
 "Eliminar livro %(id)s apenas da base de dados, caminho do livro inválido: "
 "%(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Renomear autor de: '%(src)s' para '%(dest)s' falhou com o erro: %(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Ficheiro %(file)s não encontrado no Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Renomear título de: '%(src)s' para '%(dest)s' falhou com o erro: %(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Caminho do livro %(path)s não encontrado no Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr "Encontrada uma conta existente para este endereço de email"
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Este nome de utilizador já está registado"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 #, fuzzy
 msgid "Invalid Email address format"
 msgstr "Formato de endereço de email inválido"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr ""
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 "O módulo Python 'advocate' não está instalado, mas é necessário para "
 "carregar capas"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Erro ao descarregar a capa"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr ""
 "O ficheiro de capa não é um ficheiro de imagem válido, ou não foi possível "
 "ser armazenado"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Erro de formato da capa"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
@@ -1748,130 +1720,130 @@ msgstr ""
 "Não possui permissões para aceder a localhost ou à rede local para carregar "
 "capas"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Falha em criar um caminho para a capa"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr ""
 "Apenas ficheiros jpg/jpeg/png/webp/bmp são suportados como ficheiros de capa"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "Conteúdo do ficheiro de capa inválido"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Apenas ficheiros jpg/jpeg são suportados como ficheiros de capa"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr ""
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "Binário UnRar não encontrado"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing UnRar"
 msgstr "Erro a executar UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr ""
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr ""
 
-#: cps/helper.py:2125
+#: cps/helper.py
 #, fuzzy
 msgid "Calibre binaries not viable"
 msgstr "DB não é gravável"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Falta de permissões de execução"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing Calibre"
 msgstr "Erro a executar UnRar"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr ""
 "Enviar todos os livros para lista de espera para cópia de segurança de "
 "metadados"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Configuração Kobo"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Autentique-se com %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
@@ -1880,7 +1852,7 @@ msgstr ""
 "Ops! O servidor de email não está configurado. Por favor, contacte o seu "
 "administrador!"
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1888,35 +1860,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "Sucesso! Agora está autenticado como: '%(nickname)s'"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Hiperligação para %(oauth)s bem-sucedida"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1924,4150 +1896,4082 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr ""
 "Ops! O servidor de email não está configurado. Por favor, contacte o seu "
 "administrador!"
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "Desvincular a %(oauth)s bem-sucedido"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Falha ao desvincular de %(oauth)s"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "Não vinculado a %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Falha na autenticação com GitHub."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Falha na pesquisa de informações do utilizador no GitHub."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Falha na autenticação com Google."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Falha na pesquisa de informações de utilizador no Google."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "Failed to log in with Generic OAuth."
 msgstr "Falha na autenticação com GitHub."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "Erro no Oauth do GitHub. Por favor, tente novamente mais tarde."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "Erro no Oauth do GitHub: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Erro no Google Oauth, tente novamente mais tarde."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Erro no Oauth do Google: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, fuzzy, python-brace-format
 msgid "OAuth error: {}"
 msgstr "Erro no Oauth do GitHub: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "Livros alfabeticamente"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "Livros ordenados alfabeticamente"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Livros quentes"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr ""
 "Publicações populares deste catálogo com base no número de descarregamentos."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Top de pontuação de livros"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Publicações populares deste catálogo com base nas pontuações."
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "Livros descarregados"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Os livros mais recentes"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Livros aleatórios"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Mostrar livros aleatoriamente"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Livros lidos"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Versão atual"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Livros não lidos"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Autores"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Livros ordenados por autor"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Editoras"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Livros ordenados por editora"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Categorias"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Livros ordenados por categoria"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Séries"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Livros ordenados por série"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Idiomas"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Livros ordenados por idiomas"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Pontuações"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Livros ordenados por pontuação"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Formatos de ficheiro"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Livros ordenados por formatos de ficheiro"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Estantes"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "Livros organizados em estantes"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Sincronizar com Kobo as estantes selecionadas"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Livros organizados em estantes"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "Descrição"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} Estrelas"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Pesquisar"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Autenticar"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Token não encontrado"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "O Token expirou"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Sucesso! Por favor, volte ao seu dispositivo"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Livros"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Mostrar livros recentes"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Mostrar livros mais descarregados"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Livros descarregados"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Mostrar livros descarregados"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Mostrar livros mais bem pontuados"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Read and Unread"
 msgstr "Mostrar lido e não lido"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Mostrar Não Lidos"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Descobrir"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Category Section"
 msgstr "Mostrar secção da categoria"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Series Section"
 msgstr "Mostrar secção de séries"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Author Section"
 msgstr "Mostrar secção de autor"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Publisher Section"
 msgstr "Mostrar seleção de editoras"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Language Section"
 msgstr "Mostrar secção de idioma"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Ratings Section"
 msgstr "Mostrar secção de pontuações"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show File Formats Section"
 msgstr "Mostrar secção de formatos de ficheiro"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Livros arquivados"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Archived Books"
 msgstr "Mostrar livros arquivados"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Lista de livros"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Mostrar lista de livros"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr ""
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Mostrar livros mais bem pontuados"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Publicado depois de "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Publicado antes de "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Pontuação <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Pontuação >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, fuzzy, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Estado de leitura = %(status)s"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 "Erro na pesquisa de colunas personalizadas. Por favor, reinicie o Calibre-Web"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Pesquisa avançada"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Estante inválida especificada"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "Desculpe, não possui permissões para adicionar um livro a esta estante"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "O livro já faz parte da estante: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "O livro foi adicionado à estante: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "Não possui permissões para adicionar um livro à estante"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Os livros já fazem parte da estante: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "Livros adicionados à estante: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Não foi possível adicionar livros à estante: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "Estante inválida especificada"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Não foi possível adicionar livros à estante: %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Os livros já fazem parte da estante: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "Livros adicionados à estante: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "O livro foi removido da estante: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "Desculpe, não possui permissões para remover um livro desta estante"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Criar estante"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Desculpe, não possui permissões para editar esta estante"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Editar uma estante"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "Erro a eliminar a estante"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "Estante eliminada com sucesso"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Alterar ordem da Estante: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "Desculpe, não possui permissões para criar uma estante pública"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Estante %(title)s criada"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Estante %(title)s alterada"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Ocorreu um erro"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "Já existe uma estante pública com o nome '%(title)s' ."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "Já existe uma estante privada com o nome'%(title)s' ."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Estante: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Erro ao abrir estante. A estante não existe ou não está acessível"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Excluir estante"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Anónimo"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Não autenticado"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Sim"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Não"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Estado de leitura"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Tema"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Claro"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Escuro"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "Sépia"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Adicionar à estante"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Autor"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Navegar"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Fechar"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Apagar"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Fundir"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Editora"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Lido"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Título"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Carregar"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Conta"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Admin"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Publicado em"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Fonte"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "Sobre"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Arquivado"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "Converter"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Descrição"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Descarregar"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Editar"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "Endereço de email"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Ativar Kobo sync"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Encriptação"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "Esconder"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Identificadores"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Idioma"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Senha"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Porta"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Progresso"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Pontuação"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Guardar"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "Selecionar"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Estado"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr "Apoiar no Ko-fi →"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Tarefa"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Tarefas"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Utilizador"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Nome de utilizador"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Ver"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Aguardando"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Falhado"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Iniciado"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Concluído"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "Terminado"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Estado desconhecido"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Dados inesperados ao ler informações de atualização"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr ""
 "Não existem atualizações disponíveis. Você já tem instalada a última versão"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6075,15 +5979,15 @@ msgstr ""
 "Uma nova atualização está disponível. Clique no botão abaixo para atualizar "
 "para a versão mais recente."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Não foi possível obter informações sobre atualizações"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr "Clique no botão abaixo para atualizar para a última versão estável."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6092,275 +5996,273 @@ msgstr ""
 "Uma nova atualização está disponível. Clique no botão abaixo para atualizar "
 "para a versão: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Não existem informações disponíveis sobre o lançamento"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Descobrir (Livros aleatórios)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Livros quentes (Mais descarregados)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "Livros descarregados por %(user)s"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Autor: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Editora: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Séries: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "Pontuação: Nenhuma"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Pontuação: %(rating)s estrelas"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Formato do ficheiro: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Categoria: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Idioma: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Livros quentes"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Livro oculto"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "Erro a eliminar a estante"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "Formato de endereço de email inválido"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 #, fuzzy
 msgid "Invalid request"
 msgstr "Função inválida"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr ""
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 #, fuzzy
 msgid "Error creating shelf"
 msgstr "Erro a eliminar a estante"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Criar estante"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 #, fuzzy
 msgid "Shelf name is required"
 msgstr "Este campo é obrigatório"
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "Erro a eliminar a estante"
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "Editar uma estante"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "Utilizador não encontrado"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "{} utilizadores eliminados com sucesso"
 
-#: cps/web.py:1710
+#: cps/web.py
 #, fuzzy
 msgid "Error duplicating shelf"
 msgstr "Erro a eliminar a estante"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 #, fuzzy
 msgid "Error deleting shelf"
 msgstr "Erro a eliminar a estante"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "Erro a eliminar a estante"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 #, fuzzy
 msgid "Error unhiding shelf"
 msgstr "Erro a eliminar a estante"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Descarregamentos"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Lista de formatos de ficheiro"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 #, fuzzy
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Por favor, configure primeiro as configurações de correio SMTP..."
 
-#: cps/web.py:2400
+#: cps/web.py
 #, fuzzy
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 "Ops! Por favor, atualize o seu perfil com um endereço de email válido para "
 "envio ao Kindle."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr ""
 "Sucesso! Livro enviado para lista de espera para envio a %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Ops! Ocorreu um erro ao enviar este livro: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr ""
 "Sucesso! Livro enviado para lista de espera para envio a %(eReadermail)s"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr "Por favor, aguarde um minuto para registar o próximo utilizador"
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Registar"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 #, fuzzy
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr ""
 "Ops! O servidor de email não está configurado. Por favor, contacte o seu "
 "administrador!"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr ""
 "Ops! O servidor de email não está configurado. Por favor, contacte o seu "
 "administrador!"
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "Ops! O seu email não é permitido para registo"
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "Sucesso! O email de confirmação foi enviado para a sua conta de email."
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
@@ -6369,7 +6271,7 @@ msgstr ""
 "Instancia do Calibre-Web não configurada. Por favor, contacte o seu "
 "administrador"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
@@ -6378,36 +6280,36 @@ msgstr ""
 "Ops! O servidor de email não está configurado. Por favor, contacte o seu "
 "administrador!"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 #, fuzzy
 msgid "Cannot activate LDAP authentication"
 msgstr "Não é possível ativar a autenticação LDAP"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr "Por favor, aguarde um minuto antes de nova autenticação"
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, fuzzy, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "agora você está autenticado como: '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "Sucesso! Agora está autenticado como: '%(nickname)s'"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
@@ -6416,13 +6318,13 @@ msgstr ""
 "Instancia do Calibre-Web não configurada. Por favor, contacte o seu "
 "administrador"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6431,715 +6333,685 @@ msgstr ""
 "Autenticação recurso como:'%(nickname)s', servidor LDAP não acessível ou "
 "utilizador desconhecido"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, fuzzy, python-format
 msgid "Could not login: %(message)s"
 msgstr "Não foi possível autenticar-se: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 #, fuzzy
 msgid "Wrong Username or Password"
 msgstr "Nome de utilizador ou senha incorretos"
 
-#: cps/web.py:2832
+#: cps/web.py
 #, fuzzy
 msgid "New Password was sent to your email address"
 msgstr "Nova senha foi enviada para seu endereço de email"
 
-#: cps/web.py:2836
+#: cps/web.py
 #, fuzzy
 msgid "An unknown error occurred. Please try again later."
 msgstr "Ocorreu um erro desconhecido. Por favor, tente novamente mais tarde."
 
-#: cps/web.py:2838
+#: cps/web.py
 #, fuzzy
 msgid "Please enter valid username to reset password"
 msgstr ""
 "Por favor, digite um nome de utilizador válido para poder redefinir a senha"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, fuzzy, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "Agora você está autenticado como: '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 #, fuzzy
 msgid "Success! Profile Updated"
 msgstr "Perfil atualizado"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "Foi encontrada uma conta já existente com este endereço de email."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 #, fuzzy
 msgid "Invalid book ID."
 msgstr "Função inválida"
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr ""
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr ""
 "Não foi encontrado nenhum ficheiro gmail.json válido com informações do OAuth"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "%(book)s enviado para o dispositivo de leitura"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "Enviar para dispositivo de leitura"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-send completed successfully"
 msgstr "{} utilizadores eliminados com sucesso"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr ""
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr ""
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s enviado para dispositivo de leitura"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Calibre ebook-convert %(tool)s não encontrado"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "Formato %(format)s não encontrado no disco"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "O conversor de ebook falhou com erro desconhecido"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Conversor Kepubify falhou: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "Ficheiro convertido não encontrado ou mais de um ficheiro na pasta %(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre falhou com erro: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Conversor de ebook falhou: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "A religar base de dados Calibre"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "Apagar livro"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Apagar livro"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "A descomprimir pacote de atualização"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Nenhum resultado encontrado"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Ativar Kobo sync"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "Email"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 #, fuzzy
 msgid "Backing up Metadata"
 msgstr "Cópia de segurança de metadados"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "Na Biblioteca"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "Geradas %(count)s miniaturas para capa"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "Miniaturas de capa"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "Geradas {0} miniaturas de série"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "A esvaziar a cache de miniaturas da capa"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "Livros organizados em estantes"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Alterar senha"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Criar estante"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "Configurações do OAuth"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Configurações"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "selecionar uma opção"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "Adicionar à estante"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Público)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "Descarregamentos"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Descarregamentos"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "Ordenar de acordo com a data do livro, o mais recente primeiro"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "Ordenar de acordo com a data do livro, o mais antigo primeiro"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Autor"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Autor"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Publicado antes de "
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Publicado antes de "
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Ordenar de acordo com a data do livro, o mais recente primeiro"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "Ordenar de acordo com a data do livro, o mais antigo primeiro"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "Enviar para o endereço de email do dispositivod e leitura"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "Enviar para dispositivo de leitura"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Ver Livros"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Estante pública"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr ""
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "Importar utilizadores LDAP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Configurações do servidor de email"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "Nome de servidor SMTP"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "Porta SMTP"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "Autenticação SMTP"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Do email"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Service"
 msgstr "Serviço de eMail"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail via Oauth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Pasta da base de dados Calibre"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Nível de registos"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Porta externa"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Livros por página"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Carregamentos"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Navegação anónima"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Inscrição pública"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Autenticação remota Magic Link"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Autenticação de Proxy reverso"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Nome do cabeçalho do Proxy reverso"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Editar configurações básicas"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Editar configuração de IU"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Editar configuração da base de dados do Calibre"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "Tarefas agendadas"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "Hora de início"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "Duração máxima"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "Gerar miniaturas para capa de séries"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Religar à biblioteca do Calibre"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr "Criar cópia de segurança dos metadados"
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "Atualizar Cache de miniaturas"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Setup KOReader Sync"
 msgstr "leitor de epub"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr ""
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Administração"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Descarregar pacote de depuração"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Ver historial"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Reiniciar"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Desligar"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "Dados da versão"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Versão"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Detalhes"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "Atualização falhou:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Canal de atualização"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Versão atual"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Verificar atualizações"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Aplicar atualizações"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Tem a certeza de que quer reiniciar?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Tem certeza de que quer encerrar?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "A atualizar, por favor, não refresque esta página"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7147,455 +7019,432 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Livros nesta biblioteca"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "A carregar..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "Atualização falhou:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Erro de ligação"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Séries: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "via"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "Na Biblioteca"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "reduzir"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Outros por"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Apagar livro"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Apagar formatos:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Converter formato do livro:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Converter de:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr "selecionar uma opção"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Converter para:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Converter livro"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Erro"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Formato de carregamento"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "Identificador da série"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Data de publicação"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Tipo de identificador"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Valor do identificador"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Remover"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Adicionar identificador"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Obter capa a partir de URL (JPEG - Imagem será descarregada e armazenada na "
 "base de dados)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Carregar capa a partir de disco local"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "Ativar Kobo sync"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Ver livro ao guardar"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Obter metadados"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Termo-chave"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "Pesquisar termo-chave"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "A carregar..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Erro de pesquisa!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr ""
 "Nenhum resultado encontrado! Por favor, tente pesquisar por outro termo-"
 "chave."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "Este campo é obrigatório"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 #, fuzzy
 msgid " Exchange author & title"
 msgstr "Trocar autor por título"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "Criar estante"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr ""
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Update Title Sort automatically  "
 msgstr "Atualizar ordenação de título automaticamente"
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Atualizar ordenação de autor automaticamente"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Preencher título"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Preencher ordenação do título"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Ordenação de título"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Preencher ordenação de autor"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Ordenação de autor"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Preencher autores"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Preencher categorias"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Preencher série"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Preencher idiomas"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Data de publicação"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Preencher editoras"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Preencher comentários"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Comments"
 msgstr "Comentários"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Archived?"
 msgstr "Arquivado"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Read?"
 msgstr "Lido"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "Preencher "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Tem realmente a certeza?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "Livros com título serão fundidos de:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "Em livro com o título:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr ""
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr ""
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr ""
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr ""
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr ""
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Editar metadados"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "Criar estante"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr ""
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Adicionar"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
@@ -7603,164 +7452,164 @@ msgstr ""
 "Ops! O servidor de email não está configurado. Por favor, contacte o seu "
 "administrador!"
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 #, fuzzy
 msgid "Message"
 msgstr "Fundir"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Nova senha foi enviada para seu endereço de email"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Enviar para dispositivo de leitura"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Voltar"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Localização da base de dados Calibre"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7776,13 +7625,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7793,7 +7642,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7804,43 +7653,43 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr ""
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
 "can be wherever you desire"
 msgstr ""
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Usar Google Drive?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Autenticar com Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Pasta Calibre no Google Drive"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "ID de canal de metadados"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Revogar"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Religar à biblioteca do Calibre"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7850,141 +7699,141 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "Tem certeza de que quer encerrar?"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Religar à biblioteca do Calibre"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr ""
 "Novo local da base de dados é inválido. Por favor, insira um caminho válido"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Usar autenticação padrão"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Usar autenticação LDAP"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Usar OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Configuração do servidor"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Porta do servidor"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Localização do ficheiro de certificado SSL (deixar vazio para servidores não-"
 "SSL)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Localização do ficheiro de chave SSL (deixar vazio para servidores não-SSL)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Canal de atualização"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Estável"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Desenvolvimento"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "Alojamentos confiáveis (Separado por vírgulas)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Configuração do ficheiro de historial"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr ""
 "Localização e nome do ficheiro de historial de acesso (access.log se nenhuma "
 "indicação)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Ativar historial de acesso"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr ""
 "Localização e nome do ficheiro de historial de acesso (access.log se nenhuma "
 "indicação)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "Configuração do servidor"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 "Converter caracteres não latinos nos títulos e autores enquanto guarda em "
 "disco"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Ativar carregamentos"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr ""
 "(Por favor, certifique-se de que os utilizadores também tenham direitos de "
 "carregamento)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Formatos de ficheiros de carregamento permitidos"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Ativar navegação anónima"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Ativar inscrição pública"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "Usar email como nome de utilizador"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Ativar autenticação remota do Magic Link"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7992,154 +7841,154 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Solicitações desconhecidas de Proxy para a Kobo Store"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Porta externa do servidor (para chamadas API encaminhadas)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Usar Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Chave API Goodreads"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Hardcover Sync"
 msgstr "Ativar Kobo sync"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "O Token expirou"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Chave API Goodreads"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8147,423 +7996,423 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Permitir autenticação por Proxy reverso"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Tipo de autenticação"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "Nome ou endereço IP do servidor LDAP"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "Porta do servidor LDAP"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "Criptografia LDAP"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Caminho do certificado CA do LDAP (Necessário apenas para autenticação por "
 "certificado de cliente)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Caminho do certificado LDAP (Necessário apenas para autenticação por "
 "certificado de cliente)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Caminho do ficheiro de chave LDAP (Necessário apenas para autenticação por "
 "certificado de cliente)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "Autenticação LDAP"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Simples"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "Nome de utilizador do administrador LDAP"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "Senha de administrador LDAP"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "Nome distinto LDAP (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "Filtro de Objeto do utilizador LDAP"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "O Servidor LDAP é OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr ""
 "As seguintes configurações são necessárias para a importação de utilizadores"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "Filtro de objetos do grupo LDAP"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "Nome do grupo LDAP"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "Campo de membros do grupo LDAP"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "LDAP deteção de filtro de utilizador membro LDAP"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "Autodetetar"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "Filtro personalizado"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "Filtro de utilizador Membro LDAP"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "Obter metadados"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
 msgstr ""
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "Editar configuração de IU"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "Token não encontrado"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "Erro de ligação"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "Configurações do OAuth"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Id"
 msgstr "ID do cliente OAuth de %(provider)s"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Secret"
 msgstr "Senha do cliente Oauth de %(provider)s"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "Configuração de visualização"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "Nome de utilizador"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr ""
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "Serviço de eMail"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr ""
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "Nome do grupo LDAP"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr ""
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Configuração predefinida para novos utilizadores"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Permitir descarregamentos"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Permitir visualizador de eBook"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Permitir carregamentos"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Permitir editar"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Permitir apagar livros"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Permitir alterar senha"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Permitir editar estantes públicas"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr ""
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Obter credenciais OAuth de %(provider)s"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "ID do cliente OAuth de %(provider)s"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "Senha do cliente Oauth de %(provider)s"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Binários externos"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Path to Calibre Binaries"
 msgstr "Caminho para o conversor de ebooks do Calibre"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Calibre E-Book Converter Settings"
 msgstr "Configurações do conversor de ebooks do Calibre"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Caminho para o conversor de ebooks do Kepubify"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "Caminho para o binário UnRar"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Security Settings"
 msgstr "Configurações do OAuth"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8571,339 +8420,334 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr "Limitar tentativas de autenticação falhada"
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr ""
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr ""
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Session protection"
 msgstr "Proteção de sessão"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr "Básica"
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr "Forte"
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "User Password policy"
 msgstr "Política de senha do utilizador"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr "Tamanho mínimo da senha"
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr "Exigir números"
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr "Exigir letras minúsculas"
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr "Exigir letras maiúsculas"
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr "Exigir caracteres especiais"
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Configuração de visualização"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Nº aleatório de livros exibir"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr "Nº de autores a exibir antes de esconder (0=Desativar Esconder)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "Apagar"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "Tema caliBlur! Escuro"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Expressão regular para ignorar colunas"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Ligar Lido/Não Lido à coluna Calibre"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "Ligar Lido/Não Lido à coluna Calibre"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Exibir restrições com base na coluna Calibre"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Expressão regular para ordenação de títulos"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Configuração de visualização"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Custom CSS"
 msgstr "Filtro personalizado"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Configuração predefinida para novos utilizadores"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "Versão"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Utilizador Admin"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "Exibição de página única"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "Idioma predefinido"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "Configuração predefinida para novos utilizadores"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "Idioma predefinido para os livros visíveis"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "Visibilidade predefinida para novos utilizadores"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Visibilidade predefinida para novos utilizadores"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Mostrar livros aleatoriamente em visualização de detalhes"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Adicionar etiquetas Permitidas/Negadas"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Adicionar valores permitidos/negados de coluna personalizada"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Carregar"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "Arquivado"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "Descarregar"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Início"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8912,14 +8756,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8927,96 +8771,95 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "Fundir livros selecionados"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "{} utilizadores eliminados com sucesso"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "Erro a eliminar a estante"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "Nenhum resultado encontrado"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "Escolha um nome de utilizador"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "Pesquisar na biblioteca"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "Criar estante"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "Fundir livros selecionados"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "Erro a eliminar a estante"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Historial Calibre-Web: "
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -9024,11 +8867,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -9039,11 +8882,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -9053,162 +8896,162 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "Livros arquivados"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9216,11 +9059,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9228,110 +9071,108 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "Metadados atualizados com sucesso"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identificadores"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "Capa"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
 "investigation."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9339,157 +9180,157 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Configurações do OAuth"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "Configurações"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "Configurações do OAuth"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9497,103 +9338,102 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Sincronizar com Kobo as estantes selecionadas"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Configurações do OAuth"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9601,44 +9441,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Converter formato do livro:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9646,874 +9486,862 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Ativar inscrição pública"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Configurações do OAuth"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Ativar inscrição pública"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Ativar inscrição pública"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Apagar formatos:"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Obter metadados"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Pontuação"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Seguinte"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Marcar como não Lido"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Marcar como lido"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "Marcar como não Lido"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "Marcar como não Lido"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Adicionar ao ficheiro"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Restaurar do ficheiro"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Restaurar do ficheiro"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Adicionar ao ficheiro"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "Restaurar do ficheiro"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "Pesquisar na biblioteca"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "Configurações da base de dados atualizadas"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "Pontuação acima"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "Livro %(index)s de %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 #, fuzzy
 msgid "File sizes"
 msgstr "Tamanhos de letra"
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Descrição:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "Enviar para o endereço de email do dispositivod e leitura"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "Enviar para o endereço de email do dispositivod e leitura"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "Criar estante"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "Apagar formatos:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "Falha em criar um caminho para a capa"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "Falha em criar um caminho para a capa"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr ""
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Apagar livro"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "Mostrar livros mais bem pontuados"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "Selecionar"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "Fundir livros selecionados"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Apagar livro"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "Anterior"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "Fundir livros selecionados"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "Detalhes do livro"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "editar metadados"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "Fundir livros selecionados"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "Nenhum resultado encontrado"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr ""
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Apagar formatos:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be permanently deleted:"
 msgstr "Este livro será apagado permanentemente da base de dados"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "Livros não lidos"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "Este livro será apagado permanentemente da base de dados"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "Este livro será apagado permanentemente da base de dados"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr ""
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr ""
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr ""
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "Escolha o tipo do servidor"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Standard Email Account"
 msgstr "Usar conta de email padrão"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Gmail Account"
 msgstr "Conta Gmail"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr "Configurar conta Gmail"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Revogar acesso ao Gmail"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "Senha SMTP"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Limite de tamanho do anexo"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Save and Send Test Email"
 msgstr "Guardar e enviar email de teste"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Domínios permitidos (Lista Branca)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Adicionar domínio"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Digite o nome do domínio"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Domínios ngados (Lista Negra)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10521,119 +10349,113 @@ msgstr ""
 "Abra o ficheiro .kobo/Kobo/Kobo eReader.conf em um editor de texto e "
 "adicione (ou edite):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Token Kobo:"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "Lista"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "Criar estante"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "Termo de pesquisa:"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "Ver livro ao guardar"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "Criar estante"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "A carregar..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
@@ -10642,17 +10464,16 @@ msgstr ""
 "Tem a certeza de que quer alterar a função selecionada para os utilizadores "
 "selecionados?"
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "Falha em criar um caminho para a capa"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
@@ -10660,27 +10481,25 @@ msgstr ""
 "Tem a certeza de que quer alterar a função selecionada para os utilizadores "
 "selecionados?"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "Criar estante"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "Falha em criar um caminho para a capa"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
@@ -10689,421 +10508,420 @@ msgstr ""
 "Instancia do Calibre-Web não configurada. Por favor, contacte o seu "
 "administrador"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Criar ocorrência"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Voltar para entrada"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "Terminar sessão"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "Editar uma estante"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show this shelf in your sidebar"
 msgstr "sincronizar esta Estante com o Dispositivo Kobo"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "Mostrar tudo"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "Estante pública"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Adicionar à estante"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Entrada"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Alternar navegação"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Pesquisar na biblioteca"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Catálogo de ebooks Calibre-Web"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Sair"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "Configurações"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "Pesquisar na biblioteca"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Não existem informações disponíveis sobre o lançamento"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Catálogo de ebooks Calibre-Web"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Apagar livro"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Por favor, não refresque a página"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Criar estante"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Anterior"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Detalhes do livro"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Tem certeza de que quer encerrar?"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Fundir livros selecionados"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Formato de carregamento"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Apagar formatos:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Apagar livro"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nenhum resultado encontrado"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Dimensionar para melhor"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "Para:"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "Configuração"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Adicionar à estante"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Fundir livros selecionados"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Marcar como não Lido"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Apagar livro"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Apagar livro"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Criar estante"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Erro de ligação"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr ""
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "Grelha"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "Senha SMTP"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Memorizar-me"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Esqueceu-se da senha?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Autentique-se com o Magic Link"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 #, fuzzy
 msgid "Log in with SSO"
 msgstr "Autentique-se com o Magic Link"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Mostrar historial Calibre-Web: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Calibre-Web Log: "
 msgstr "Mostrar historial Calibre-Web: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Saída do fluxo, não pode ser exibida"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Mostrar historial de acesso: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Descarregar historial Calibre-Web"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "Descarregar historial de acessos"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "Partilhar com todos"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Selecionar etiquetas permitidas/negadas"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Selecionar valores permitidos/negados para coluna personalizada"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Selecionar etiquetas de utilizador permitidas/negadas"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr ""
 "Selecionar valores de utilizador permitidos/negados para coluna personalizada"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Digite a etiqueta"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Adicionar restrição de visualização"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "Este formato de livro será apagado permanentemente da base de dados"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Este livro será apagado permanentemente da base de dados"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "e disco rígido"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Nota importante Kobo: os livros apagados continuarão existindo em qualquer "
 "dispositivo Kobo que esteja emparelhado."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11111,578 +10929,574 @@ msgstr ""
 "Os livros devem primeiro ser arquivados e o dispositivo deve ser "
 "sincronizado antes que um livro possa ser apagado com segurança."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Escolher a localização do ficheiro"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "tipo"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "nome"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "tamanho"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "Pasta superior"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "Ok"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Catálogo de ebooks Calibre-Web"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "leitor de epub"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "Ações"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "Preto"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "Tamanhos de letra"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Página seguinte"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr ""
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 #, fuzzy
 msgid "Default"
 msgstr "Apagar"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr ""
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr ""
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 #, fuzzy
 msgid "KaiTi"
 msgstr "Aguardando"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 #, fuzzy
 msgid "Arial"
 msgstr "Vertical"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 #, fuzzy
 msgid "Spread"
 msgstr "Lido"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 #, fuzzy
 msgid "Two columns"
 msgstr "Coluna Lido é inválida"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 #, fuzzy
 msgid "One column"
 msgstr "Coluna Lido é inválida"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Refluir o texto quando as barras laterais estiverem abertas."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Leitor de banda desenhada"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Atalhos de teclado"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Página anterior"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Página seguinte"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 msgid "Single Page Display"
 msgstr "Exibição de página única"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr "Exibição de tira única"
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Dimensionar para melhor"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Dimensionar para largura"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Dimensionar para altura"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Dimensionar para nativo"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Girar para direita"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Girar para esquerda"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Inverter imagem"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "Exibir"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page"
 msgstr "Página única"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr "Tira longa"
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Dimensionar"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Melhor"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Largura"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Altura"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Nativo"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Rodar"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Inverter"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Horizontal"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Vertical"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Direction"
 msgstr "Descrição"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Esquerda para a direita"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Direita para a esquerda"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Reset to Top"
 msgstr "Voltar para entrada"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Remember Position"
 msgstr "Memorizar-me"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "Barra de rolagem"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "Mostrar"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "Leitor de DJVU"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "Leitor de PDF"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "Leitor de TXT"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Criar nova conta"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Escolher um nome de utilizador"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "O seu endereço de email"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Magic Link - Autorizar novo dispositivo"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "Noutro dispositivo, autentique-se e visite:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr ""
 "Uma vez verificado, você será automaticamente ligado a este dispositivo."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Esta ligação de verificação irá expirar em 10 minutos."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "Gerar miniaturas para capa de série"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Nenhum resultado encontrado"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Termo de pesquisa:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Resultados sobre:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Data de publicação de"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Data de publicação até"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr ""
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Excluir etiquetas"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Excluir série"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "Excluir estante"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Excluir idiomas"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Extensões"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Excluir extensões"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Pontuação acima"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Pontuação abaixo"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "De:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "Para:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Apagar esta estante"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "Editar propriedades da estante"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Livro oculto"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "Organizar livros manualmente"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "Desativar alterar ordenação"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "Ativar alterar ordenação"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Fundir livros selecionados"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Conta"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Token não encontrado"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Apagar esta estante"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Adicionar à estante"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Pesquisar na biblioteca"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Pesquisar na biblioteca"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Partilhar com todos"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "sincronizar esta Estante com o Dispositivo Kobo"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Utilizador não encontrado"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Livro oculto"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Estatísticas da biblioteca"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Livros nesta biblioteca"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Autores nesta biblioteca"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Categorias nesta biblioteca"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Séries nesta biblioteca"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Estatísticas do sistema"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "Programa"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Versão instalada"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Tempo de execução"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Actions"
 msgstr "Ações"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "Rodar"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 "Esta tarefa será cancelada. Qualquer progresso feito por esta tarefa será "
 "guardado."
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
@@ -11690,395 +11504,395 @@ msgstr ""
 "Se esta for uma tarefa agendada, ela será executada novamente durante o "
 "próximo horário agendado."
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "{} utilizadores eliminados com sucesso"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Catálogo de ebooks Calibre-Web"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "O seu endereço de email"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "Configurações"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Redefinir senha do utilizador"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "Configuração do servidor"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "Enviar para o endereço de email do dispositivod e leitura"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "Preencher idiomas"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Idioma dos livros"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "Não foi indicado um idioma de livro válido"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "Configurações do OAuth"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Ligação"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Desvincular"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Token de sincronização Kobo"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Criar/Ver"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "Forçar sincronização completa Kobo"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "Sincronizar com Kobo apenas livros em estantes selecionadas"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "Sincronizar com Kobo apenas livros em estantes selecionadas"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "Configurações do OAuth"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Adicionar valores permitidos/negados da coluna personalizada"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Magic Shelves Order"
 msgstr "Sincronizar com Kobo as estantes selecionadas"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "Livros recentemente adicionados"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "Editar estantes públicas"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Apagar utilizador"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12086,158 +11900,158 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Alterar senha"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Alterar senha"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Criar/Ver"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Gerar URL de autenticação Kobo"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Selecionar..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Remover seleções"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "Editar utilizador"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "Escolha um nome de utilizador"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Email"
 msgstr "Email de teste"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email"
 msgstr "Enviar para o endereço de email do dispositivo de leitura"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email"
 msgstr "Email do dispositivo de leitura"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "Enviar para o endereço de email do dispositivo de leitura"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "Email do dispositivo de leitura"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Idioma"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "Idiomas de livros visíveis"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "Editar etiquetas permitidas"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Etiquetas permitidas"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Editar etiquetas não permitidas"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Etiquetas não permitidas"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "Editar valores de coluna permitidos"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "Valores de coluna permitidos"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "Editar valores de coluna não permitidos"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "Valores de coluna não permitidos"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "Alterar senha"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "Editar estantes públicas"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "Sincronizar com Kobo as estantes selecionadas"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "Sincronizar com Kobo as estantes selecionadas"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Read/Unread Section"
 msgstr "Mostrar secção de lidos/não lidos"

--- a/cps/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/cps/translations/pt_BR/LC_MESSAGES/messages.po
@@ -16,257 +16,255 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 "Banco de dados do Calibre indisponível. Reconfigure o caminho da biblioteca."
 
-#: cps/admin.py:208
+#: cps/admin.py
 msgid "Server restarted, please reload page."
 msgstr "Servidor reiniciado, por favor recarregue a página"
 
-#: cps/admin.py:210
+#: cps/admin.py
 msgid "Performing Server shutdown, please close window."
 msgstr "Executando o desligamento do servidor, por favor feche a janela"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "Sucesso ! Banco de Dados Reconectado"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Comando desconhecido"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 "Sucesso ! Livros enfileirados para Backup de Metadados, por favor verifique "
 "os resultados em Tarefas"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr "Erro ao iniciar a tarefa de busca automática do Hardcover: %(error)s"
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr "Revise as Correspondências do Hardcover"
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr "Erro ao carregar a fila de revisão: %(error)s"
 
-#: cps/admin.py:414
+#: cps/admin.py
 msgid "Hardcover ID applied successfully"
 msgstr "ID do Hardcover aplicado com sucesso"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr "Correspondências %(action)s"
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr "Não há correspondências pendentes para rejeitar"
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr "Rejeitado %(count)s correspondência(s)"
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr "Nenhum livro com capa encontrado para processar."
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr "Falha ao iniciar a atualização da miniatura: {}"
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Página de Administração"
 
-#: cps/admin.py:653
+#: cps/admin.py
 msgid "Hardcover token expires"
 msgstr "Token do Hardcover expira"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Configuração Básica"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Configuração de UI"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 "A Coluna Personalizada No.%(column)d não existe no banco de dados do calibre"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Editar Usuários"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Todos"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Usuário não encontrado"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} usuário(s) removidos com sucesso"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Mostrar Tudo"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Requisição Malformada"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "Nome do Convidado não pode ser alterado"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "Convidado não pode ter este perfil"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr ""
 "Nenhum usuário administrador restante, impossível remover perfil de "
 "administrador"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "Valor tem de ser Verdadeiro ou Falso"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Perfil Inválido"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "Convidado não pode ter esta visão"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "Visão Inválida"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 "O idioma do Convidado é detectado automaticamente e não pode ser alterado"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Nenhum Idioma Válido Fornecido"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Nenhum Idioma do Livro Válido Fornecido"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Parâmetro não encontrado"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "Settings DB não é gravável"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Coluna Lido Inválida"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Coluna Restrito Inválida"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr "Configuração do Calibre-Web NextGen atualizada"
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Você realmente quer apagar a Kobo Token?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "Você realmente quer apagar este domínio?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "Você realmente quer apagar este usuário?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Tem certeza que quer apagar essa estante?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr "Tem certeza que quer alterar o idioma do(s) usuário(s) selecionados?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "Tem certeza que quer alterar os idiomas de livros visíveis par o usuário(s) "
 "selecionado(s)?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 "Tem certeza que quer alterar o perfil selecionado para o(s) usuário(s) "
 "selecionado(s)?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
@@ -274,7 +272,7 @@ msgstr ""
 "Tem certeza que quer alterar as restrições selecionada para o(s) usuário(s) "
 "selecionado(s)?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -282,14 +280,14 @@ msgstr ""
 "Tem certeza de que quer alterar as restrições de visibilidade selecionadas "
 "para os usuários selecionados?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "Tem certeza de que quer alterar o comportamento de sincronização da estante "
 "para o usuário selecionado?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
@@ -297,128 +295,123 @@ msgstr ""
 "Tem certeza de que quer alterar o comportamento de sincronização da estante "
 "para o usuário selecionado?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Tem certeza que queres alterar a localização da biblioteca Calibre?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Negar"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Permitir"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "{} entradas de sincronização deletadas"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, python-brace-format
 msgid "Book {} not found"
 msgstr "Livro {} não encontrado"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Tag não encontrada"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Ação Inválida"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json Não Está Configurado para Aplicação Web"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "A localização do arquivo de log não é válida, digite o caminho correto"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "A localização do arquivo de log de acesso não é válida, digite o caminho "
 "correto"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 "Digite um provedor LDAP, porta, DN e identificador de objeto do usuário"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Por favor, digite uma Conta de Serviço LDAP e Senha"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "Por favor, digite uma Conta de Serviço LDAP"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "O filtro de objeto de grupo LDAP precisa ter um identificador de formato "
 "\"%s\""
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "Filtro de objeto de grupo LDAP tem parênteses sem par"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "O filtro de objeto de usuário LDAP precisa ter um identificador de formato "
 "\"%s\""
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "Filtro de objeto de usuário LDAP tem parênteses sem par"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "O filtro de usuário membro do LDAP precisa ter um identificador de formato "
 "\"%s\""
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "Filtro de usuário de membro LDAP tem parênteses sem par"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -426,29 +419,24 @@ msgstr ""
 "Localização de LDAP CACertificate, Certificados ou Key Inválida, Insira o "
 "Caminho Correto"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Adicionar Novo Usuário"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Editar configurações do servidor de e-mail"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "Sucesso ! Conta do Gmail Verificada."
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Ops ! Erro de banco de dados: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -456,53 +444,53 @@ msgstr ""
 "E-mail de teste enfileirado para envio para %(email)s, verifique o resultado "
 "em Tarefas"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Ocorreu um erro ao enviar o e-mail de teste: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Por favor, configure seu endereço de e-mail primeiro..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Atualização das configurações do servidor de e-mail"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 msgid "Email Your Users"
 msgstr "Enviar e-mail para seus usuários"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr ""
 "Por favor, configure o servidor de e-mail em Editar Configurações do "
 "Servidor de E-mail primeiro."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr "Por favor, insira um assunto para o e-mail de anúncio."
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr "Por favor, insira o corpo da mensagem para o e-mail de anúncio."
 
-#: cps/admin.py:2060
+#: cps/admin.py
 msgid "Please set an email address on your own account first..."
 msgstr ""
 "Por favor, configure um endereço de e-mail em sua própria conta primeiro..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "Por favor, selecione pelo menos um endereço de e-mail"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -510,7 +498,7 @@ msgstr ""
 "E-mail de teste enfileirado para envio para %(email)s, verifique o resultado "
 "em Tarefas"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -519,559 +507,556 @@ msgstr ""
 "E-mail de teste enfileirado para envio para %(email)s, verifique o resultado "
 "em Tarefas"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "Editar configurações de tarefas agendadas"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "Hora de início inválida para a tarefa especificada"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "Duração inválida para a tarefa especificada"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "Configurações de tarefas agendadas atualizadas"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr ""
 "Ops ! Ocorreu um erro desconhecido. Por favor, tente novamente mais tarde."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 msgid "title"
 msgstr "Título"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Editar Usuário %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Sucesso! Senha do usuário %(user)s redefinida"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Ops! Por favor, configure as definições de SMTP."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Visualizador do Log"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Solicitação de pacote de atualização"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Baixando pacote de atualização"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Descompactando pacote de atualização"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Substituindo arquivos"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "As conexões à base de dados estão fechadas"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Parando servidor"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Atualização concluída, pressione okay e recarregue a página"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Atualização falhou:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "Erro HTTP"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Erro de conexão"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Tempo limite durante o estabelecimento da conexão"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Erro genérico"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr "Arquivo de atualização não pôde ser salvo no diretório temporário"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "Arquivos não puderam ser substituídos durante a atualização"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "Falha ao extrair pelo menos um usuário LDAP"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Falha ao criar pelo menos um usuário LDAP"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Erro: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Erro: Nenhum usuário retornado na resposta do servidor LDAP"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "No mínimo um usuário LDAP não encontrado no banco de dados"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} Usuário(s) Importado(s) com Sucesso"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr "Caminho dos livros inválido"
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "A localização do banco de dados não é válida, digite o caminho correto"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "DB não é gravável"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "Localização do Keyfile Inválida, Insira o Caminho Correto"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr "Localização do Certfile Inválida, Insira o Caminho Correto"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr "Tamanho da senha deve ser entre 1 e 40"
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "Configurações do Banco de Dados Atualizada"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "Configuração do Banco de Dados"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Por favor, preencha todos os campos!"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "O e-mail não é de um domínio válido"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Adicionar novo usuário"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Usuário '%(user)s' criado"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr ""
 "Encontrada uma conta existente para este endereço de e-mail ou apelido."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Usuário '%(nick)s' excluído"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "Impossível excluir Convidado"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "Nenhum usuário administrador restante, não é possível apagar o usuário"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "O Email não pode ser vazio e deve ter endereço válido"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Usuário '%(nick)s' atualizado"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr "Conexão falhou: Servidor retornou código %(code)s"
 
-#: cps/admin.py:3276
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr "Conexão falhou: Não foi possível conectar ao servidor."
 
-#: cps/admin.py:3278
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr "Conexão falhou: Tempo Limite do pedido alcançado."
 
-#: cps/admin.py:3280
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr "Conexão falhou: Resposta com JSON inválido."
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Erro de conexão"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr "Os seguintes campos estão fantando no Metadata: %(fields)s"
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr "A URL do Metadata é válida! Encontrados %(count)s endpoints."
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "Não há informações de lançamento disponíveis"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr "Conexão falhou: Não foi possível conectar ao servidor."
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr "Conexão falhou: Tempo Limite do pedido alcançado."
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr "Conexão falhou: Resposta com JSON inválido."
 
-#: cps/admin.py:3340
+#: cps/admin.py
 msgid "An unknown error occurred."
 msgstr "Ocorreu um erro desconhecido."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 msgid "Restore already in progress."
 msgstr "Restauração já em andamento."
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 "Restauração falhou: O caminho da biblioteca Calibre não está configurado."
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Restauração falhou: %(err)s"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 "Restauração completa, mas a limpeza do app.db falhou. Veja os logs para "
 "detalhes."
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr "Importar anotações do Kobo"
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 msgid "No file uploaded."
 msgstr "Nenhum arquivo enviado."
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr "O arquivo excede %(max)d MB."
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr "O arquivo enviado não é um banco de dados SQLite."
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr "Anotações: %(title)s"
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr "Tcheco"
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr "Alemão"
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr "Grego"
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr "Espanhol"
 
-#: cps/constants.py:265
+#: cps/constants.py
 msgid "Finnish"
 msgstr "Finlandês"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr "Francês"
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr "Galego"
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr "Indonésio"
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr "Italiano"
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr "Japonês"
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr "Cambojano"
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr "Coreano"
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr "Holandês"
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr "Norueguês"
 
-#: cps/constants.py:276
+#: cps/constants.py
 msgid "Polish"
 msgstr "Polonês"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr "Português"
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr "Português (Brasil)"
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr "Russo"
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr "Eslovaco"
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr "Sueco"
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr "Turco"
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr "Vietnamita"
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr "Chinês Simplificado"
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr "Chinês Tradicional"
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "não instalado"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Faltam as permissões de execução"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr "Voltar para edição de metadados"
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr "Voltar para o livro"
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, python-format
 msgid "Change cover — %(title)s"
 msgstr "Trocar capa — %(title)s"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr "A capa do livro está bloqueada. Desbloqueie-a primeiro."
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr "Forneça uma URL para a capa."
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr "Este livro não possui uma capa incorporada que possamos extrair."
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 msgid "Unknown cover source."
 msgstr "Fonte de capa desconhecida."
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr "Não foi possível salvar o estado do bloqueio."
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr "Somente URLs http(s) podem ser visualizadas."
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr "Não foi possível renderizar a pré-visualização do e-reader."
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr "Não foi possível carregar uma imagem de origem para visualização."
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr "Falha ao salvar a capa"
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr "A troca de tema está temporariamente desativada até a v5.0.0"
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
@@ -1079,357 +1064,345 @@ msgstr ""
 "Atualização da Biblioteca 🔄 Checando por livros que podem estar faltando, "
 "por favor, aguarde..."
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr "Configurações do Usuário do Calibre-Web NextGen"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr "Formato de Data"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Book ID"
 msgstr "ID do Livro"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Título do Livro"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Book Author"
 msgstr "Autor do Livro"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr "Tipo de Gatilho"
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Filepath"
 msgstr "Caminho do arquivo"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Filename"
 msgstr "Nome do Arquivo"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr "Manual?"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr "Num. Ajustes"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr "Backup do Original?"
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr "Ajustes Aplicados"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr "Formato Original"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "End Format"
 msgstr "Formato Final"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 msgid "Unknown User"
 msgstr "Usuário Desconhecido"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 "✅ Todos os Serviços de MOnitoração estão funcionando como esperado! 👍"
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 "🔴 O Serviço Ingest está rodando, mas o Detector de Mudança de Metadados não."
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 "🔴 O Serviço Detector de Mudança de Metadados está rodando, mas o Ingest não."
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 "⛔ Nem o Serviço Ingest e nem o Detector de Mudança de Metadados estão "
 "rodando."
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr "Um Erro Ocorreu"
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 msgid "Invalid book selection."
 msgstr "Seleção de livro inválida."
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr "Livro não encontrado."
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 msgid "Selected book has no EPUB format."
 msgstr "O livro selecionado não possui formato EPUB."
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 msgid "EPUB file not found on disk."
 msgstr "Arquivo EPUB não encontrado no disco."
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 msgid "EPUB Fixer started for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr "Você deve ser admin para acessar esta página."
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr "Os dados do usuário e da imagem são obrigatórios."
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 msgid "Invalid image data format."
 msgstr "Formato inválido de dados da imagem."
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr "Imagem do perfil atualizada com sucesso."
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Nenhum"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 msgid "Duplicate Books"
 msgstr "Livros duplicados"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr "O grupo de duplicados já foi descartado"
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 msgid "Duplicate group dismissed"
 msgstr "Grupo de duplicados descartado"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 msgid "Duplicate group restored"
 msgstr "Grupo de duplicados restaurado"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr "O grupo de duplicados não foi descartado"
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 msgid "Duplicate scan queued"
 msgstr "Verificação de duplicados adicionada à fila"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr "Verificação de duplicados concluída (alternativa)"
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 msgid "Invalid resolution strategy"
 msgstr "Estratégia de resolução inválida"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr "ID do Livro faltando ou inválido para carregar formato"
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Upload concluído, processando, por favor aguarde ..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 #, fuzzy
 msgid "Failed to queue upload for processing"
 msgstr "Falha em cenfileirar o upload para processamento"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Formato de origem ou destino para conversão ausente"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "Livro enfileirado com sucesso para conversão para %(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Ocorreu um erro ao converter este livro: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 #, fuzzy
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "Tipo do arquivo não pode ser enviada para este servidor"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr ""
 "A extensão de arquivo '%(ext)s' não pode ser enviada para este servidor"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "O arquivo a ser carregado deve ter uma extensão"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 "Oops! O Livro selecionado não está disponível. O arquivo não existe ou não é "
 "acessível"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "Usuário não tem permissão para fazer upload da capa"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 "Os identificadores não diferenciam maiúsculas de minúsculas, substituindo o "
 "identificador antigo"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "%(langname)s não é um idioma válido"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Metadados atualizados com sucesso"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "Erro ao editar o livro: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1437,97 +1410,97 @@ msgstr ""
 "O livro carregado provavelmente existe na biblioteca, considere alterar "
 "antes de carregar novo: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "O arquivo %(filename)s não pôde ser salvo no diretório temporário"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Falha ao mover arquivo de capa %(file)s: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Formato do Livro Apagado com Sucesso"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Livro Apagado com Sucesso"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "Você não tem permissão para apagar livros"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "editar metadados"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "%(seriesindex)s não é um número válido, ignorando"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr ""
 "Usuário não tem direitos para fazer upload de formatos de arquivo adicionais"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Falha ao criar o caminho %(path)s (Permissão negada)."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Falha ao armazenar o arquivo %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Formato de arquivo %(ext)s adicionado a %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Token não encontrado"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "Formato %(format)s não encontrado no disco"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1535,7 +1508,7 @@ msgstr ""
 "Configuração do Google Drive não concluída, tente desativar e ativar o "
 "Google Drive novamente"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1543,88 +1516,87 @@ msgstr ""
 "O domínio Callback não foi verificado, por favor siga os passos para "
 "verificar o domínio no console do desenvolvedor do google"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr "Este email foi enviado via Calibre-Web NextGen"
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "Formato %(format)s não encontrado para o id do livro: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(format)s não encontrado no Google Drive: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s não encontrado: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "Enviar para E-Reader"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "Formato %(format)s não encontrado para o id do livro: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "Formato %(format)s não encontrado para o id do livro: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 #, fuzzy
 msgid "Test Email"
 msgstr "E-mail de teste"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "E-mail de registro do usuário: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Converter %(orig)s em %(format)s e enviar para E-Reader"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Enviar %(format)s para o E-Reader"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s enviado para E-Reader"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "O arquivo solicitado não pôde ser lido. Permissões erradas, Talvez?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "Status Lido não pode ser alterado: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
@@ -1632,12 +1604,12 @@ msgstr ""
 "A exclusão da pasta de livros do livro %(id)s falhou, o caminho tem "
 "subpastas: %(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "Falha ao excluir livro %(id)s: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1646,73 +1618,73 @@ msgstr ""
 "Excluindo livro %(id)s somente do banco de dados, caminho do livro inválido: "
 "%(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Renomear autor de: '%(src)s' para '%(dest)s' falhou com o erro: %(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Arquivo %(file)s não encontrado no Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Renomear título de: '%(src)s' para '%(dest)s' falhou com o erro: %(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Caminho do livro %(path)s não encontrado no Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr "Encontrado uma conta existente para este E-Mail"
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Este nome de usuário já está registrado"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 #, fuzzy
 msgid "Invalid Email address format"
 msgstr "Formato de endereço de e-mail inválido"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr "Senha não está conforme as regras de validação"
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 "O módulo Python 'advocate' não está instalado, mas é necessário para uploads "
 "de capa"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Erro ao Baixar a capa"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr ""
 "O arquivo de capa não é um arquivo de imagem válido, ou não pôde ser "
 "armazenado"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Erro de Formato da Capa"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
@@ -1720,122 +1692,122 @@ msgstr ""
 "Você não tem permissão para acessar localhost ou a rede local para uploads "
 "de capa"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Falha em criar caminho para a capa"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr ""
 "Apenas arquivos jpg/jpeg/png/webp/bmp são suportados como arquivos de capa"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "Conteúdo do arquivo de capa inválido"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Apenas arquivos jpg/jpeg são suportados como arquivos de capa"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr ""
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "Binário UnRar não encontrado"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing UnRar"
 msgstr "Erro excecutando UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr "Não foi possível encontrar o diretório especificado"
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr "Por favor, especifique um diretório, não um arquivo"
 
-#: cps/helper.py:2125
+#: cps/helper.py
 #, fuzzy
 msgid "Calibre binaries not viable"
 msgstr "Binários do Calibre não viáveis"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr "Binários do calibre faltando: %(missing)s"
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Faltam as permissões de execução: %(missing)s"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing Calibre"
 msgstr "Erro excecutando Calibre"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr "Enfileirar todos os livros para backup de metadados"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Configuração Kobo"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr "Adicionados recentemente"
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr "Mais bem avaliados"
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr "Em leitura"
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr "Não lidos"
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr "Publicações recentes"
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Registre-se com %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
@@ -1844,7 +1816,7 @@ msgstr ""
 "Falha de Login: Não foi possível se conectar com o endpoint de informações "
 "do usuário."
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
@@ -1852,7 +1824,7 @@ msgid ""
 msgstr ""
 "Falha de Login: O provedor OAuth retornou um perfil de usuário inválido."
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1860,35 +1832,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "Sucesso! Agora você está logado como: '%(nickname)s'"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Link para %(oauth)s bem-sucedido"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1896,780 +1868,771 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr ""
 "O servidor de E-Mail não está configurado, por favor contacte o seu "
 "administrador!"
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "Desvincular para %(oauth)s bem-sucedido"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Falha ao desvincular para %(oauth)s"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "Não vinculado a %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Falha no login com o GitHub."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Falha na busca de informações do usuário no GitHub."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Falha no login com o Google."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Falha na busca de informações de usuário no Google."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 msgid "Failed to log in with Generic OAuth."
 msgstr "Falha no login com o OAuth Genérico."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "Erro no Oauth do GitHub, tente novamente mais tarde."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "Erro no Oauth do GitHub: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Erro no Google Oauth, tente novamente mais tarde."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Erro no Oauth do Google: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, fuzzy, python-brace-format
 msgid "OAuth error: {}"
 msgstr "Erro no Oauth: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "Livros Alfabéticos"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "Livros ordenados alfabeticamente"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Livros Quentes"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "Publicações populares deste catálogo baseadas em Downloads."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Livros Mais Bem Avaliados"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Publicações populares deste catálogo baseadas em Avaliação."
 
-#: cps/opds.py:182
+#: cps/opds.py
 msgid "Recently added Books"
 msgstr "Livros adicionados recentemente"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Os últimos Livros"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Livros Aleatórios"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Mostrar Livros Aleatórios"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Livros Lidos"
 
-#: cps/opds.py:201
+#: cps/opds.py
 msgid "Books currently being read"
 msgstr "Livros sendo lidos"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Livros Não Lidos"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Autores"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Livros ordenados por Autor"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Editoras"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Livros ordenados por editora"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Categorias"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Livros ordenados por categoria"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Séries"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Livros ordenados por série"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Idiomas"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Livros ordenados por Idiomas"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Avaliações"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Livros ordenados por Avaliação"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Formatos de arquivo"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Livros ordenados por formatos de arquivo"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Estantes"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "Livros organizados em Estantes"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Sincronizar Estantes Selecionadas com Kobo"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Livros organizados em Estantes"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "Descrição"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} Estrelas"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Pesquisar"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Login"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Token não encontrado"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "O Token expirou"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Sucesso! Por favor, volte ao seu aparelho"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Livros"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Mostrar livros recentes"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Mostrar Livros Quentes"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Livros Baixados"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Mostrar Livros Baixados"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Mostrar Livros Mais Bem Avaliados"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Read and Unread"
 msgstr "Mostrar lido e não lido"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Mostrar Não Lidos"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Descubra"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Category Section"
 msgstr "Mostrar seção de categoria"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Series Section"
 msgstr "Mostrar seção de séries"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Author Section"
 msgstr "Mostrar seção de autor"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Publisher Section"
 msgstr "Mostrar seção de editoras"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Language Section"
 msgstr "Mostrar seção de idioma"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Ratings Section"
 msgstr "Mostrar seção de avaliações"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show File Formats Section"
 msgstr "Mostrar seção de formatos de arquivo"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Livros Arquivados"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Archived Books"
 msgstr "Mostrar livros arquivados"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr "Favoritos"
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr "Mostrar Favoritos"
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Lista de Livros"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Mostrar Lista de Livros"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr "Duplicados"
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Mostrar Livros Duplicados"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Publicado depois de "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Publicado antes de "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Avaliação <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Avaliação >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, fuzzy, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Status de leitura = %(status)s"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr "Erro na pesquisa de colunas personalizadas, reinicie o Calibre-Web"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Pesquisa Avançada"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Estante inválida especificada"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr ""
 "Desculpe, você não tem permissão para adicionar um livro a esta estante"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "O livro já faz parte da estante: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr "%(book_id)s é um ID de livro inválido. Não foi adicionado à estante"
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "O livro foi adicionado à estante: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "Você não tem permissão para adicionar um livro à estante"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Os livros já fazem parte da estante: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "Livros foram adicionados à estante: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Não foi possível adicionar livros à estante: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "Estante inválida especificada"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Não foi possível adicionar livros à estante: %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Os livros já fazem parte da estante: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "Livros foram adicionados à estante: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "O livro foi removido da estante: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "Desculpe, você não tem permissão para remover um livro desta estante"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Crie uma Estante"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Desculpe, você não tem permissão para editar esta estante"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Editar uma estante"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "Erro apagando Estante"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "Estante Apagada com Sucesso"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Alterar ordem da Estante: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "Desculpe, você não tem permissão para criar uma estante pública"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Estante %(title)s criada"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Estante %(title)s alterada"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Houve um erro"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "Já existe uma estante pública com o nome '%(title)s' ."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "Já existe uma estante privada com o nome'%(title)s' ."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Estante: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Erro ao abrir estante. A estante não existe ou não está acessível"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Excluir Estante"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr "Nome (A → Z)"
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr "Nome (Z → A)"
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr "Quantidade de livros (maior → menor)"
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr "Quantidade de livros (menor → maior)"
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr "Criado (mais recente → mais antigo)"
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr "Criado (mais antigo → mais recente)"
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr "Modificado (mais recente → mais antigo)"
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr "Modificado (mais antigo → mais recente)"
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr "Manual (arraste abaixo)"
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr "Ler agora"
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr "Abrir detalhes de {title}"
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr "Ler {title}"
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr "Padrão (nome de usuário / senha)"
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Anônimo"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Não autenticado"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr "Ordem na série"
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr "Ordem na série (decrescente)"
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr "Adicionar tag"
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr "Nova tag"
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr "Remover tag"
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr "Remover tag {name}"
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr "Renomear tag {name}"
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr "Nome da tag"
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr "O nome da tag não pode ser vazio"
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr "Salvar nome da tag"
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr "Não foi possível renomear a tag"
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr "Tag renomeada para {name}"
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr "Você precisa estar conectado"
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr "Você não tem permissão para editar metadados"
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr "Já existe uma tag com esse nome"
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr "O nome da tag deve ser texto"
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr "O nome da tag não pode conter vírgulas"
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr "Digite um nome de tag válido"
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr "Não foi possível carregar esta página"
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr "Página não encontrada"
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr "Limpar avaliação"
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr "Não avaliado"
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Sim"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Não"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr "Corpo da Mensagem de Email"
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr "Avaliado em {rating} de 5"
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr "Mais de {name}"
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
@@ -2678,311 +2641,299 @@ msgstr ""
 "Mesclar {n} livros no primeiro selecionado? Os demais serão removidos após "
 "seus formatos serem copiados."
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr "Aplicar a {n} livros"
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr "Critério de correspondência"
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr "Campo da regra"
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr "Operador da regra"
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr "Não foi possível carregar as regras da estante inteligente."
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr "Possui capa"
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr "Índice de séries"
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Status de leitura"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr "Possui ID do Hardcover"
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr "Nos últimos N dias"
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr "Não nos últimos N dias"
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr "antes de / menor que"
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr "até a data / no máximo"
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr "depois de / maior que"
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr "a partir de / no mínimo"
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr "está entre"
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr "não está entre"
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr "não começa com"
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr "não termina com"
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr "está vazio"
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr "não está vazio"
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr "Aparência"
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Tema"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr "Sistema"
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Claro"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Escuro"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "Sépia"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr "Alto contraste"
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr "Meia-noite (AMOLED)"
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr "Igualar às configurações de luz ou escuro do seu dispositivo"
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr "Tema salvo."
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr "Não foi possível salvar o tema."
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr "Tema padrão para novas contas"
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr "Adicionar formato"
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr "Adicionar regra"
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Adicionar à estante"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr "Adicionar a sua própria"
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr "Senhas de aplicativos"
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Autor"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr "Autores (separar com &)"
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr "Voltar para fazer login"
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr "Azul"
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr "Conteúdo do livro"
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Navegue em"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr "Alterar senha"
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Fechar"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr "Fechar menu"
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr "Falha na converção"
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr "Converter para o formato"
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr "Copiar"
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr "Não foi possível alterar a senha"
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr "Não foi possível criar."
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr "Não foi possível buscar a capa."
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr "Não foi possível carregar os metadados."
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr "Não foi possível carregar o arquivo do livro ({status})"
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr "Não foi possível carregar sua conta."
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr "Não foi possível salvar."
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr "URL da imagem da capa"
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr "Falha ao atualizar a capa."
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr "Capa atualizada"
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr "Criar estante inteligente"
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr "Criar sua conta"
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr "Tema escuro"
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Apagar"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr "Apagar livro"
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
@@ -2991,2207 +2942,2172 @@ msgstr ""
 "Apagar \"{title}\"? Isso remove permanentemente o livro e todos os seus "
 "arquivos da sua biblioteca. Isso não pode ser desfeito."
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr "Apagando…"
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr "Não foi possível apagar este livro."
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 "Apagar o arquivo {fmt}? O livro permanece; apenas este formato é removido."
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr "Apagar {fmt}"
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr "Apagar {n} livro(s)? Isso não pode ser desfeito."
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr "Descrição contém"
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr "Desmarcar {title}"
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr "Editar metadados"
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr "Editar {title}"
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr "Falha ao carregar livros."
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr "Falha ao abrir o livro."
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr "Gerar"
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr "Verde"
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr "Ajuda"
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr "Cor de destaque"
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr "Importar do Kobo"
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr "Idioma da Interface"
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr "Nome de usuário ou senha inválidos."
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr "Fonte do corpo da interface"
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr "Fonte da exibição da interface"
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr "Idiomas (separados por vírgula)"
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr "Tema claro"
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr "Falha ao fazer login."
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr "Marcar como lido"
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr "Marcar como não lido"
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Mesclar"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr "Nenhum livro aqui."
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr "Nenhum resultado para \"{q}\"."
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr "Nenhuma sugestão"
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr "Nenhum livro {filter} aqui."
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr "Senha alterada."
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr "Colar URL"
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr "Estante privada"
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr "Perfil"
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr "Perfil salvo."
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr "Estante pública"
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Editora"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Lido"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr "Progresso de leitura"
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr "Vermelho"
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr "Remover {name}"
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr "Redefinir"
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr "Redefinir sua senha"
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr "Revogar {label}"
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr "Salvar alterações"
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr "Falha ao salvar."
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr "Salvar perfil"
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr "Salvo."
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr "Salvando…"
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Título"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr "Não lidos"
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr "Atualizar senha"
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Upload"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr "Escolha livros para enviar"
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr "O upload falhou."
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr "Upload de imagem"
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr "Enviando..."
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr "Amarelo"
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr "ex. MOBI"
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr "Chave da API {name}"
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr "{n} livro(s) adicionado(s) à estante."
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr "{n} livro(s) apagado(s)."
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr "{n} marcado(s) como lido(s)"
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr "{n} marcado(s) como não lido(s)"
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr "{n} selecionado(s)"
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr "{pct}% lido"
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr "Novidades"
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr "Ajuda — novas atualizações disponíveis"
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 "As últimas novidades e correções no Calibre-Web NextGen — do mais recente "
 "para o mais antigo."
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr "{n} atualização"
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr "{n} atualizações"
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr "Lendo"
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr "Visualização em grade"
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr "Biblioteca"
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr "Visualização em lista"
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Conta"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Admin"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr "Abrir sua biblioteca"
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr "Revisar Duplicatas"
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr "Explorar sua biblioteca"
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Publicado em"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Fonte"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr "Personalizar"
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr "Personalizar barra lateral"
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr "Personalizar navegação"
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr "Feito"
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr "Redefinir para o padrão"
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr "Mostrar sempre"
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 "Editando barra lateral. Reordene ou esconda seções, depois toque em Feito."
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr "Edição cancelada."
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 "Arraste para reordenar. Toque em ✕ para esconder uma seção. As teclas de "
 "seta movem o controle focalizado."
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr "Barra lateral salva."
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr "Barra lateral redefinida para o padrão."
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr "Atualizar biblioteca"
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr "Incluído em"
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr "Ignorar mensagem de apoio no Ko-fi"
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr "Ignorar anúncio de ajuda"
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr "Abrir o Ko-fi →"
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr "Data de Publicação"
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr "Apoie-nos no Ko-fi!"
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr "começa com"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr "contém"
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr "não contém"
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr "≤"
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr "≥"
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr "Algumas escolhas aleatórias da sua biblioteca"
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "Sobre"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr "Configurações de conta"
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr "Conta: {name}"
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr "Adicionar aos favoritos"
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr "Avançado"
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr "Pesquisa avançada"
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr "Todas as estantes"
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr "Permitir login remoto (link mágico)"
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr "Grupos permitidos (separado por vírgulas)"
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr "Qualquer"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr "Qualquer formato"
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr "Qualquer idioma"
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr "Qualquer série"
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr "Qualquer tag"
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr "Aplicar seleção"
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr "Aplicando…"
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr "Arquivado"
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Arquivado"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr "Perguntar no Discord"
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr "Autenticação"
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr "Autenticação e segurança"
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr "Autor A-Z"
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr "Autor Z-A"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr "Autorizado — entrando…"
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr "Criar usuários automaticamente no primeiro login"
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr "Voltar para a biblioteca"
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr "Voltar para a visualização clássica"
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr "Configuração básica"
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr "Livro {number}"
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr "Livros por página"
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr "Configurações do CWA (ingest/convert)"
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr "Cancelar renomeação"
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr "Cancelar edição de título"
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr "Cancelar {task}"
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr "Alterar capa"
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr "Escolha uma capa"
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr "Escolha a imagem da capa para enviar"
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr "Escolha uma imagem..."
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr "Escolha seu tema"
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr "Limpar seleção"
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr "Fechar o leitor"
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr "Colunas"
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr "Confortável"
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr "Compacto"
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr "Configurado"
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr "Confirmar nova senha"
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "Converter"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr "Converter antes de enviar"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr "Converter de"
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr "Copiado para a área de transferência"
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr "Copiar link"
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr "Não foi possível criar a estante."
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr "Não foi possível criar a estante."
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr "Não foi possível excluir a estante."
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr "Não foi possível carregar candidatos."
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr "Não foi possível carregar duplicados."
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr "Não foi possível carregar destaques."
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr "Não foi possível carregar estatísticas."
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr "Não foi possível carregar tarefas."
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr "Não foi possível carregar esse arquivo de texto"
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr "Não foi possível carregar usuários."
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr "Não foi possível ler este arquivo de quadrinhos."
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr "Não foi possível recarregar os metadados"
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr "Não foi possível renomear a estante."
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr "Não foi possível redefinir a senha."
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr "Capa atual"
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr "Senha atual"
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr "Leitura atual"
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr "Incluído em"
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Descrição"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr "Documentação"
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Baixar"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr "Livros duplicados"
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr "Pré-visualização no e-reader"
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Editar"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "Endereço de e-mail"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Ativar Kobo sync"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Criptografia"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr "Favoritar"
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr "Favoritado"
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr "Formatos"
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr "Formatos — excluir"
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr "Formatos — incluir"
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr "Vá para a sua biblioteca"
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr "Ajuda e suporte"
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr "Menu de ajuda"
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr "Livro ocultado"
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "Esconder"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr "Ocultar campos"
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr "Ocultar senha"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr "Destaque"
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr "Destaques"
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr "Ícone"
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Identificadores"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr "Importado como"
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr "No seu livro"
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr "KOReader Progresso"
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Idioma"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr "Idiomas — incluir"
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr "Última modificação"
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr "Última sincronização"
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr "Configurações da biblioteca"
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr "Carregar mais"
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr "Carregando"
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr "Bloquear capa"
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr "Marcar como lido"
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr "Marcar como não lido"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr "Máx."
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr "Mais configurações do servidor"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr "Mover para baixo"
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr "Mover para cima"
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr "Minha conta"
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr "Nome"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr "Precisa reportar um problema? Experimente o novo"
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr "Novo"
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr "Nova senha"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr "Novo nome da estante"
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr "Novo nome da estante…"
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr "Nova estante…"
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr "Nova estante inteligente"
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr "Novo usuário"
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr "Mais recentes"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr "Publicados mais recentemente"
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr "Próxima página"
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr "Nenhum livro corresponde a esta estante inteligente no momento."
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr "Nenhum livro corresponde a esses critérios."
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 "Nenhum candidato encontrado ainda. Tente uma pesquisa diferente ou atualize."
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr "Nenhum conteúdo encontrado."
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr "Nenhum grupo duplicado encontrado."
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr "Nenhuma tag excluída"
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 "Nenhum destaque ainda. Destaque enquanto lê ou importe de um dispositivo "
 "Kobo."
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr "Nenhum {items} corresponde a \"{query}\"."
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr "Nenhuma página encontrada neste quadrinho."
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr "Ainda não há estantes - crie uma abaixo"
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr "Ainda não há estantes. Crie uma acima para começar a guardar livros."
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr "Nenhuma fonte precisa de uma chave."
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr "Nenhuma tarefa em execução"
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr "Ainda não há {items}."
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr "Não configurado"
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr "Mais antigos"
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr "Publicados há mais tempo"
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr "Abrir Conta"
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr "Abrir leitor clássico"
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr "Abrir navegação"
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr "Abrir leitor"
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr "Abrir a interface clássica"
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr "Abra o link abaixo em seu dispositivo conectado."
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr "Servidor OpenLDAP"
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr "Abre na visualização clássica"
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr "Leitor de PDF"
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr "Margens da página"
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr "Tema da página"
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr "Página {number}"
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Senha"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr "Senha (deixe em branco para manter)"
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
@@ -5199,159 +5115,154 @@ msgstr ""
 "Escolha uma capa de qualquer fonte que suportamos, cole um URL, envie um "
 "arquivo ou use a capa incorporada no próprio livro."
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr "Selecionado {label}. Arraste para reordenar, solte para largar."
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Porta"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr "Preparando seu link mágico..."
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr "Página anterior"
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Progresso"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr "Público"
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr "Publicados após"
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr "Publicados antes"
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr "Mostrando livros aleatórios"
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Avaliação"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr "Avaliação (estrelas)"
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr "Status de leitura"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr "Filtro de status de leitura"
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr "Configurações do leitor salvas."
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr "Aparência da leitura"
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr "Destinatário(s)"
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr "Host de redirecionamento (URL completa)"
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr "Registrando…"
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr "Recarregar"
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr "Recarregar metadados do disco"
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr "Recarregando…"
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr "Lembrar de mim"
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr "Remover dos favoritos"
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr "Remover da estante"
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr "Remover destaque"
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr "Remover identificador"
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr "Remover regra"
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr "Renomear"
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr "Reordenar"
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr "Substituir a capa por esta?"
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr "Substituir a capa?"
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr "Reportar Problema no Discord"
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr "Reportar Problema no GitHub"
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr "Requerer associação a grupo"
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr "Redefinir senha para {name}"
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
@@ -5360,444 +5271,441 @@ msgstr ""
 "Redefinir senha para {name}? Sua senha atual deixará de funcionar e uma "
 "substituta será enviada por e-mail."
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr "Login via cabeçalho de proxy reverso"
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr "Linhas por carregamento"
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Salvar"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr "Salvar configurações de email"
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr "Salvar nome"
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr "Salvar configurações de segurança"
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr "Salvar configurações"
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 "Salvo. Reinicie o servidor para que as alterações de login tenham efeito."
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr "Tarefas agendadas"
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr "Pesquisar título, autor..."
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr "Pesquisando em todas as fontes…"
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr "Pesquisando..."
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr "Configurações de Segurança salvas."
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr "Veja como cada capa parece com espaçamento para o seu dispositivo"
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "Selecione"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr "Selecionar vários"
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr "Enviar"
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr "Enviou falhou."
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr "Enviar para E-Reader"
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr "Enviar para o endereço de e-mail do E-Reader"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr "Enviando..."
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr "Índice da série"
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr "Visualização da série"
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr "Série — incluir"
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr "Configurações salvas."
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr "Mostrar senha"
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr "Sair"
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr "Entrando…"
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr "Título do site"
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr "Estantes inteligentes"
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr "Algumas fontes necessitam de uma chave para obter capas melhores"
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr "Algo deu errado"
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr "Ordem de classificação"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr "Detalhes da fonte"
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr "Início da leitura"
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr "Dashboard de estatísticas"
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Estado"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr "Apoiar no Ko-fi →"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr "Sincronizar apenas as estantes selecionadas com o Kobo"
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr "Visualização em tabela"
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr "Tag"
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Tags"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr "Tags — excluir"
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr "Tags — incluir"
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Tarefa"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Tarefas"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr "Detalhes técnicos"
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr "Esta URL não é uma imagem utilizável."
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr "Título A–Z"
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr "Título Z–A"
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr "Título, autor ou ISBN"
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr "URL do token"
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr "Melhores avaliados"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr "Desarquivar"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr "Mostrar"
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr "Desbloqueie a capa para alterá-la"
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr "Sem título"
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr "Atualização falhou."
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr "Enviar como capa"
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr "Enviar livros"
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
@@ -5805,257 +5713,253 @@ msgstr ""
 "Use esta para conectar a leitores OPDS ou sincronizar com KOReader sem a sua "
 "senha principal."
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr "Usar esta capa"
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Usuário"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr "Administração de usuário"
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Nome de usuário"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Ver"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr "Visualizar configurações"
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr "Quando bloqueada, a busca de metadados não substituirá esta capa."
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr "Sua Biblioteca"
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr "Seu navegador não pode reproduzir este formato de áudio."
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr "Sua biblioteca digital pessoal"
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 "Seu endereço de e-reader salvo é exibido — mude-o apenas para este envio."
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr "livros"
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr "cópias"
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr "{count} livro"
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr "{count} livros"
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr "{count} arquivo na fila para importação"
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr "{count} arquivo rejeitado"
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr "{count} arquivos na fila para importação"
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr "{count} arquivos rejeitados"
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr "{count} resultado"
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr "{count} resultados"
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr "{count} resultados para \"{query}\""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr "{n} encontrados"
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr "{ok} de {total} fontes respondidas"
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr "← Voltar para o livro"
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr "← Voltar para o login"
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr "← Biblioteca"
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Aguardando"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Falha"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Iniciado"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Concluído"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "Terminado"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Status Desconhecido"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Dados inesperados ao ler informações de atualização"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr "Não há atualização disponível. Você já tem a última versão instalada"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6063,15 +5967,15 @@ msgstr ""
 "Uma nova atualização está disponível. Clique no botão abaixo para atualizar "
 "para a versão mais recente."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Não foi possível buscar as informações de atualização"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr "Clique no botão abaixo para atualizar para a última versão estável."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6080,255 +5984,253 @@ msgstr ""
 "Uma nova atualização está disponível. Clique no botão abaixo para atualizar "
 "para a versão: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Não há informações de lançamento disponíveis"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Descobrir (Livros Aleatórios)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Livros Quentes (Mais Baixados)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "Livros baixados por %(user)s"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Autor: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Editora: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Série: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "Avaliação: Nenhuma"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Avaliação: %(rating)s estrelas"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Formato do arquivo: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Categoria: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Idioma: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 msgid "Favorite Books"
 msgstr "Livros Favoritos"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 msgid "Hidden Books"
 msgstr "Livros Ocultos"
 
-#: cps/web.py:1193
+#: cps/web.py
 msgid "Error loading magic shelf"
 msgstr "Erro ao carregar a estante mágica"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 msgid "Invalid rules format"
 msgstr "Formato de regras inválido"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 msgid "Invalid request"
 msgstr "Requisição inválida"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr "Nome e regras são obrigatórios"
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 msgid "Error creating shelf"
 msgstr "Erro ao criar estante"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 msgid "Create Magic Shelf"
 msgstr ""
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 msgid "Shelf name is required"
 msgstr "Nome da estante é obrigatório"
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "Erro ao atualizar estante"
 
-#: cps/web.py:1652
+#: cps/web.py
 msgid "Edit Magic Shelf"
 msgstr ""
 
-#: cps/web.py:1668
+#: cps/web.py
 msgid "Shelf not found"
 msgstr "Estante não encontrada"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr "Permissão negada"
 
-#: cps/web.py:1704
+#: cps/web.py
 msgid "Shelf duplicated successfully"
 msgstr "Estante duplicada com sucesso"
 
-#: cps/web.py:1710
+#: cps/web.py
 msgid "Error duplicating shelf"
 msgstr "Erro ao duplicar estante"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 msgid "Error deleting shelf"
 msgstr "Erro ao apagar estante"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 msgid "Error hiding shelf"
 msgstr "Erro ao ocultar estante"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 msgid "Error unhiding shelf"
 msgstr "Erro ao revelar estante"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Downloads"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Lista de formatos de arquivo"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Por favor, configure primeiro as configurações de correio SMTP..."
 
-#: cps/web.py:2400
+#: cps/web.py
 #, fuzzy
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 "Ops! Por favor, atualize seu perfil com um endereço de e-mail válido para o "
 "eReader."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "Livro enfileirado com sucesso para envio para %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Ops! Ocorreu um erro ao enviar este livro: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr "Nenhum endereço de email selecionado"
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr "Endereços de e-mail adicionais estão desativados para sua conta."
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "Livro adicionado à fila de envio para os endereços selecionados."
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr "Por favor espere um minuto para registrar o próximo usuário"
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Registre-se"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr ""
 "Erro de conexão ao limitador backend, por favor contacte o seu administrador!"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr ""
 "O servidor de E-Mail não está configurado, por favor contacte o seu "
 "administrador!"
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "Seu e-mail não tem permissão para registrar"
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "O e-mail de confirmação foi enviado para a sua conta de e-mail."
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
@@ -6337,7 +6239,7 @@ msgstr ""
 "Instancia do Calibre-Web não configurado, por favor contacte o seu "
 "administrador"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
@@ -6346,28 +6248,28 @@ msgstr ""
 "O servidor de E-Mail não está configurado, por favor contacte o seu "
 "administrador!"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr "Não é possível ativar a autenticação LDAP"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr "Por favor, espere um minuto para o próximo login"
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "Agora você está logado como: '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
@@ -6376,7 +6278,7 @@ msgstr ""
 "Bem-vindo! Sua conta foi criada automaticamente. Você está logado como: "
 "'%(nickname)s'"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
@@ -6385,13 +6287,13 @@ msgstr ""
 "Instancia do Calibre-Web não configurado, por favor contacte o seu "
 "administrador"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6400,706 +6302,676 @@ msgstr ""
 "Login de reserva como:'%(nickname)s', servidor LDAP não acessível ou usuário "
 "desconhecido"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr "Não foi possível efetuar o login: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 #, fuzzy
 msgid "Wrong Username or Password"
 msgstr "Nome de Usuário ou Senha incorretos"
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr "Nova Senha foi enviada para seu endereço de e-mail"
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr "Ocorreu um erro desconhecido. Por favor, tente novamente mais tarde."
 
-#: cps/web.py:2838
+#: cps/web.py
 #, fuzzy
 msgid "Please enter valid username to reset password"
 msgstr "Por favor, digite um nome de usuário válido para redefinir a senha"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, fuzzy, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "Agora você está logado como: '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 #, fuzzy
 msgid "Success! Profile Updated"
 msgstr "Perfil atualizado"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "Encontrada uma conta existente para este endereço de e-mail."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 #, fuzzy
 msgid "Invalid book ID."
 msgstr "ID de livro inválido."
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr "Plugin de Sincronização KOReader"
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr ""
 "Não foi encontrado nenhum arquivo gmail.json válido com informações do OAuth"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "%(book)s enviado para E-Reader"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "Enviar para E-Reader"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-send completed successfully"
 msgstr "{} usuário(s) removidos com sucesso"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-Send"
 msgstr "Enviar"
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr "Remover conteúdo do diretório temp"
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s enviado para E-Reader"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Calibre ebook-convert %(tool)s não encontrado"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "Formato %(format)s não encontrado no disco"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "O conversor de Ebook falhou com erro desconhecido"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Kepubify-converter falhou: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "Arquivo convertido não encontrado ou mais de um arquivo na pasta %(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre falhou com erro: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Ebook-converter falhou: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Reconectando banco de dados Calibre"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "Duplicados"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Selecionar Duplicatas"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Descompactando pacote de atualização"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Duplicados"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Ativar Hardcover sync"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "E-mail"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 #, fuzzy
 msgid "Backing up Metadata"
 msgstr "Fazendo cópia de segurança de metadados"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "Na Biblioteca"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "Gerado %(count)s miniaturas de capa"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "Miniatura da Capa"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "Gerado {0} miniaturas de série"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "Limpando o cache de miniaturas da capa"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "Livros organizados em Estantes"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Alterar senha"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Crie uma Estante"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "Configurações de Segurança"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Configurações"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "selecione uma opção"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "Adicionar à estante"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Público)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "Downloads por usuário"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Downloads por usuário"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 msgid "Date added, newest first"
 msgstr "Data de inclusão, mais novos primeiro"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 msgid "Date added, oldest first"
 msgstr "Data de inclusão, mais antigos primeiro"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 msgid "Author A → Z"
 msgstr "Autor A → Z"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 msgid "Author Z → A"
 msgstr "Autor Z → A"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 msgid "Published, newest first"
 msgstr "Publicado, mais novos primeiro"
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 msgid "Published, oldest first"
 msgstr "Publicado, mais antigos primeiro"
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr "Número na série, ascendente"
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr "Número na série, descendente"
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Adicionado à estante, mais recentes primeiro"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 msgid "Added to shelf, oldest first"
 msgstr "Adicionado à estante, mais antigos primeiro"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr "Usuárioss&nbsp;&nbsp;👤"
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "Enviar para o endereço de e-mail do E-Reader"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "Enviar para E-Reader"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Ver Livros"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Estante Pública"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr "Gerenciar Imagens de Perfil"
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "Importar usuários LDAP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Configurações do servidor de e-mail;&nbsp;📬"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "SMTP Hostname"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "Porta SMTP"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "Login SMTP"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Do E-mail"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Service"
 msgstr "Serviço de E-Mail"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail via Oauth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr "Configuração&nbsp;&nbsp;⚙️"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Diretório do Banco de Dados Calibre"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Nível de Log"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Porta externa"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Livros por página"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Envios"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Navegação Anônima"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Inscrição Pública"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Login remoto Magic Link"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Login de Proxy Reverso"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Nome do cabeçalho do Proxy Reverso"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr "Configurações do NextGen"
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Editar Configurações Básicas"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Editar Configuração de UI"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Editar Configuração do Banco de Dados do Calibre"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "Tarefas Agendadas&nbsp;&nbsp;⌛"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "Hora de início"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "Duração máxima das tarefas"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "Gerar miniaturas de capa de séries"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Reconectar à Biblioteca do Calibre"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr "Gerar Cópias de Segurança de Metadados"
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "Atualizar Cache de Capas de Miniaturas"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Setup KOReader Sync"
 msgstr "Configurar Sincrinização KOReader"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Run Hardcover Auto-Fetch"
 msgstr "Token da API Hardcover"
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Administração&nbsp;&nbsp;🚀"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Baixar Pacote de Depuração"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Ver Logs"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Reiniciar"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Desligar"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "Informação da Versão&nbsp;&nbsp;📜"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Versão"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Detalhes"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "Atualização falhou:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Canal de Atualização"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Versão atual"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Verificar Atualizações"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Aplicar Atualizações"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Tem a certeza que quer reiniciar?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Tem certeza que quer desligar?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Atualizando, por favor não recarregue esta página"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7107,451 +6979,428 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Livros nesta Biblioteca"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Enviando..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "Atualização falhou:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Erro de conexão"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Série: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "via"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "Na Biblioteca"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "reduzir"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Mais por"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Apagar Livro"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Apagar formatos:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Converter formato do livro:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Converter de:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "select an option"
 msgstr "selecione uma opção"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Converter para:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Converter livro"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Erro"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Formato de upload"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "ID da série"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Data de Publicação"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Tipo de identificador"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Valor do Identificador"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Remover"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Adicionar Identificador"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Buscar capa na URL (JPEG - Imagem será baixada e armazenada na base de dados)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Upload de Capa do Disco Local"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "Ativar Hardcover sync"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Ver Livro ao Salvar"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Buscar Metadados"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Palavra-chave"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "Pesquisar palavra-chave"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr "Chaves de API"
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Carregando..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Erro de busca!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr ""
 "Nenhum resultado(s) encontrado(s)! Por favor, tente outra palavra-chave."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "Este campo é obrigatório"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 #, fuzzy
 msgid " Exchange author & title"
 msgstr "Trocar autor e título"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "Selecionar todos"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr "Limpar seleções"
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Update Title Sort automatically  "
 msgstr "Atualizar Ordenação de Título automaticamente"
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Atualizar Ordenação de Autor automaticamente"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Digite o Título"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Digite a ordenação do título"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Ordenação de Título"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Digite a Ordenação de Author"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Ordenação de Autor"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Entrar Autores"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Entrar Categorias"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Entrar Série"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Entrar Idiomas"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Data de Publicação"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Entrar Editoras"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Entrar Comentários"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Comments"
 msgstr "Comentários"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 msgid "Archived?"
 msgstr "Arquivado?"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 msgid "Read?"
 msgstr "Lido?"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "Entrar "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Você realmente tem certeza?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "Livros com Título serão mesclados de:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "Em livro com título:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr "Os seguintes livros serão removidos:"
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr "Os seguintes livros serão arquivados:"
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr "Os seguintes livros serão desarquivados:"
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr "Os seguintes livros serão marcados como lidos:"
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr "Os seguintes livros serão marcados como não lidos:"
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Editar Metadados"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr "Edite os campos que queira mudar. Campos em branco serão ignorados:"
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "Crie uma Estante"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr "Por favor, selecione uma estante a qual o livro será adicionado:"
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr "-- Selecione a Estante --"
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Adicionar"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
@@ -7559,164 +7408,164 @@ msgstr ""
 "O servidor de E-Mail não está configurado, por favor contacte o seu "
 "administrador!"
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 #, fuzzy
 msgid "Message"
 msgstr "Mensagem"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Por favor, selecione pelo menos um endereço de e-mail"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Enviar para E-Reader"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Voltar"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Localização da Base de Dados Calibre (arquivo metadata.db)"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7732,13 +7581,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7749,7 +7598,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7768,11 +7617,11 @@ msgstr ""
 "      uma vez que você selecionou a opção <b>Separar Arquivos de Livros da "
 "Biblioteca</b>."
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr "Separar Funcionalidade da Biblioteca"
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
@@ -7782,32 +7631,32 @@ msgstr ""
 "code> deve ficar em <code>/calibre-library</code>, mas os seus arquivos de "
 "biblioteca podem estar onde desejar"
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Usar Google Drive?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Autenticar o Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Pasta Calibre no Google Drive"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "Metadata Watch Channel ID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Revogar"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Reconectar à Biblioteca do Calibre"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7817,96 +7666,96 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "Tem certeza que quer desligar?"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Reconectar à Biblioteca do Calibre"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr "Novo local do banco de dados inválido, insira um caminho válido"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Usar Autenticação padrão"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Usar Autenticação LDAP"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Usar OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Configuração do Servidor"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Porta do Servidor"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "Localização do certfile SSL (deixe vazio para Servidores não-SSL)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "Localização do Keyfile SSL (deixe vazio para Servidores não-SSL)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Canal de Atualização"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Estável"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Nightly"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "Hosts confiáveis (Separado por vírgula)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Configuração do Arquivo de Log"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr ""
 "Localização e nome do arquivo de log de acesso (access.log para nenhuma "
 "entrada)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Habilitar Log de Acesso"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr ""
 "Localização e nome do arquivo de log de acesso (access.log para nenhuma "
 "entrada)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "Configuração do Servidor"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 "Converta caracteres não ingleses no título e autor enquanto salva em disco"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
@@ -7914,41 +7763,41 @@ msgstr ""
 "Embutir Matedados ao arquivo Ebook ao Baixar/Converter/e-mail (precisa dos "
 "binários Calibre/Kepubify)"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Habilitar Uploads"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr ""
 "(Por favor, certifique-se de que os usuários também tenham direitos de "
 "upload)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Formatos de arquivo de upload permitidos"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Habilitar Navegação Anônima"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Habilitar Registro Público"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "Use e-mail como nome de usuário"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Habilitar Login Remoto do Magic Link"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7956,157 +7805,157 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Solicitações desconhecidas de proxy para a Kobo Store"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Porta externa do servidor (para chamadas API encaminhadas)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 "Sincronizar progresso de leitura do Kobo ao Hardcover (Requer chave API por "
 "usuário)"
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Usar Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Chave API Goodreads"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Hardcover Sync"
 msgstr "Ativar Hardcover sync"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr "Chave API Hardcover"
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "O Token expirou"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Chave API Goodreads"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8114,181 +7963,181 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Permitir a Autenticação por Proxy Reverso"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Tipo de Login"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "Nome ou endereço IP do servidor LDAP"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "Porta do servidor LDAP"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "Criptografia LDAP"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Caminho do CACertificate LDAP (Necessário apenas para autenticação de "
 "certificado de cliente)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Caminho do Certificado LDAP (Necessário apenas para autenticação de "
 "certificado de cliente)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Caminho do Keyfile LDAP (Necessário apenas para autenticação de certificado "
 "de cliente)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "Autenticação LDAP"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Simples"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "Nome de usuário do administrador LDAP"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "Senha de Administrador LDAP"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "Nome Distinto LDAP (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "Filtro de Objeto do Usuário LDAP"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "O Servidor LDAP é OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr ""
 "As seguintes configurações são necessárias para a mportação de Usuários"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "Filtro de objetos do grupo LDAP"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "Nome do Grupo LDAP"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "Campo de Membros do Grupo LDAP"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "LDAP Detecção de filtro de usuário membro LDAP"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "Autodetectar"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "Filtro Personalizado"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "Filtro de Utilizador Membro LDAP"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr "Provedor OAuth Genérico"
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr "URL de Metadados OAuth (para auto-discovery)"
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "Testar Metadados"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr "Deixe vazio abaixo para usar configuração manual"
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr "Usar URLs Endpoint Manuais (sobreescreve auto-discovery)"
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
@@ -8296,243 +8145,243 @@ msgstr ""
 "Selecione isto para configurar manualmente endpoints OAuth individuais ao "
 "invés de usar auto-discovery"
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "Configuração Manual de Endpoint"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr "URL Base de OAuth"
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr "Endpoint de Autorização"
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "Token do Endpoint"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr "UserInfo do Endpoind"
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "Testar Conexão"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "Escopos do OAuth"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr "Lista separada por espaços de escopos OAuth"
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Id"
 msgstr "ID do cliente OAuth de %(provider)s"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Secret"
 msgstr "Senha do cliente Oauth de %(provider)s"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "Configuração de Mapeamento de Campos"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "Campo Nome de usuário"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr "Campo JWT de onde extrair nome do usuário"
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "Campo de E-Mail"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr "Campo JWT de onde extrair email"
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "Grupo OAuth para Admin"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr "Grupo OAuth para Admin"
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Configuração padrão para novos usuários"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Permitir Downloads"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Permitir Visualizador de eBook"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Permitir Uploads"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Permitir Editar"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Permitir Apagar Livros"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Permitir Alterar Senha"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Permitir a Edição de Estantes Públicas"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr "Texto Botão Login"
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Obter credenciais OAuth de %(provider)s"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "ID do cliente OAuth de %(provider)s"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "Senha do cliente Oauth de %(provider)s"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Binários externos"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Path to Calibre Binaries"
 msgstr "Caminho para os binários Calibre"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Calibre E-Book Converter Settings"
 msgstr "Configurações do Calibre E-Book Converter"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Caminho para Kepubify E-Book Converter"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "Caminho para o binário UnRar"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Security Settings"
 msgstr "Configurações de Segurança"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8540,339 +8389,334 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr "Limit de tentativas de login falho"
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr "Configurar Backend para o Limiter"
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr "Opções para o Backend Limiter"
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr "Verifique se as extensõe dos arquivos são iguais ao conteúdo no Upload"
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Session protection"
 msgstr "Proteção de Seção"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr "Básica"
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr "Forte"
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "User Password policy"
 msgstr "Política de senha do usuário"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr "Tamanho mínimo de senha"
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr "Forçar número"
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr "Forçar caracteres minúsculos"
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr "Forçar caracteres maiúsculos"
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr "Forçar caracteres (necessário para caracters Chinês/Japonês/Coreano)"
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr "Forçar caracteres especiais"
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Configuração de Visualização"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Nº de Livros Aleatórios a Exibir"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr "Nº de Autores a Exibir Antes de Esconder (0=Desativar Esconder)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "Padrão"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "Tema caliBlur! Dark"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Expressão Regular para Ignorar Colunas"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Ligar Lido/Não Lido à coluna Calibre"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "Ligar Lido/Não Lido à coluna Calibre"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Exibir restrições com base na coluna Calibre"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Expressão regular para ordenação de Títulos"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Configuração de Visualização"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Custom CSS"
 msgstr "Filtro Personalizado"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Configuração padrão para novos usuários"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "Versão"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Usuário Admin"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "Página única"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "Idioma Padrão"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "Configuração padrão para novos usuários"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "Idioma Visível Padrão dos Livros"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "Visibilidade Padrão para Novos Usuários"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Visibilidade Padrão para Novos Usuários"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Mostrar Livros Aleatórios em Visualização de Detalhes"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Adicionar Tags Permitidas/Negadas"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Adicionar Valores Permitidos/Negados de Coluna Personalizada"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Upload"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "Executar Arquivamento"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "Baixar"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Início"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8881,14 +8725,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8896,96 +8740,95 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "Editar livros selecionados"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "{} usuário(s) removidos com sucesso"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "Erro enviando email"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "Nenhum resultado encontrado"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "Escolha um nome de usuário"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "Pesquisar na Biblioteca"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "Crie uma Estante"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "Editar livros selecionados"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "Erro enviando email"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Habilitar/Desabilitar Serviços do Calibre-Web Automated"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8993,11 +8836,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -9008,11 +8851,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -9022,163 +8865,163 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "Livros Arquivados"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr "Habilitar Serviço de Forçagem de Capas e Metadados Automático do CWA"
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9186,11 +9029,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9198,65 +9041,63 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "Metadados atualizados com sucesso"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identificadores"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "Capa"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 1-200 MB (default: 15)"
 msgstr "Intervalo: 5-120 minutos (padrão: 15)"
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr "Tempo Limite de Processamendo do Ingest"
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
@@ -9266,49 +9107,49 @@ msgstr ""
 "antes de desistir. Arquivos com tempo limite excedido são movidos para o "
 "diretório de falha de backup para investigação."
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr "Tempo Limite (minutos):"
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr "Intervalo: 5-120 minutos (padrão: 15)"
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Stale temp age (minutes):"
 msgstr "Tempo Limite (minutos):"
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr "Intervalo: 5-120 minutos (padrão: 15)"
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr "Intervalo: 5-120 minutos (padrão: 15)"
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9316,163 +9157,163 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Delay (minutes):"
 msgstr "Tempo Limite (minutos):"
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr "Intervalo: 5-120 minutos (padrão: 15)"
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Token da API Hardcover"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Token Required"
 msgstr "Token da API Hardcover"
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr "Intervalo: 5-120 minutos (padrão: 15)"
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr "Intervalo: 5-120 minutos (padrão: 15)"
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr "Intervalo: 5-120 minutos (padrão: 15)"
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "Configurações Web UI"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "Backup Automático das Configuração"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9480,36 +9321,35 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr "Habilitar Notificação de Contribuição de Tradução"
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -9519,22 +9359,22 @@ msgstr ""
 "quando estiver usando uma língua diferente do Inglês se a tradução para a "
 "língua escolhida não estiver completa."
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Sincronizar Estantes Selecionadas com Kobo"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Habilitar Fundos Borrados no Celular (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -9542,16 +9382,16 @@ msgstr ""
 "Quando ativo, o efeito de fundo borrado será renderizado em telas pequenas. "
 "Desabilite se você notar demora na animação ou rolagem de tela."
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Backup Automático das Configuração"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -9559,11 +9399,11 @@ msgstr ""
 "Quando habilitado, uma cópia de todos os arquivos importados serão gravados "
 "em <i>/config/processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -9571,21 +9411,21 @@ msgstr ""
 "Quando habilitado, os arquivos importados originais que passarem por "
 "conversão serão gravados em /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9598,11 +9438,11 @@ msgstr ""
 "subdiretórios em /config/processed_books organizados e para minimizar espaço "
 "em disco."
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -9612,33 +9452,33 @@ msgstr ""
 "convertidos para o formato escolhido aqui (exceto aqueles formatos "
 "selecionados na lista ignorar abaixo)"
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Escolha o Formato alvo:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9646,21 +9486,21 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "Calibre pode detectar Títulos de Livros Duplicados na Importação e "
 "dependendo de "
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr "automesclar"
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -9668,582 +9508,570 @@ msgstr ""
 "configuração. Pode ser configurada para apagar ambas instâncias ou de um "
 "livro duplicado ou deixar todas (padrão)."
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Descartar duplicata na importação, deixar cópia da biblioteca"
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr "Sobreescreve cópia da biblioteca com a nova versão sendo importada"
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Cria uma duplicata, deixando as duas cópias"
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Habilitar Registro Público"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Backup Automático das Configuração"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Manual only"
 msgstr "Manual?"
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Habilitar Notificações de Atualização do CWA"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Habilitar Registro Público"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Formato Original"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Testar Metadados"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Avaliação"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr "Clique para Ver Mais"
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Próximo"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Marcar como Não Lido"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Marcar como Lido"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "Marcar como Lido"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "Marcar como Não Lido"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 msgid "Added to favorites"
 msgstr "Adicionado aos favoritos"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 msgid "Removed from favorites"
 msgstr "Removido dos favoritos"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Desarquivar"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Arquivar"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 msgid "Restored from archive"
 msgstr "Desarquivado"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Hide from your library"
 msgstr "Ocultar de sua biblioteca"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr "Livro reexibido"
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "Configurações do Banco de Dados Atualizada"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "Avaliação Acima"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "Livro %(index)s de %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr "ID"
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr "UUID"
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 #, fuzzy
 msgid "File sizes"
 msgstr "Tamanhos das Fonte"
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Descrição:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "Selecione o endereço de e-mail do E-Reader"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 msgid "Choose email addresses:"
 msgstr "Escolha o endereço de email:"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "Selecione Todos"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Additional email addresses:"
 msgstr "Escolha o endereço de email:"
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Enter additional email addresses (separated by commas):"
 msgstr "Escolha o endereço de email:"
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "Selecionar formatos:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "Falha em criar caminho para a capa"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "Falha em criar caminho para a capa"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
@@ -10252,148 +10080,148 @@ msgstr ""
 "Livros com título e autores iguais. Inspeção visual recomendada para "
 "identificar duplicatas verdadeiras."
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Duplicados"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "Mostrar Livros Duplicados"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr "Selecionar Duplicatas"
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "Remover Seleções"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "Apagar livros selecionados"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Duplicados"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Auto-Resolve Duplicates"
 msgstr "Selecionar Duplicatas"
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "Anterior"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "Mesclar livros selecionados"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "Detalhes do Livro"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "editar metadados"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "Arquivar livros selecionados"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "Nenhum Livro Duplicado encontrado"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr "Sua biblioteca não tem livros com título e autor duplicados."
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
@@ -10401,128 +10229,128 @@ msgstr ""
 "Esta procura tenta encontrar livros com título E autor idênticos para evitar "
 "falso positivos "
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Selecionar formatos:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr "Esta ação não pode ser desfeita!"
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be permanently deleted:"
 msgstr "Este livro será apagado permanentemente do banco de dados"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "Livros Não Lidos"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "Os seguintes livros serão removidos:"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "Este livro será apagado permanentemente do banco de dados"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr "Sucesso"
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr "Livros duplicados selecionados foram apagados com Sucesso!"
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr "Um erro ocorreu ao processar seu pedido."
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "Conta do tipo Email"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Standard Email Account"
 msgstr "Use Conta de E-Mail Padrão"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Gmail Account"
 msgstr "Conta Gmail"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Setup Gmail Account"
 msgstr "Configurar Conta Gmail"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Revogar Acesso ao GMail"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "Senha SMTP"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Limite do Tamanho do Anexo"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Save and Send Test Email"
 msgstr "Salvar e enviar e-mail de teste"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Domínios Permitidos (Lista Branca)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Adicionar Domínio"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Digite o nome do domínio"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Domínios Negados (Lista Negra)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10530,119 +10358,113 @@ msgstr ""
 "Abra o arquivo .kobo/Kobo/Kobo eReader.conf em um editor de texto e adicione "
 "(ou edite):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Token Kobo:"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "Lista"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "Selecione Todos"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "Termo de busca:"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "Ver Livro ao Salvar"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "Selecione Todos"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "Carregando..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
@@ -10651,17 +10473,16 @@ msgstr ""
 "Tem certeza que quer alterar o perfil selecionado para o(s) usuário(s) "
 "selecionado(s)?"
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "Falha em criar caminho para a capa"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
@@ -10669,27 +10490,25 @@ msgstr ""
 "Tem certeza que quer alterar o perfil selecionado para o(s) usuário(s) "
 "selecionado(s)?"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "Selecione Todos"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "Falha em criar caminho para a capa"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
@@ -10698,422 +10517,421 @@ msgstr ""
 "Instancia do Calibre-Web não configurado, por favor contacte o seu "
 "administrador"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Criar Issue"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Voltar para Início"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "Deslogar"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "Editar uma estante"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show this shelf in your sidebar"
 msgstr "Sincronizar esta Estante com o Dispositivo Kobo"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "Mostrar Tudo"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "Estante Pública"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Adicionar à estante"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 #, fuzzy
 msgid "KOReader Sync is disabled."
 msgstr "Plugin de Sincronização KOReader"
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Início"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Alternar Navegação"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Pesquisar na Biblioteca"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Catálogo de e-books Calibre-Web Automated"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Sair"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "Configurações"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "Atualizar Biblioteca"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Não há informações de lançamento disponíveis"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Catálogo de e-books Calibre-Web Automated"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr "Veja Log de Mudanças"
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Duplicados"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr "Contribuir aqui!"
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Por favor, não atualize a página"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Crie uma Estante"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Anterior"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Detalhes do Livro"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Esta ação não pode ser desfeita!"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Apagar livros selecionados"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 msgid "Formats:"
 msgstr "Formatos:"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Apagar formatos:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Duplicar Livro"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nenhum Livro Duplicado encontrado"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "Selecionar Duplicatas"
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Dimensionar para Melhor"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "Para:"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "Configuração"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Adicionar à estante"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Marcar livros selecionados como lidos"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Marcar como Não Lido"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Apagar Livro"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Apagar Livro"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Crie uma Estante"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Erro de conexão"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr "Filtrar por iniciais"
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "Grade"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "Senha SMTP"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Lembre-se de mim"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Esqueceu a senha?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Entre com o Magic Link"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 #, fuzzy
 msgid "Log in with SSO"
 msgstr "Entre com o Single-Sign-On"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Mostrar Log Calibre-Web: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Calibre-Web Log: "
 msgstr "Mostrar Log Calibre-Web: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Saída do fluxo, não pode ser exibida"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Mostrar Log de Acesso: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Baixar Log Calibre-Web"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "Baixar Log de Acesso"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "Compartilhar com Todos"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Selecione Tags Permitidas/Negadas"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Selecione Valores Permitidos/Negadaos da Coluna Personalizada"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Selecione Tags de usuário Permitidas/Negadas"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr ""
 "Selecione Valores de Coluna Personalizada Permitidos/Negados do Usuário"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Digite a tag"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Adicionar Restrição de Visualização"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "Este formato de livro será apagado permanentemente do banco de dados"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Este livro será apagado permanentemente do banco de dados"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "e disco rígido"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Nota importante Kobo: os livros apagados permanecerão em qualquer "
 "dispositivo Kobo emparelhado."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11121,579 +10939,575 @@ msgstr ""
 "Os livros devem primeiro ser arquivados e o dispositivo deve ser "
 "sincronizado antes que um livro possa ser apagado com segurança."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Escolha a Localização do Arquivo"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "tipo"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "nome"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "tamanho"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "Diretório Acima"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "Ok"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Catálogo de e-books Calibre-Web Automated"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "leitor de epub"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "Ações"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "Preto"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "Tamanhos das Fonte"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Página seguinte"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr "Fonte"
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 #, fuzzy
 msgid "Default"
 msgstr "Padrão"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr "Yahei"
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr "SimSun"
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 #, fuzzy
 msgid "KaiTi"
 msgstr "KaiTi"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 #, fuzzy
 msgid "Arial"
 msgstr "Arial"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 #, fuzzy
 msgid "Spread"
 msgstr "Spread"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 #, fuzzy
 msgid "Two columns"
 msgstr "Duas Colunas"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 #, fuzzy
 msgid "One column"
 msgstr "Uma Coluna"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Refluir o texto quando as barras laterais estiverem abertas."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Leitor de Quadrinhos"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Atalhos de Teclado"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Página Anterior"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Página seguinte"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page Display"
 msgstr "Página única"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr "Página Esticada"
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Dimensionar para Melhor"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Dimensionar para Largura"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Dimensionar para Altura"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Dimensionar para a Nativo"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Girar para direita"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Girar para esqueda"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Inverter Imagem"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "Mostrar"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page"
 msgstr "Página única"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr "Página Esticada"
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Dimensionar"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Melhor"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Largura"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Altura"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Nativo"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Rodar"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Inverter"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Horizontal"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Vertical"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Direction"
 msgstr "Direção"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Esquerda para a direita"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Direita para a esquerda"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Reset to Top"
 msgstr "Voltar para Início"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Remember Position"
 msgstr "Lembrar Posição"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "Barra de Rolagem"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "Mostrar"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "leitor de DJVU"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "Leitor de PDF"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "Leitor de TXT"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Registrar Nova Conta"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Escolha um nome de usuário"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Seu endereço de e-mail"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Magic Link - Autorizar Novo Dispositivo"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "Em outro dispositivo, faça login e visite:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr ""
 "Uma vez verificado, você será automaticamente conectado a este dispositivo."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Este link de verificação irá expirar em 10 minutos."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "Gerar miniaturas de capa de Série"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Nenhum resultado encontrado"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Termo de busca:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Resultados para:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Data de Publicação de"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Data de Publicação Até"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr "Vazio"
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Excluir Tags"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Excluir Série"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "Excluir Estante"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Excluir idiomas"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Extensões"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Excluir extensões"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Avaliação Acima"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Avaliação Abaixo"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "De:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "Para:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Apagar esta estante"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "Editar Propriedades da Estante"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Livro Escondido"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "Organizar os livros manualmente"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "Desabilitar Alterar Ordem"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "Habilitar Alterar Ordem"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Editar livros selecionados"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Conta"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Token não encontrado"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Apagar esta estante"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Adicionar à estante"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Pesquisar na Biblioteca"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Pesquisar na Biblioteca"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Compartilhar com Todos"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "Sincronizar esta Estante com o Dispositivo Kobo"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Usuário não encontrado"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Livro Escondido"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Estatísticas da Biblioteca"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Livros nesta Biblioteca"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Autores nesta Biblioteca"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Categorias nesta Biblioteca"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Séries nesta Biblioteca"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Estatísticas do Sistema"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "Programa"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Versão Instalada"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Tempo de execução"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Actions"
 msgstr "Ações"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "Rodar"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 "Esta tarefa será cancelada. Qualquer progresso feito por esta tarefa será "
 "salvo."
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
@@ -11701,396 +11515,396 @@ msgstr ""
 "Se esta for uma tarefa agendada, ela será executada novamente durante o "
 "próximo horário agendado."
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "Livros duplicados selecionados foram apagados com Sucesso!"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Catálogo de e-books Calibre-Web Automated"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "Seu endereço de e-mail"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "Configurações"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Redefinir senha do usuário"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "Configuração do Servidor"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "Selecione o endereço de e-mail do E-Reader"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "Entrar Idiomas"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Idioma dos Livros"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "Nenhum Idioma do Livro Válido Fornecido"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "Configurações do OAuth"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Vincular"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Desvincular"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Hardcover API Token"
 msgstr "Token da API Hardcover"
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Token de Sincronização Kobo"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Criar/Ver"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "Forçar sincronização completa Kobo"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "Sincronizar apenas livros em estantes selecionadas com Kobo"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "Sincronizar apenas livros em estantes selecionadas com Kobo"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "Configurações de Segurança"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Adicionar valores Permitidos/Negados da coluna personalizada"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Magic Shelves Order"
 msgstr "Sincronizar Estantes Selecionadas com Kobo"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr "Nome (A-Z)"
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr "Nome (Z-A)"
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr "Contagem de livros (maior para menor)"
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr "Contagem de livros (menor para maior)"
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "Livros recentemente adicionados"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "Editar Estantes Públicas"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Apagar Usuário"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12098,156 +11912,156 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Alterar senha"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 msgid "Create app password"
 msgstr "Criar senha de aplicativo"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr "Rótulo"
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 msgid "Created"
 msgstr "Criado"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr "Último uso"
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr "Nunca"
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr "Descartar esta senha de aplicativo?"
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Gerar URL de Autenticação Kobo"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr "Visível"
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Selecione..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Remover Seleções"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "Editar Usuário"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "Escolha um nome de usuário"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Email"
 msgstr "Entre com o E-mail"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email"
 msgstr "Entre com o endereço de e-mail do E-Reader"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email"
 msgstr "E-mail do E-Reader"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "Entre com o endereço de e-mail do E-Reader"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "E-mail do E-Reader"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Idioma"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "Idiomas dos Livros Visíveis"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "Editar Tags Permitidas"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Tags Permitidas"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Editar Tags Não Permitidas"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Tags Não Permitidas"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "Editar Valores de Coluna Permitidos"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "Valores de Coluna Permitidos"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "Editar Valores de Coluna Não Permitidos"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "Valores de Coluna Não Permitidos"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "Alterar senha"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "Editar Estantes Públicas"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "Sincronizar Estantes Selecionadas com Kobo"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "Sincronizar Estantes Selecionadas com Kobo"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Read/Unread Section"
 msgstr "Mostrar seção de lidos/não lidos"

--- a/cps/translations/ru/LC_MESSAGES/messages.po
+++ b/cps/translations/ru/LC_MESSAGES/messages.po
@@ -22,38 +22,38 @@ msgstr ""
 "Generated-By: Babel 2.13.1\n"
 "X-Generator: Poedit 3.9\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Статистика"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr "База данных Calibre недоступна. Пожалуйста, укажите путь к библиотеке."
 
-#: cps/admin.py:208
+#: cps/admin.py
 msgid "Server restarted, please reload page."
 msgstr "Сервер перезапущен, пожалуйста, перезагрузите страницу."
 
-#: cps/admin.py:210
+#: cps/admin.py
 msgid "Performing Server shutdown, please close window."
 msgstr "Выполняется остановка сервера, пожалуйста, закройте окно."
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "Успех! Подключение к базе данных восстановлено"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Неизвестная команда"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 "Успех! Книги поставлены в очередь резервного копирования метаданных, "
 "проверьте результаты в Заданиях"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
@@ -61,7 +61,7 @@ msgstr ""
 "Ошибка: синхронизация с Hardcover отключена. Включите её в основных "
 "настройках или с помощью переменной HARDCOVER_SYNC_ENABLED."
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
@@ -69,48 +69,48 @@ msgstr ""
 "Ошибка: Токен Hardcover недоступен. Задайте переменную окружения "
 "HARDCOVER_TOKEN или укажите его в Основных настройках."
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 "Успех! Запущено задание автопоиска метаданных сервиса Hardcover. Проверьте "
 "панель заданий."
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 "Ошибка запуска задачи автоматического получения данных из Hardcover: "
 "%(error)s"
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr "Проверить совпадения метаданных из сервиса Hardcover"
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr "Ошибка загрузки очереди проверки: %(error)s"
 
-#: cps/admin.py:414
+#: cps/admin.py
 msgid "Hardcover ID applied successfully"
 msgstr "ID Hardcover успешно применён"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr "Совпадение %(action)s"
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr "Нет ожидающих совпадений для отклонения"
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr "Отклонено %(count)s совпадение(ий)"
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
@@ -118,116 +118,114 @@ msgstr ""
 "Запущено обновление кэша миниатюр для {} книг(и). Это может занять несколько "
 "минут."
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr "Нет книг с обложками для обработки."
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr "Не удалось запустить обновление миниатюр: {}"
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Панель администратора"
 
-#: cps/admin.py:653
+#: cps/admin.py
 msgid "Hardcover token expires"
 msgstr "Срок действия токена Hardcover истекает"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Основные настройки"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Настройка интерфейса"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr "Пользовательский столбец №%(column)d отсутствует в базе данных Calibre"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Редактировать пользователей"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Все"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Пользователь не найден"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "Успешно удалено пользователей: {}"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Показать всё"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Некорректный запрос"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "Имя гостевого пользователя нельзя изменить"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "Гостевому пользователю недоступна эта роль"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr "Не осталось администраторов, невозможно удалить роль администратора"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "Значение должно быть true или false"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Неверная роль"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "Гостевому пользователю недоступно это представление"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "Неверное представление"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 "Язык гостевого пользователя определяется автоматически и не может быть "
 "изменён"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Не указан допустимый язык/регион"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Не указан допустимый язык книг"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Параметр не найден"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "База данных настроек недоступна для записи"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
@@ -236,53 +234,53 @@ msgstr ""
 "существующей библиотеки не удалось — книги могут сохранять свой прежний "
 "порядок до тех пор, пока вы не повторите попытку или не отредактируете их."
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Неверный столбец чтения"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Недопустимый столбец ограничений"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr "Обновлена ​​конфигурация Calibre-Web NextGen"
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Вы действительно хотите удалить токен Kobo?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "Вы действительно хотите удалить этот домен?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "Вы действительно хотите удалить этого пользователя?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Вы уверены, что хотите удалить эту полку?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr ""
 "Вы уверены, что хотите изменить языковые настройки выбранных пользователей?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "Вы уверены, что хотите изменить видимые языки книг для выбранных "
 "пользователей?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 "Вы уверены, что хотите изменить выбранную роль для выбранных пользователей?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
@@ -290,7 +288,7 @@ msgstr ""
 "Вы уверены, что хотите изменить выбранные ограничения для выбранных "
 "пользователей?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -298,25 +296,25 @@ msgstr ""
 "Вы уверены, что хотите изменить ограничения видимости для выбранных "
 "пользователей?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "Вы уверены, что хотите изменить поведение синхронизации полок для выбранных "
 "пользователей?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
 msgstr ""
 "Вы уверены, что хотите изменить доступность полок в OPDS для выбранных "
 "пользователей?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Вы уверены, что хотите изменить расположение библиотеки Calibre?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
@@ -324,7 +322,7 @@ msgstr ""
 "Calibre-Web NextGen выполнит поиск обновлённых обложек и обновит их "
 "миниатюры. Это может занять некоторое время. Продолжить?"
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
@@ -333,29 +331,25 @@ msgstr ""
 "NextGen, чтобы принудительно выполнить полную синхронизацию с вашим "
 "устройством Kobo Reader?"
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Запретить"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Разрешить"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "Удалено записей синхронизации: {}"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, python-brace-format
 msgid "Book {} not found"
 msgstr "Книга {} не найдена"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
@@ -364,7 +358,7 @@ msgstr ""
 "Состояние синхронизации для книги {0} (пользователь {1}) очищено; устройство "
 "получит книгу повторно при следующей синхронизации"
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
@@ -374,74 +368,73 @@ msgstr ""
 "значение last_modified было увеличено, поэтому устройство получит её при "
 "следующей синхронизации"
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Тег не найден"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Неверное действие"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json не настроен для веб-приложения"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "Неверное расположение файла журнала, укажите правильный путь"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "Неверное расположение файла журнала доступа, укажите правильный путь"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 "Пожалуйста, укажите поставщика LDAP, порт, DN и идентификатор пользователя"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Пожалуйста, укажите учётную запись и пароль службы LDAP"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "Пожалуйста, укажите учётную запись службы LDAP"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Фильтр объектов группы LDAP должен содержать один идентификатор формата "
 "\"%s\""
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "Фильтр объектов группы LDAP имеет несогласованные скобки"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Фильтр объектов пользователей LDAP должен содержать один идентификатор "
 "формата \"%s\""
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "Фильтр объектов пользователей LDAP имеет несогласованные скобки"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Фильтр пользователей-участников LDAP должен содержать один идентификатор "
 "формата \"%s\""
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "Фильтр пользователей-участников LDAP имеет несогласованные скобки"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -449,29 +442,24 @@ msgstr ""
 "Неверное расположение CA-сертификата, сертификата или ключа LDAP, укажите "
 "правильный путь"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Добавить нового пользователя"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Редактировать настройки почтового сервера"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "Успех! Учётная запись Gmail подтверждена."
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Ошибка базы данных: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -479,52 +467,52 @@ msgstr ""
 "Тестовое письмо поставлено в очередь отправки на %(email)s, проверьте "
 "результат в Заданиях"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Произошла ошибка при отправке тестового письма: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Пожалуйста, сначала настройте адрес электронной почты..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Настройки почтового сервера обновлены"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 msgid "Email Your Users"
 msgstr "Отправить email пользователям"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr ""
 "Пожалуйста, сначала настройте почтовый сервер в разделе «Редактирование "
 "настроек почтового сервера»."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr "Пожалуйста, введите тему для email-рассылки."
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr "Пожалуйста, введите текст сообщения для email-рассылки."
 
-#: cps/admin.py:2060
+#: cps/admin.py
 msgid "Please set an email address on your own account first..."
 msgstr ""
 "Пожалуйста, сначала укажите email-адрес в вашем собственном аккаунте..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 msgid "Please select at least one recipient."
 msgstr "Пожалуйста, выберите хотя бы одного получателя."
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr "Нет действительных получателей - ничего не было отправлено."
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -532,7 +520,7 @@ msgstr ""
 "Тестовое письмо с объявлением поставлено в очередь на отправку на %(email)s, "
 "проверьте результат в Заданиях."
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -541,159 +529,157 @@ msgstr ""
 "Информационное письмо добавлено в очередь для %(num)s получателей - "
 "проверьте Задания для контроля доставки."
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 "%(num)s адресов пропущено, так как они недействительны или дублируются."
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "Редактировать настройки запланированных заданий"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "Указано неверное время начала задания"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "Указана неверная продолжительность задания"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "Настройки запланированных заданий обновлены"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Неизвестная ошибка. Пожалуйста, попробуйте позже."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 msgid "title"
 msgstr "название"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Редактировать пользователя %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Успех! Пароль пользователя %(user)s сброшен"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Пожалуйста, настройте параметры SMTP."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Просмотр журнала"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Запрос пакета обновления"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Скачивание пакета обновления"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Распаковка пакета обновления"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Замена файлов"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Подключения к базе данных закрыты"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Остановка сервера"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Обновление завершено, нажмите OK и перезагрузите страницу"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Сбой обновления:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "Ошибка HTTP"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Ошибка подключения"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Тайм-аут при установлении соединения"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Общая ошибка"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr "Не удалось сохранить файл обновления во временной директории"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "Не удалось заменить файлы во время обновления"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "Не удалось извлечь хотя бы одного пользователя LDAP"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Не удалось создать хотя бы одного пользователя LDAP"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Ошибка: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Ошибка: LDAP-сервер не вернул пользователей"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "По крайней мере один пользователь LDAP не найден в базе данных"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "Пользователь {} успешно импортирован"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr "Неверный путь к книгам"
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "Неверное расположение базы данных, укажите правильный путь"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "База данных недоступна для записи"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "Неверное расположение файла ключа, укажите правильный путь"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr "Неверное расположение файла сертификата, укажите правильный путь"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
@@ -701,13 +687,13 @@ msgstr ""
 "Автоматическое создание пользователей невозможно включить без активации "
 "аутентификации через обратный прокси-сервер"
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 "Для автоматического создания пользователей требуется допустимое имя "
 "заголовка обратного прокси-сервера"
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
@@ -715,77 +701,77 @@ msgstr ""
 "Неверный формат хоста переадресации OAuth. Пожалуйста, укажите полный URL-"
 "адрес с протоколом (например, https://your-domain.com)."
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 "В поле «Хост перенаправления OAuth» не следует указывать путь. Используйте "
-"только базовый URL (например, [https://your-domain.com](https://your-domain."
-"com))"
+"только базовый URL (например, [https://your-domain.com](https://your-"
+"domain.com))"
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr "Длина пароля должна быть от 1 до 40 символов"
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "Настройки базы данных обновлены"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "Конфигурация базы данных"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Пожалуйста, заполните все поля."
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "Электронная почта не из разрешённого домена"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Добавить нового пользователя"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Пользователь '%(user)s' создан"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "Учётная запись с таким email или именем уже существует."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Пользователь '%(nick)s' удалён"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "Нельзя удалить гостевого пользователя"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "Не осталось администраторов, невозможно удалить пользователя"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "Email не может быть пустым и должен быть действительным адресом"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Пользователь '%(nick)s' обновлён"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
@@ -793,7 +779,7 @@ msgstr ""
 "Соединение установлено успешно! Endpoint обнаружения OIDC доступен."
 "%(endpoints)s"
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
@@ -801,12 +787,12 @@ msgstr ""
 "Ошибка подключения: endpoint обнаружения OIDC не найден (404). Проверьте "
 "правильность базового URL-адреса."
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr "Ошибка подключения: сервер вернул код состояния %(code)s"
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
@@ -814,14 +800,14 @@ msgstr ""
 "Ошибка подключения: не удалось подключиться к серверу. Проверьте URL-адрес и "
 "сетевое соединение."
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 "Ошибка подключения: время ожидания запроса истекло. Сервер может работать "
 "медленно или быть недоступен."
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
@@ -829,12 +815,12 @@ msgstr ""
 "Ошибка подключения: сервер вернул неверный JSON. Возможно, это не endpoint "
 "OIDC."
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Ошибка подключения: %(error)s"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
@@ -843,29 +829,29 @@ msgstr ""
 "В метаданных отсутствуют обязательные поля OIDC: %(fields)s. Возможно, это "
 "недействительный эндпоинт метаданных OIDC."
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr "URL метаданных действителен! Найдено %(count)s эндпоинтов OAuth."
 
-#: cps/admin.py:3322
+#: cps/admin.py
 msgid " User info endpoint is available."
 msgstr " Endpoint с информацией о пользователе доступен."
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 " Примечание: Endpoint с информацией о пользователе не найден - это может "
 "вызвать проблемы с аутентификацией."
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 "URL метаданных не найден (ошибка 404). Пожалуйста, проверьте правильность "
 "URL."
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
@@ -873,48 +859,48 @@ msgstr ""
 "Ошибка подключения: не удалось подключиться к URL-адресу метаданных. "
 "Проверьте URL-адрес и сетевое соединение."
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr "Ошибка подключения: время ожидания запроса истекло."
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr "Ошибка подключения: неверный JSON в ответе."
 
-#: cps/admin.py:3340
+#: cps/admin.py
 msgid "An unknown error occurred."
 msgstr "Произошла неизвестная ошибка."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 msgid "Restore already in progress."
 msgstr "Восстановление уже выполняется."
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr "Ошибка восстановления: путь библитеки Calibre не сконфигурирован."
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr "Ошибка восстановления: metadata.db не найдена в %(path)s"
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr "Ошибка восстановления: app.db не найден в %(path)s"
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Ошибка восстановления: %(err)s"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 "Восстановление выполнено успешно, за исключением очистки app.db. Смотрите "
 "подробнее в логах."
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
@@ -923,477 +909,467 @@ msgstr ""
 "Восстановаление выполнено. Бекапы и логи восстановления сохранены в %(dir)s. "
 "Информация о ссылках на книги сброшена."
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr "Импортировать аннотации Kobo"
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 msgid "No file uploaded."
 msgstr "Файл не загружен."
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr "Размер файла превышает %(max)d МБ."
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr "Загруженный файл не является базой данных SQLite."
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr "Аннотации: %(title)s"
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr "Чешский"
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr "Немецкий"
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr "Греческий"
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr "Испанский"
 
-#: cps/constants.py:265
+#: cps/constants.py
 msgid "Finnish"
 msgstr "Финский"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr "Французский"
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr "Галисийский"
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr "Венгерский"
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr "Индонезийский"
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr "Итальянский"
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr "Японский"
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr "Кхмерский"
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr "Корейский"
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr "Нидерландский"
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr "Норвежский"
 
-#: cps/constants.py:276
+#: cps/constants.py
 msgid "Polish"
 msgstr "Польский"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr "Португальский"
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr "Португальский (Бразилия)"
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr "Русский"
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr "Словацкий"
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr "Словенский"
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr "Шведский"
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr "Турецкий"
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr "Украинский"
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr "Вьетнамский"
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr "Китайский (упрощённый, Китай)"
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr "Китайский (традиционный, Тайвань)"
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "не установлено"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Отсутствуют права на выполнение"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr "Вернуться к редактированию метаданных"
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr "Вернуться к книге"
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, python-format
 msgid "Change cover — %(title)s"
 msgstr "Изменить обложку - %(title)s"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr "Обложка этой книги заблокирована. Сначала разблокируйте её."
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr "Укажите URL-адрес обложки."
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr "У этой книги нет встроенной обложки, которую мы могли бы извлечь."
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 msgid "Unknown cover source."
 msgstr "Неизвестный источник обложки."
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr "Не удалось сохранить состояние блокировки."
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 "Предварительный просмотр возможен только для URL-адресов, начинающихся с "
 "http(s)."
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr "Не удалось отобразить предварительный просмотр для eReader."
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 "Не удалось загрузить исходное изображение для предварительного просмотра."
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr "Ошибка сохранения обложки."
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr "Переключение темы временно отключено до версии 5.0.0"
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 "Обновление библиотеки 🔄 Проверка пропущенных книг, пожалуйста, подождите..."
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 "Неверное cron-выражение для сканирования дубликатов. Изменения не сохранены."
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr "Пользовательские настройки Calibre-Web NextGen"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr "Отметка времени"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Book ID"
 msgstr "ID книги"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Название книги"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Book Author"
 msgstr "Автор книги"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr "Тип триггера"
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Filepath"
 msgstr "Путь к файлу"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Filename"
 msgstr "Имя файла"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr "Вручную?"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr "Кол-во исправлений"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr "Создана резервная копия оригинала?"
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr "Применённые исправления"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr "Исходный формат"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "End Format"
 msgstr "Конечный формат"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 msgid "Unknown User"
 msgstr "Неизвестный пользователь"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr "Статистика и активность Calibre-Web NextGen"
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr "Calibre-Web NextGen - Полная история применения метаданных"
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr "Calibre-Web NextGen - Полная история применения метаданных (с путями)"
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr "Calibre-Web NextGen - Полная история импорта"
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr "Calibre-Web NextGen - Полная история конвертации"
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 "Calibre-Web NextGen - Полная история исправлений EPUB (без путей и "
 "исправлений)"
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 "Calibre-Web NextGen - Полная история исправлений EPUB (с путями и "
 "исправлениями)"
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr "✅ Все службы мониторинга работают как положено! 👍"
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 "🔴 Служба приема данных запущена, но система обнаружения изменений "
 "метаданных — нет"
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 "🔴 Система обнаружения изменений метаданных запущена, но служба приема "
 "данных — нет"
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 "⛔ Ни служба приема данных, ни средство обнаружения изменений метаданных не "
 "запущены"
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr "Произошла ошибка"
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr "Calibre-Web NextGen - Конвертация библиотеки"
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr "Calibre-Web NextGen - Сервис EPUB Fixer"
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 "Инструмент исправления EPUB для одиночных книг не поддерживается при работе "
 "с библиотеками Google Drive."
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 msgid "Invalid book selection."
 msgstr "Неверный выбор книги."
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr "Книга не найдена."
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 msgid "Selected book has no EPUB format."
 msgstr "У выбранной книги нет формата EPUB."
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 msgid "EPUB file not found on disk."
 msgstr "Файл EPUB не найден на диске."
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 msgid "EPUB Fixer started for selected book."
 msgstr "EPUB Fixer запущен для выбранной книги."
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr "Не удалось запустить EPUB Fixer для выбранной книги."
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr "Вы должны быть администратором для доступа к этой странице."
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr "Необходимы как имя пользователя, так и данные изображения."
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 "Неверный формат данных изображения. Файл должен быть корректным изображением."
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr "Неправильный формат. Разрешается загружать только PNG и JPEG."
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 "Изображение слишком большое. Пожалуйста, используйте изображение размером "
 "менее 500 КБ."
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr "Неверные данные изображения Base64."
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 msgid "Invalid image data format."
 msgstr "Неверный формат данных изображения."
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr "Ошибка проверки изображения."
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr "Изображение профиля успешно обновлено."
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 "Система управления профильными изображениями Calibre-Web NextGen (в "
 "разработке)"
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Нет"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 msgid "Duplicate Books"
 msgstr "Дубликаты книг"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr "Группа дубликатов уже скрыта"
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 msgid "Duplicate group dismissed"
 msgstr "Группа дубликатов скрыта"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 msgid "Duplicate group restored"
 msgstr "Группа дубликатов восстановлена"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr "Группа дубликатов не скрыта"
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 msgid "Duplicate scan queued"
 msgstr "Сканирование дубликатов в очереди"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr "Сканирование дубликатов завершено (резервный режим)"
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 msgid "Invalid resolution strategy"
 msgstr "Неверная стратегия обработки"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
@@ -1401,92 +1377,89 @@ msgstr ""
 "Папка Ingest недоступна для записи. Проверьте права доступа к тому /cwa-book-"
 "ingest."
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr "Отсутствует или неверный идентификатор книги для загрузки формата"
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr "Невозможно загрузить формат: Книга больше не существует в библиотеке"
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Загрузка завершена, обработка, пожалуйста, подождите..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 msgid "Failed to queue upload for processing"
 msgstr "Не удалось поставить загрузку в очередь на обработку"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Отсутствует исходный или конечный формат для конвертации"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "Книга поставлена в очередь для конвертации в %(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Произошла ошибка при конвертации книги: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "Данный тип файлов не разрешён для загрузки на сервер"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr "Расширение файла '%(ext)s' не разрешено для загрузки на сервер"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "Загружаемый файл должен иметь расширение"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr "Выбранная книга недоступна. Файл не существует или недоступен"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "У пользователя нет прав для загрузки обложки"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 "Обложка заблокирована. Сначала разблокируйте её на странице выбора обложек."
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 "Идентификаторы нечувствительны к регистру, старый идентификатор будет "
 "перезаписан"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "Язык '%(langname)s' не поддерживается"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Метаданные успешно обновлены"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "Ошибка редактирования книги: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1494,76 +1467,76 @@ msgstr ""
 "Загружаемая книга, вероятно, уже существует в библиотеке. Рассмотрите "
 "возможность её изменения перед загрузкой новой: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "Не удалось сохранить файл %(filename)s во временную директорию"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Не удалось переместить файл обложки %(file)s: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Формат книги успешно удалён"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Книга успешно удалена"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "У вас недостаточно прав для удаления книг"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "редактировать метаданные"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr ""
 "Индекс серии: %(seriesindex)s не является допустимым числом, пропускаем"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr "У пользователя нет прав для загрузки дополнительных форматов файлов"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Не удалось создать путь %(path)s (Доступ запрещён)."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Не удалось сохранить файл %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Формат файла %(ext)s добавлен к %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 msgid "Book not found"
 msgstr "Книга не найдена"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr "У книги нет файлов на диске для перезагрузки"
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "Файл книги не найден на диске: %(path)s"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr "Не удалось извлечь метаданные из файла %(format)s: %(err)s"
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
@@ -1571,21 +1544,21 @@ msgstr ""
 "Не удалось переименовать папку книги в соответствии с обновленными "
 "метаданными: %(err)s"
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr "Не удалось сохранить перезагруженные метаданные: %(err)s"
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr "Перезагружено %(n)d поле(й) из %(fmt)s на диске"
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr "Метаданные на диске совпадают с текущими - поля не обновлены"
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1593,7 +1566,7 @@ msgstr ""
 "Настройка Google Drive не завершена, попробуйте деактивировать и снова "
 "активировать Google Drive"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1601,99 +1574,98 @@ msgstr ""
 "Домен обратного вызова не подтверждён, выполните шаги для подтверждения "
 "домена в Google Developer Console"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr "Это письмо было отправлено через Calibre-Web NextGen."
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr "Информационное письмо для %(email)s"
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "Формат %(format)s не найден для книги с ID: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "Формат %(format)s не найден на Google Drive: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "Формат %(format)s не найден: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "Отправить на eReader"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "Превышено время ожидания конвертации для книги с ID: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "Ошибка конвертации для книги с ID: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr "Тестовое письмо Calibre-Web NextGen"
 
-#: cps/helper.py:387
+#: cps/helper.py
 msgid "Test Email"
 msgstr "Тестовое письмо"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr "Начать работу с Calibre-Web NextGen"
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Регистрационное письмо для пользователя: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Конвертировать %(orig)s в %(format)s и отправить на eReader"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Отправить %(format)s на eReader"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, python-format
 msgid "%(book)s send to eReader"
 msgstr "Книга «%(book)s» отправлена на eReader"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "Не удалось прочитать запрошенный файл. Возможно, недостаточно прав?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "Не удалось установить статус прочтения: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
 msgstr ""
 "Не удалось удалить папку книги %(id)s, путь содержит подпапки: %(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "Не удалось удалить книгу %(id)s: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1702,70 +1674,70 @@ msgstr ""
 "Удаление книги %(id)s только из базы данных, путь книги в базе данных "
 "недействителен: %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Переименование названия с '%(src)s' на '%(dest)s' не удалось: %(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Файл %(file)s не найден на Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Переименование заголовка с '%(src)s' на '%(dest)s' не удалось: %(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Путь книги %(path)s не найден на Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr "Найдена существующая учётная запись для этого адреса электронной почты"
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Это имя пользователя уже занято"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr "Неверный формат адреса электронной почты"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr "Пароль не соответствует правилам валидации"
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 "Модуль Python 'advocate' не установлен, но требуется для загрузки обложек"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Ошибка загрузки обложки"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr "Изображение обложки превышает максимальный размер %(size)s МБ"
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr ""
 "Файл обложки не является допустимым изображением или не может быть сохранён"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Ошибка формата обложки"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
@@ -1773,35 +1745,35 @@ msgstr ""
 "У вас нет прав для доступа к localhost или локальной сети для загрузки "
 "обложек"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Не удалось создать путь для обложки"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "Только файлы jpg/jpeg/png/webp/bmp поддерживаются в качестве обложки"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "Неверное содержимое файла обложки"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Только файлы jpg/jpeg поддерживаются в качестве обложки"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr "Обложка"
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "Исполняемый файл UnRar не найден"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr "Ошибка выполнения UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
@@ -1810,37 +1782,37 @@ msgstr ""
 "Обнаружена неподдерживаемая архитектура: %(arch)s. Calibre-Web NextGen "
 "оптимизирован для x86_64 и aarch64."
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr "Не удалось найти указанную директорию"
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr "Пожалуйста, укажите директорию, а не файл"
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr "Бинарные файлы Calibre неработоспособны"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr "Отсутствуют бинарные файлы calibre: %(missing)s"
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Отсутствуют права на выполнение: %(missing)s"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr "Ошибка выполнения Calibre"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr "Поставить все книги в очередь резервного копирования метаданных"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
@@ -1848,36 +1820,36 @@ msgstr ""
 "Пожалуйста, зайдите в Calibre-Web NextGen не с локального хоста (localhost), "
 "чтобы получить корректный api_endpoint для устройства Kobo"
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Настройка Kobo"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr "Недавно добавленные"
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr "Высоко оценённые"
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr "Читаю сейчас"
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr "К прочтению"
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr "Недавние публикации"
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Регистрация через %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
@@ -1887,12 +1859,12 @@ msgstr ""
 "сконфигурирован scope. Пожалуйста, проверьте конфигурацию OAuth scopes или "
 "свяжитесь с администратором."
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 "Вход не выполнен: токен OAuth истёк. Пожалуйста, попробуйте войти снова."
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
@@ -1901,7 +1873,7 @@ msgstr ""
 "пользователе провайдера OAuth. Пожалуйста, попробуйте снова или свяжитесь с "
 "администратором."
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
@@ -1909,7 +1881,7 @@ msgstr ""
 "Вход не выполнен: провайдер OAuth вернул неверные данные профиля "
 "пользователя. Пожалуйста, свяжитесь с администратором."
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1920,38 +1892,38 @@ msgstr ""
 "%(fields)s. Пожалуйста, проверьте конфигурацию OAuth или свяжитесь с "
 "администратором."
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr "Ошибка связи с OAuth аккаунтом. Попробуйте снова."
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 "Вход не выполнен: вашей учётной записи не разрешён доступ к этому приложению."
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 "Ошибка OAuth: Провайдер вернул неверную информацию о пользователе. "
 "Попробуйте снова."
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr "Эта учётная запись %(oauth)s уже привязана к другому пользователю"
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "Успех! Вы вошли как: %(nickname)s"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Привязка к %(oauth)s выполнена успешно"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1962,58 +1934,58 @@ msgstr ""
 "%(provider)s. Пожалуйста, свяжитесь с администратором для создания аккаунта "
 "или привязки существующего."
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 "Ошибка аутентификации OAuth. Пожалуйста, попробуйте снова или свяжитесь с "
 "администратором."
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 msgid "OAuth system error. Please contact administrator."
 msgstr "Системная ошибка OAuth. Пожалуйста, свяжитесь с администратором."
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "Отвязка от %(oauth)s выполнена успешно"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Не удалось отвязаться от %(oauth)s"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "Не привязано к %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Не удалось войти через GitHub."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Не удалось получить информацию о пользователе из GitHub."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Не удалось войти через Google."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Не удалось получить информацию о пользователе из Google."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 msgid "Failed to log in with Generic OAuth."
 msgstr "Не удалось войти через Generic OAuth."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 "Сбой аутентификации OAuth: ошибка проверки токена. Пожалуйста, попробуйте "
 "ещё раз."
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
@@ -2021,7 +1993,7 @@ msgstr ""
 "Сбой аутентификации OAuth из-за непредвиденной ошибки. Пожалуйста, свяжитесь "
 "с администратором."
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
@@ -2031,204 +2003,197 @@ msgstr ""
 "пожалуйста, настройте параметр «Хост перенаправления OAuth» в разделе "
 "Администратор > Основные настройки > OAuth."
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "Ошибка GitHub Oauth, повторите попытку позже."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "Ошибка GitHub Oauth: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Ошибка Google Oauth, повторите попытку позже."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Ошибка Google Oauth: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr "Ошибка OAuth: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "Книги по алфавиту"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "Книги, отсортированные по алфавиту"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Популярные книги"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "Популярные публикации из этого каталога на основе скачиваний."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Книги с наивысшим рейтингом"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Популярные публикации из этого каталога на основе рейтинга."
 
-#: cps/opds.py:182
+#: cps/opds.py
 msgid "Recently added Books"
 msgstr "Недавно добавленные книги"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Последние книги"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Случайные книги"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Показать случайные книги"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Прочитанные книги"
 
-#: cps/opds.py:201
+#: cps/opds.py
 msgid "Books currently being read"
 msgstr "Книги, читаемые сейчас"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Непрочитанные книги"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Авторы"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Книги, упорядоченные по автору"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Издатели"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Книги, упорядоченные по издателю"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Категории"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Книги, упорядоченные по категории"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Серии"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Книги, упорядоченные по серии"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Языки"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Книги, упорядоченные по языкам"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Рейтинги"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Книги, упорядоченные по рейтингу"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Форматы файлов"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Книги, упорядоченные по форматам файлов"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Полки"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "Книги, расставленные на полках"
 
-#: cps/opds.py:260
+#: cps/opds.py
 msgid "Magic Shelves"
 msgstr "Умные полки"
 
-#: cps/opds.py:261
+#: cps/opds.py
 msgid "Books organized in magic shelves"
 msgstr "Книги, расставленные на умных полках"
 
-#: cps/opds.py:317
+#: cps/opds.py
 msgid "description"
 msgstr "описание"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} звёзд"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Поиск"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Вход"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Токен не найден"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Срок действия токена истёк"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Успех! Пожалуйста, вернитесь к своему устройству"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
@@ -2237,109 +2202,108 @@ msgstr ""
 "прежде чем можно будет выполнять быструю проверку после импорта и изменения "
 "метаданных. "
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Книги"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Показать недавние книги"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Показать популярные книги"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Скачанные книги"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Показать скачанные книги"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Показать книги с наивысшим рейтингом"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 msgid "Show Read and Unread"
 msgstr "Показать прочитанные и непрочитанные"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Показать непрочитанные"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Интересное"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Category Section"
 msgstr "Показать раздел категорий"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Series Section"
 msgstr "Показать раздел серий"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Author Section"
 msgstr "Показать раздел авторов"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Publisher Section"
 msgstr "Показать раздел издателей"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Language Section"
 msgstr "Показать раздел языков"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Ratings Section"
 msgstr "Показать раздел рейтингов"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show File Formats Section"
 msgstr "Показать раздел форматов файлов"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Архивированные книги"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Archived Books"
 msgstr "Показать архивированные книги"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr "Избранное"
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr "Показать избранное"
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Список книг"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Показать список книг"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr "Дубликаты"
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 msgid "Show Duplicate Books"
 msgstr "Показать дубликаты книг"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr "Calibre-Web NextGen %(latest)s доступен — вы используете %(current)s."
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
@@ -2348,389 +2312,388 @@ msgstr ""
 "Помогите улучшить перевод Calibre-Web NextGen на %(language)s язык - "
 "%(count)s строк на вашем языке ещё нуждаются в переводе."
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Опубликовано после "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Опубликовано до "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Рейтинг <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Рейтинг >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Статус прочтения = '%(status)s'"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr "Ошибка при поиске пользовательских столбцов, перезапустите Calibre-Web"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Расширенный поиск"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Указана недопустимая полка"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "Извините, у вас нет прав для добавления книг на эту полку"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "Книга уже находится на полке: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr "%(book_id)s - недопустимый ID книги. Не удалось добавить на полку"
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "Книга добавлена на полку: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "У вас нет прав для добавления книг на полку"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Книги уже находятся на полке: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "Книги добавлены на полку: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Не удалось добавить книги на полку: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 msgid "Invalid series specified"
 msgstr "Указана неверная серия"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "В серии нет книг, которые вы можете просматривать: %(name)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Все книги серии '%(name)s' уже на полке: %(sname)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "%(count)d книг из серии '%(name)s' добавлено на полку: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "Книга удалена с полки: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "Извините, у вас нет прав для удаления книг с этой полки"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Создать полку"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Извините, у вас нет прав для редактирования этой полки"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Редактировать полку"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "Ошибка удаления полки"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "Полка успешно удалена"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Изменить порядок полки: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "Извините, у вас нет прав для создания публичной полки"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Полка %(title)s создана"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Полка %(title)s изменена"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Произошла ошибка"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "Публичная полка с именем '%(title)s' уже существует."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "Приватная полка с именем '%(title)s' уже существует."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Полка: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Ошибка открытия полки. Полка не существует или недоступна"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr "Неверный режим сортировки: %(mode)s"
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr "Недопустимые данные запроса: 'order' должен быть списком"
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr "Не удалось сохранить порядок"
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 msgid "Reorder Shelves"
 msgstr "Изменить порядок полок"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr "Название (А → Я)"
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr "Название (Я → А)"
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr "По количеству книг (от большего к меньшему)"
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr "По количеству книг (от меньшего к большему)"
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr "По дате создания (от новых к старым)"
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr "По дате создания (от старых к новым)"
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr "По дате изменения (сначала новые)"
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr "По дате изменения (сначала старые)"
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr "Вручную (перетащите ниже)"
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr "Читать сейчас"
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr "Открыть сведения о книге «{title}»"
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr "Читать «{title}»"
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr "Стандартный (имя пользователя / пароль)"
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr "LDAP"
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr "OAuth / OpenID Connect"
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Анонимный"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Без аутентификации"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr "Простая (служебная учётная запись)"
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr "Порядок в серии"
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr "Порядок в серии (в обратном порядке)"
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr "Добавить метку"
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr "Новый тег"
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr "Удалить тег"
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr "Удалить тег {name}"
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr "Переименовать тег {name}"
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr "Имя тега"
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr "Имя тега не может быть пустым"
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr "Сохранить имя тега"
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr "Выбрать формат"
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr "Не удалось переименовать тег"
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr "Тег переименован в {name}"
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr "Необходимо выполнить вход"
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr "У вас нет прав на редактирование метаданных"
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr "Тег с таким именем уже существует"
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr "Имя тега должно быть текстом"
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr "Имя тега не должно содержать запятые"
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr "Введите корректное имя тега"
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr "Не удалось загрузить эту страницу"
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr "Страница не найдена"
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr "Сбросить оценку"
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr "Без оценки"
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Да"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Нет"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr "Текст email-сообщения"
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr "Оценка {rating} из 5"
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr "Ещё от {name}"
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
@@ -2739,143 +2702,141 @@ msgstr ""
 "Объединить {n} книг с первой выбранной? Остальные будут удалены после "
 "копирования их форматов."
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr "Применить к {n} книгам"
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr "Условие совпадения"
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr "Поле правила"
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr "Оператор правила"
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr "Не удалось загрузить правила смарт-полки."
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr "Есть обложка"
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr "Номер в серии"
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Статус прочтения"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr "Есть ID Hardcover"
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr "За последние N дней"
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr "Не за последние N дней"
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr "до / меньше"
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr "не позднее / не более"
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr "после / больше"
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr "не ранее / не менее"
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr "в диапазоне"
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr "вне диапазона"
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr "не начинается с"
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr "не заканчивается на"
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr "не заполнено"
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr "заполнено"
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr "Внешний вид"
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Тема"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr "Системная"
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Светлая"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Тёмная"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "Сепия"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr "Высокая контрастность"
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr "Полночь (AMOLED)"
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr "Использовать светлую или тёмную тему устройства"
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr "Тема сохранена."
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr "Не удалось сохранить тему."
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr "Тема оформления по умолчанию для новых аккаунтов"
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
@@ -2883,169 +2844,159 @@ msgstr ""
 "Применяется к аккаунтам, создаваемым с этого момента. Каждый пользователь "
 "выбирает свою тему в меню Аккаунт → Тема."
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr "Добавить формат"
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr "Добавить правило"
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Добавить на полку"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr "Добавить свой"
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr "Метка пароля приложения"
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr "Пароли приложений"
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Автор"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr "Авторы (разделяйте через &)"
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr "Вернуться ко входу"
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr "Синий"
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr "Содержимое книги"
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Просмотр"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr "Изменить пароль"
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Закрыть"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr "Закрыть меню"
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr "Содержание"
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr "Сбой конвертации."
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr "Конвертировать в"
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr "Конвертировать в формат"
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr "Копировать"
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr "Не удалось изменить пароль."
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr "Не удалось создать."
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr "Не удалось получить обложку."
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr "Не удалось загрузить метаданные."
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr "Не удалось загрузить файл книги ({status})"
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr "Не удалось загрузить вашу учётную запись."
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr "Не удалось сохранить."
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr "URL-адрес обложки"
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr "Сбой обновления обложки."
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr "Обложка обновлена."
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr "Создать умную полку"
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr "Создать аккаунт"
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr "Тёмная тема"
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Удалить"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr "Удалить книгу"
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
@@ -3054,485 +3005,478 @@ msgstr ""
 "Удалить «{title}»? Это действие навсегда удалит книгу и все её файлы из "
 "вашей библиотеки. Его нельзя отменить."
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr "Удаление…"
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr "Не удалось удалить эту книгу."
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr "Удалить файл {fmt}? Книга останется, будет удален только этот формат."
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr "Удалить {fmt}"
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr "Удалить {n} книг(у)? Это действие нельзя отменить."
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr "Описание содержит"
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr "Снять выделение с {title}"
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr "Редактировать метаданные"
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr "Редактировать {title}"
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr "Отображается вид библиотеки по умолчанию."
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr "Показать все книги"
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr "Редактировать вид по умолчанию"
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr "Не удалось загрузить книги."
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr "Не удалось открыть книгу."
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr "Сгенерировать"
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr "Зелёный"
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr "Справка"
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr "Цвет выделения"
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr "Импорт из Kobo"
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr "Язык интерфейса"
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr "Неверное имя пользователя или пароль."
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr "Основной шрифт интерфейса"
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr "Шрифт заголовков интерфейса"
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr "По умолчанию (Optima / Без засечек)"
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr "По умолчанию (Книжный с засечками)"
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr "Системный шрифт без засечек"
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr "Книжный шрифт с засечками"
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr "Моноширинный шрифт"
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr "Метка (например, KOReader на телефоне)"
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr "Языки (через запятую)"
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr "Светлая тема"
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr "Ошибка входа."
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr "Пометить как прочитанное"
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr "Пометить как непрочитанное"
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Объединить"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr "Метаданные применены к {n} книге(ам)."
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 "Новый пароль для \"{label}\" - скопируйте его сейчас, он больше не будет "
 "показан:"
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr "Новые пароли не совпадают."
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr "Здесь нет книг."
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr "Нет результатов для \"{q}\"."
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr "Нет вариантов"
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr "Здесь нет книг ({filter})."
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr "Пароль изменён."
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr "Вставить URL"
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr "Приватная полка"
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr "Профиль"
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr "Профиль сохранён."
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr "Публичная полка"
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Издатель"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr "Издатели (через запятую)"
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Прочитано"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr "Прогресс чтения"
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr "Красный"
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr "Ошибка регистрации."
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr "Удалить {name}"
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr "Ошибка запроса."
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr "Сбросить"
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr "Сбросить пароль"
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr "Отозвать {label}"
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr "Сохранить изменения"
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr "Сохранение не удалось."
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr "Сохранить профиль"
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr "Сохранено."
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr "Сохранение…"
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr "Ошибка поиска."
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr "Искать метаданные"
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr "Провайдеры метаданных"
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr "Загрузка провайдеров…"
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr "Не удалось загрузить провайдеров."
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr "Не удалось обновить провайдера."
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr "{provider}: {state}"
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr "Вкл"
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr "Выкл"
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr "Результаты поиска"
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr "Поиск в библиотеке"
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr "Выбрать {title}"
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr "Тема «Сепия»"
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr "Номер в серии: {n}"
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr "{series} #{n}"
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr "Войти"
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr "Ошибка входа. Пожалуйста, попробуйте снова."
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr "Перейти к контенту"
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr "Некоторые поля не удалось сохранить."
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr "Оглавление"
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr "Теги (через запятую)"
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Название"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr "Непрочитанные книги"
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr "Обновить пароль"
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Загрузить"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr "Выберите книги для загрузки"
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr "Сбой загрузки."
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr "Загрузить изображение"
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr "Загрузка…"
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr "Жёлтый"
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr "например, MOBI"
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr "Читалка {format}"
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr "API-ключ {name}"
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr "{n} книг(и) добавлено на полку."
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr "{n} книг(и) удалено."
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr "{n} отмечено как прочитанное."
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr "{n} отмечено как непрочитанное."
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr "{n} выбрано"
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr "Прочитано: {pct}%"
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr "Что нового"
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr "Справка - доступны новые обновления"
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr "Последние функции и исправления в Calibre-Web NextGen - новые сверху."
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr "{n} обновление"
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr "{n} обновлений"
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 "Списка изменений пока нет - загляните сюда после следующего обновления."
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
@@ -3540,252 +3484,249 @@ msgstr ""
 "Интерфейс переведен на ваш язык; эти примечания к обновлению написаны на "
 "английском."
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr "В процессе чтения"
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr "Сетка"
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr "Библиотека"
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr "Список"
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr "Синхронизация"
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Учётная запись"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Администрирование"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr "Под капотом"
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr "Открыть вашу библиотеку"
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr "Просмотр тегов"
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr "Открыть табличный вид"
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr "Просмотреть дубликаты"
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr "Открыть ваши полки"
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr "Управление синхронизацией и паролями приложений"
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr "Проверьте адрес вашей читалки"
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr "Создать пароль приложения"
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr "Просмотр серий"
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr "Просмотр авторов"
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr "Просмотр языков"
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr "Открыть табличный вид"
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr "Открыть панель администратора"
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr "Открыть настройки учетной записи"
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr "Раздел \"Интересное\""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr "Обзор библиотеки"
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr "Перейти к загрузке"
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr "Открыть поиск"
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr "Издания"
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr "Вернуться к новому интерфейсу"
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr "Вернуться к результатам"
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr "Издания для этой книги не найдены."
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr "Подробнее о книге"
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr "Детали результата"
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Опубликовано"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr "Формат"
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Источник"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr "Настроить"
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr "Настроить боковую панель"
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr "Настроить навигацию"
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr "Готово"
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr "Сбросить по умолчанию"
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr "Всегда отображается"
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 "Редактирование боковой панели. Измените порядок или скройте разделы, затем "
 "нажмите «Готово»."
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr "Редактирование отменено."
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 "Перетащите для изменения порядка. Нажмите ✕, чтобы скрыть раздел. Клавиши со "
 "стрелками перемещают выделенный элемент."
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr "Боковая панель сохранена."
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr "Настройки боковой панели сброшены по умолчанию."
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr "{label} перемещен(а) на позицию {pos} из {total}"
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 "Изменение порядка {label} (позиция {pos} из {total}). Используйте клавиши со "
 "стрелками для перемещения."
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr "Удалить {label}"
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr "Восстановить {label}"
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr "{label} скрыт(а)"
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr "{label} восстановлен(а)"
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr "Не удалось сохранить боковую панель. Пожалуйста, попробуйте снова."
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr "Обновить библиотеку"
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr "<"
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr "="
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ">"
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
@@ -3793,44 +3734,43 @@ msgstr ""
 "Необходим однократный полный поиск дубликатов. Запустите его в настройках "
 "CWA, а затем вернитесь сюда."
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr "Дата добавления"
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 "Удалить «{name}»? Он будет удалён из {count} книги, сама книга останется."
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 "Удалить «{name}»? Он будет удалён из {count} книг, сами книги останутся."
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr "Скрыть сообщение о поддержке на Ko-fi"
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr "Скрыть справочное объявление"
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr "Открыть Ko-fi →"
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr "Дата публикации"
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr "Поддержите нас на Ko-fi!"
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
@@ -3838,88 +3778,88 @@ msgstr ""
 "Открывает полные страницы настроек. Внесенные там изменения применятся ко "
 "всему серверу."
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr "«{name}» уже существует для {count} книги. Объединить этот тег с ним?"
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr "«{name}» уже существует для {count} книг. Объединить этот тег с ним?"
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr "начинается с"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr "содержит"
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr "не содержит"
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr "заканчивается на"
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr "за последние N дней"
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr "не равно"
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr "равно"
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr "не за последние N дней"
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr "в эту дату или позже"
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr "в эту дату или раньше"
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr "≤"
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr "≥"
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr "(заменить обложку)"
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr "2:3 (обложка издательства, без отступов для стандартных обложек)"
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr "3:4 (стандартный)"
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 "Поиск дубликатов уже выполняется. Этот список обновится после завершения."
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr "Несколько случайных книг из вашей библиотеки"
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
@@ -3927,173 +3867,169 @@ msgstr ""
 "Необходим однократный полный поиск дубликатов. Используйте кнопку «Поиск "
 "дубликатов» выше, чтобы запустить его."
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr "Ключи API"
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "О программе"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr "Настройки аккаунта"
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr "Учётная запись: {name}"
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr "Добавить идентификатор"
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr "Добавить в избранное"
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr "Группа администраторов"
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr "Дополнительно"
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr "Расширенный поиск"
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr "Все полки"
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr "Разрешить удаленный вход (по волшебной ссылке)"
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr "Разрешённые группы (через запятую)"
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr "Любой"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr "Любой формат"
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr "Любой язык"
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr "Любая серия"
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr "Любые теги"
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr "Применить выбранные"
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 "Применить ко всем выбранным (изменятся только заполненные поля; текущие "
 "значения будут заменены):"
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr "Применение…"
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr "Архив"
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "В архиве"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr "Спросить в Discord"
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr "Авторизация"
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr "Авторизация и безопасность"
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr "Автор А–Я"
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr "Автор Я–А"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr "Авторизация успешна — выполняем вход…"
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr "URL авторизации"
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr "Автоматически создавать пользователей"
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr "Автоматически создавать пользователей при первом входе"
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr "Вернуться в библиотеку"
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr "Вернуться к классическому виду"
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr "Base DN"
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr "Основные настройки"
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr "По умолчанию для книги"
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr "Плотность отображения книг"
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr "Книга {number}"
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr "Книг на странице"
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
@@ -4102,489 +4038,475 @@ msgstr ""
 "устройства при следующей синхронизации. Здесь, в вашей библиотеке, они "
 "останутся."
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr "Встроенные провайдеры (оставьте пустым, чтобы отключить):"
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr "Массовые действия"
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr "Путь к CA-сертификату"
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr "Настройки CWA (импорт/конвертация)"
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr "Можно загружать книги"
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Отмена"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr "Отменить переименование"
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr "Отменить редактирование названия"
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr "Отменить задачу «{task}»"
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr "Путь к файлу сертификата"
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr "Путь к сертификату"
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr "Изменить обложку"
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr "Проверка…"
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr "Выбрать обложку"
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr "Выберите изображение обложки для загрузки"
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr "Выберите изображение…"
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr "Выбрать поля"
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr "Выберите тему оформления"
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr "Сбросить значение по умолчанию"
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr "Снять выделение"
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr "ID клиента"
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr "Секрет клиента"
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr "Секретный ключ клиента (оставьте пустым, чтобы сохранить текущий)"
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr "Закрыть читалку"
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr "Колонки"
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr "Комфортно"
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr "Компактно"
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr "Настроено"
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr "Подтвердите удаление тега {name}"
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr "Подтвердите новый пароль"
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "Конвертировать"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr "Конвертировать перед отправкой"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr "Конвертировать из"
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr "Скопировано в буфер обмена"
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr "Скопировать ссылку"
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr "Не удалось создать полку."
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr "Не удалось создать полку."
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr "Не удалось удалить полку."
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr "Не удалось удалить тег"
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr "Не удалось загрузить кандидатов."
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr "Не удалось загрузить дубликаты."
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr "Не удалось загрузить выделения."
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr "Не удалось загрузить статистику."
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr "Не удалось загрузить задачи."
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr "Не удалось загрузить этот текстовый файл."
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr "Не удалось загрузить пользователей."
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr "Не удалось прочитать этот архив комикса."
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr "Не удалось перезагрузить метаданные"
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr "Не удалось переименовать полку."
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr "Не удалось сбросить пароль."
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr "Не удалось сохранить порядок."
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr "Не удалось сохранить настройки читалки."
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr "Не удалось сохранить фильтр библиотеки по умолчанию."
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr "Не удалось сохранить полку."
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr "Не удалось сохранить название."
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr "Не удалось сохранить вашу позицию чтения."
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr "Не удалось запустить поиск дубликатов."
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr "Не удалось обновить полку."
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr "Не удалось обновить настройку аккаунта."
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr "Не удалось создать волшебную ссылку. Пожалуйста, попробуйте ещё раз."
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr "Обложка заблокирована"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr "Обложка недоступна"
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr "Обложка обновлена из выбранного результата."
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr "Создать"
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr "Создать учётную запись"
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr "Создать учётную запись"
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr "Не удалось создать."
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr "Создать полку и добавить книгу"
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr "Создать пользователя"
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr "Создано: {name}."
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr "Создание…"
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr "Текущий"
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr "Текущая обложка"
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr "Текущий пароль"
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr "Читаю сейчас"
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr "Пользовательский цвет рамки"
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr "Пользовательские колонки"
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr "База данных и путь к библиотеке"
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr "Дата добавления"
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr "По умолчанию (Системный без засечек)"
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr "Язык книг по умолчанию"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr "Язык интерфейса по умолчанию"
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr "Фильтр библиотеки по умолчанию сброшен."
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr "Фильтр библиотеки по умолчанию сохранен."
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr "Роли по умолчанию для новых пользователей OAuth:"
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 "Настройки по умолчанию находятся в меню Администрирование → Конфигурация → "
 "Синхронизация Kobo."
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr "Удалить книги"
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr "Не удалось удалить."
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr "Удалить полку «{name}»? Это действие нельзя отменить."
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr "Удалить тег {name}"
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr "Удалить эту смарт-полку? Это не повлияет на ваши книги."
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 "Удалить пользователя «{name}»? Его полки и данные о чтении также будут "
 "удалены."
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr "Удалить {name}"
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr "Тег {name} удалён"
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr "Удалено: {name}."
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr "Плотно"
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Описание"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr "Отключить стандартный вход по паролю"
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr "Подборки в «Обзоре» обновлены."
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr "Открытия — Случайная подборка"
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr "Скрыть"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr "Пропустить эту группу"
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr "Документация"
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr "Сортировка завершена"
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Скачать"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr "Перетащите файлы сюда или нажмите, чтобы выбрать"
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr "Дубликат"
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr "Дубликаты книг"
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr "Настройки поиска дубликатов"
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
@@ -4592,290 +4514,286 @@ msgstr ""
 "Поиск дубликатов запущен. Он выполняется в фоновом режиме — этот список "
 "обновится после завершения."
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr "Предварительный просмотр для eReader"
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 "Каждый тип (isbn, amazon, google, doi...) может использоваться только один "
 "раз."
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr "Размытие краев - мягкая рамка с эффектом боке"
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr "Зеркальные края - расширение обложки (рекомендуется)"
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Редактировать"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr "Редактировать общедоступные полки"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr "Редактировать смарт-полку"
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr "Редактировать название для «{title}»"
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "Email"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr "Сервер электронной почты (SMTP)"
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr "Email (необязательно)"
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr "Атрибут email (Claim)"
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr "Отправить мне письмо для сброса"
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr "Настройки электронной почты сохранены."
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Включить синхронизацию с Kobo"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Шифрование"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr "Истекает через"
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr "Показывать по OPDS только выбранные полки"
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr "Не удалось загрузить полки."
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr "Не удалось загрузить."
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr "Избранное"
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr "В избранном"
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr "Получить"
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr "Загрузить метаданные из сети"
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr "Файлы"
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 "Файлы добавлены в очередь на обработку и появятся в библиотеке после импорта."
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr "Стиль заливки"
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr "Фильтр: {items}"
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr "Фильтр: {items}…"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr "Семейство шрифтов"
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr "Размер шрифта"
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr "Забыли пароль?"
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr "Формат добавлен в очередь — он появится после обработки."
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr "Форматы"
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr "Форматы — исключить"
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr "Форматы — включить"
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr "Адрес отправителя"
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr "Полная таблица пользователей и ограничений"
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr "Создать новую ссылку"
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr "Введите название для смарт-полки."
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr "Перейти в вашу библиотеку"
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr "Градиент - подобранный по палитре переход (верх/низ)"
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr "Атрибут группы (Claim)"
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr "Поле участников группы"
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr "Имя группы"
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr "Фильтр объектов группы"
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr "HTML-теги разрешены и очищаются от вредоносного кода при отображении."
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr "Имя заголовка"
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr "Помощь и поддержка"
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr "Меню справки"
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr "Скрыто"
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "Скрыть"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr "Скрыть раздел «Обзор»"
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr "Скрыть поля"
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr "Скрыть пароль"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr "Выделение"
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr "Выделения"
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr "Популярное"
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr "Популярное — Самые скачиваемые"
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr "Иконка"
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr "Тип идентификатора"
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr "Значение идентификатора"
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Идентификаторы"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr "Импортировано как"
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr "В вашей книге"
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
@@ -4883,342 +4801,341 @@ msgstr ""
 "Встроенная читалка пока поддерживает только EPUB. Для других форматов "
 "скачайте файл или используйте классическую читалку."
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr "Издатель / базовый URL"
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 "Возможно, этот элемент был перемещен или всё ещё находится в классическом "
 "интерфейсе."
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr "Прогресс KOReader"
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr "Путь к файлу ключа"
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr "Путь к ключу"
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr "Kobo Libra Color / Libra 2 (1264×1680)"
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr "Синхронизация Kobo включена"
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Язык"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr "Языки — включить"
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr "Последнее изменение"
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr "Последняя синхронизация"
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr "Настройки библиотеки"
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr "Межстрочный интервал"
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr "Загрузить ещё"
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr "Загрузка"
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr "Загрузка новых подборок в «Обзоре»."
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr "Загрузка…"
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr "Заблокировать обложку"
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr "Текст кнопки входа"
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr "Метод входа"
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr "Войти через"
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr "Журналы"
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr "Выглядит отлично"
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr "Низкое разрешение"
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr "Волшебная ссылка"
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr "QR-код волшебной ссылки"
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr "Сделать приватным"
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr "Сделать общедоступным"
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr "Использовать как вид библиотеки по умолчанию"
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr "Управление ролью администратора через группу OAuth"
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr "Управление полками"
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr "Пометить как прочитанное"
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr "Пометить как непрочитанное"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr "Сопоставить"
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr "Максимально"
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr "Максимальное количество отображаемых авторов"
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr "Максимальная оценка"
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr "Фильтр пользователей-участников"
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr "Объединить с {name}"
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr "Объединено с {name}"
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr "URL метаданных (автообнаружение OIDC)"
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr "Минимально"
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr "Минимальная оценка"
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 "Дополнительные параметры обложки (поиск по провайдерам, предпросмотр для "
 "читалки)"
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr "Дополнительные настройки сервера"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr "Переместить вниз"
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr "Переместить вверх"
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr "Мой аккаунт"
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr "Название"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr "Нужно сообщить о проблеме? Попробуйте новый"
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr "Новый"
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr "Новый пароль"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr "Название новой полки"
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr "Название новой полки…"
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr "Новая полка…"
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr "Новая смарт-полка"
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr "Новый пользователь"
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr "Сначала новые"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr "Сначала недавно изданные"
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr "Следующая страница"
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr "Сейчас нет книг, подходящих для этой смарт-полки."
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr "Нет книг, соответствующих этим критериям."
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 "Возможные варианты пока не найдены. Попробуйте другой поиск или обновите "
 "страницу."
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr "Оглавление не найдено."
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr "Группы дубликатов не найдены."
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr "Нет исключённых тегов"
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 "Пока нет выделений. Выделяйте текст при чтении или импортируйте с устройства "
 "Kobo."
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr "В разделе «{items}» нет совпадений по запросу «{query}»."
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr "В этом комиксе не найдены страницы."
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr "Полок пока нет — создайте первую ниже."
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr "Полок пока нет. Создайте полку выше, чтобы начать собирать книги."
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr "Ни для одного источника не требуется ключ."
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr "Нет запущенных задач."
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr "В разделе «{items}» пока ничего нет."
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr "Не настроено"
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr "Не задано"
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr "Сначала старые"
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr "Сначала давно изданные"
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
@@ -5226,56 +5143,56 @@ msgstr ""
 "На другом устройстве, где вы уже выполнили вход, отсканируйте этот код или "
 "откройте ссылку ниже, чтобы авторизовать это устройство."
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr "Открыть аккаунт"
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr "Открыть классическую читалку"
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr "Открыть навигацию"
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr "Открыть читалку"
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr "Открыть классический интерфейс"
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr "Откройте ссылку ниже на авторизованном устройстве."
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr "Сервер OpenLDAP"
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr "Открывается в классическом интерфейсе"
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr "PDF-читалка"
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr "Поля страницы"
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr "Тема страницы"
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr "Страница {number}"
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
@@ -5283,17 +5200,16 @@ msgstr ""
 "Отмеченные ниже страницы открываются в классическом интерфейсе. Внесённые "
 "там изменения применятся ко всему серверу."
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Пароль"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr "Пароль (оставьте пустым, чтобы не менять)"
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
@@ -5301,161 +5217,156 @@ msgstr ""
 "Выберите обложку из любого поддерживаемого источника, вставьте URL-адрес, "
 "загрузите файл или используйте обложку, встроенную в саму книгу."
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 "Захвачен элемент {label}. Перетащите для сортировки, отпустите для "
 "перемещения."
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Порт"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr "Подготавливаем волшебную ссылку…"
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr "Предыдущая страница"
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Прогресс"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr "Общедоступный"
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr "Опубликовано после"
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr "Опубликовано до"
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr "Показаны случайные книги"
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Рейтинг"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr "Рейтинг (звёзды)"
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr "Статус прочтения"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr "Фильтр по статусу прочтения"
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr "Настройки читалки сохранены."
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr "Внешний вид читалки"
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr "Получатели"
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr "Хост для перенаправления (полный URL)"
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr "Обновить"
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr "Регистрация…"
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr "Перезагрузить"
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr "Перезагрузить метаданные с диска"
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr "Перезагрузка…"
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr "Запомнить меня"
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr "Удалить из избранного"
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr "Удалить с полки"
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr "Удалить выделение"
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr "Удалить идентификатор"
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr "Удалить правило"
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr "Переименовать"
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr "Изменить порядок"
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr "Заменить обложку этим вариантом?"
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr "Заменить обложку?"
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr "Сообщить о проблеме в Discord"
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr "Сообщить о проблеме на GitHub"
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr "Требовать членство в группе"
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr "Сбросить пароль для {name}"
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
@@ -5464,376 +5375,374 @@ msgstr ""
 "Сбросить пароль для пользователя {name}? Текущий пароль перестанет работать, "
 "а новый будет отправлен по электронной почте."
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr "Вход по заголовку обратного прокси"
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr "Строк при подгрузке"
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr "Время выполнения"
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr "SMTP-сервер"
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Сохранить"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr "Сохранить настройки почты"
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr "Сохранить название"
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr "Сохранить настройки безопасности"
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr "Сохранить настройки"
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 "Сохранено. Перезапустите сервер, чтобы изменения настроек входа вступили в "
 "силу."
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr "Поиск дубликатов"
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr "Запланированные задачи"
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr "Области доступа (Scopes)"
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr "Поиск по названию, автору…"
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr "Поиск по всем источникам…"
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr "Поиск…"
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr "Настройки безопасности сохранены."
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr "Посмотреть, как каждая обложка выглядит с полями для вашего устройства"
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "Выбрать"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr "Выбрать несколько"
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr "Отправить"
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr "Не удалось отправить."
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr "Отправить на читалку"
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr "Email для отправки на читалку"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr "Отправка…"
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr "Номер в серии"
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr "Просмотр серий"
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr "Серии — включить"
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr "Обслуживать по HTTPS"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr "SSL / HTTPS сервера"
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr "Объявление сервера (показывается всем пользователям)"
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr "Хост сервера"
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr "Сервисный аккаунт (DN)"
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr "Сервисный пароль"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr "Пароль сервисной учетной записи (оставьте пустым, чтобы не менять)"
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 "Укажите URL метаданных для автозаполнения адресов (endpoints) ниже или "
 "введите их вручную."
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr "Настройки сохранены."
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr "Название полки"
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr "Полка не найдена."
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr "Показывать раздел «Обзор»"
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr "Показать табличный вид"
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr "Показать все теги ({count})"
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr "Показать все: {items}"
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr "Показывать книги на языке"
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr "Показывать превью для читалки для каждого кандидата"
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr "Показать меньше тегов"
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr "Показать скрытые книги"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr "Показать пароль"
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr "Перемешать подборку"
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr "Войти по волшебной ссылке"
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr "Выйти"
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr "Выполняется вход…"
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr "Название сайта"
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr "Смарт-полка не найдена."
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr "Смарт-полки"
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr "Сплошная заливка: средний цвет обложки"
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr "Сплошная заливка: свой цвет"
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr "Сплошная заливка: преобладающий цвет обложки"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 "Некоторым источникам требуется ключ (API key) для загрузки обложек лучшего "
 "качества"
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr "Что-то пошло не так"
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr "Что-то пошло не так. Попробуйте снова."
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr "Порядок сортировки"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr "Сведения об источнике"
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr "Начато чтение"
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr "Запуск поиска…"
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr "Панель статистики"
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Статус"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr "Поддержать на Ko-fi →"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr "Синхронизировать только выбранные полки"
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr "Синхронизировать с Kobo только книги из выбранных полок"
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr "Табличный вид"
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr "Тег"
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Теги"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr "Теги — исключить"
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr "Теги — включить"
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr "Целевое соотношение сторон"
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Задание"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Задания"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr "Технические подробности"
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr "По этому URL нет подходящего изображения."
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr "Этот формат открывается в режиме полноэкранного чтения."
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 "Срок действия этой волшебной ссылки истек. Создайте новую, чтобы повторить "
 "попытку."
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr "Такой страницы не существует."
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
@@ -5841,76 +5750,75 @@ msgstr ""
 "На этой странице произошла ошибка, и её не удалось отобразить. С вашей "
 "библиотекой всё в порядке — обычно помогает перезагрузка страницы."
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr "Эта полка пуста. Добавьте книги со страницы любой книги."
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr "Название А–Я"
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr "Название Я–А"
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr "Название, автор или ISBN"
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr "URL токена"
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr "Лучшие по рейтингу"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr "Доверять заголовку аутентификации"
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr "Настройки интерфейса и отображения"
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr "Разархивировать"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr "Показать"
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr "Разблокируйте обложку выше, чтобы установить новую."
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr "Разблокируйте обложку, чтобы изменить её"
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr "Без названия"
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr "Не удалось обновить."
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr "Загрузить как обложку"
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr "Загрузить книги"
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr "Загрузка недоступна для вашего аккаунта на этом сервере."
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
@@ -5918,68 +5826,65 @@ msgstr ""
 "Используйте эти данные для подключения OPDS-читалок или синхронизации "
 "KOReader без ввода основного пароля."
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr "Использовать эту обложку"
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Пользователь"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr "Управление пользователями"
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr "Фильтр объектов пользователей"
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr "URL информации о пользователе"
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Имя пользователя"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr "Атрибут имени пользователя (Claim)"
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr "Версии"
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Просмотр"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr "Настройки отображения"
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr "Читалка"
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr "Ожидаем вашей авторизации…"
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr "Когда заблокировано, получение метаданных не перезапишет эту обложку."
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr "Когда прогресс чтения был синхронизирован впервые"
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
@@ -5989,190 +5894,189 @@ msgstr ""
 "этой полки сам по себе ничего не изменит. Переключите аккаунт в режим "
 "синхронизации только выбранных полок, чтобы настройка вступила в силу."
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr "Ваша библиотека"
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr "Ваш браузер не может воспроизвести этот аудиоформат."
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr "Ваша личная цифровая библиотека"
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 "Отображается сохранённый адрес вашей читалки — измените его только для этой "
 "отправки."
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr "все правила"
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr "любое правило"
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr "книги"
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr "подходящих книг"
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr "копии"
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr "читалка"
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr "напр., Непрочитанная научная фантастика"
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr "Тема письма для читалки"
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr "общие"
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr "до"
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr "тип (isbn, amazon, doi...)"
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr "значение"
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr "вы"
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr "Книг: {count}"
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr "Книг: {count}"
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr "{count} файл поставлен в очередь на импорт"
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr "{count} файл отклонён"
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr "{count} файлов поставлено в очередь на импорт"
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr "{count} файлов отклонено"
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr "{count} результат"
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr "{count} результатов"
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr "Результатов для «{query}»: {count}"
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr "{field} (через запятую)"
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr "{n} найдено"
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr "Получен ответ {ok} из {total} источников"
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr "...или вставьте URL изображения"
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr "← Вернуться к книге"
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr "← Вернуться ко входу"
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr "← Библиотека"
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Ожидание"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Сбой"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Запущено"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Завершено"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "Завершено"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "Отменено"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Неизвестный статус"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Неожиданные данные при чтении информации об обновлении"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr "Обновлений нет. У вас уже установлена последняя версия"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6180,15 +6084,15 @@ msgstr ""
 "Доступно новое обновление. Нажмите кнопку ниже для обновления до последней "
 "версии."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Не удалось получить информацию об обновлении"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr "Нажмите кнопку ниже для обновления до последней стабильной версии."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6197,104 +6101,104 @@ msgstr ""
 "Доступно новое обновление. Нажмите кнопку ниже для обновления до версии: "
 "%(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Информация о выпуске недоступна"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Интересное (Случайные книги)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Популярные книги (самые скачиваемые)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "Книги, скачанные пользователем %(user)s"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Автор: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Издатель: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Серия: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "Рейтинг: Нет"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Рейтинг: %(rating)s звёзд"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Формат файла: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Категория: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Язык: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 msgid "Favorite Books"
 msgstr "Избранные книги"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 msgid "Hidden Books"
 msgstr "Скрытые книги"
 
-#: cps/web.py:1193
+#: cps/web.py
 msgid "Error loading magic shelf"
 msgstr "Ошибка загрузки умной полки"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr "Умная полка&nbsp;&nbsp;&nbsp;-&nbsp;&nbsp;&nbsp;%(icon)s %(name)s"
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr "Правила не предоставлены"
 
-#: cps/web.py:1400
+#: cps/web.py
 msgid "Invalid rules format"
 msgstr "Неверный формат правил"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr "Ошибка обработки правил"
 
-#: cps/web.py:1426
+#: cps/web.py
 msgid "Invalid request"
 msgstr "Неверный запрос"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr "Требуются имя и правила"
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr "Название полки слишком длинное (макс. 100 символов)"
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
@@ -6303,47 +6207,47 @@ msgstr ""
 "на ваш Kobo, пока в настройках CWA не будет включена опция «Синхронизировать "
 "умные полки с Kobo»."
 
-#: cps/web.py:1521
+#: cps/web.py
 msgid "Error creating shelf"
 msgstr "Ошибка создания полки"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 msgid "Create Magic Shelf"
 msgstr "Создать умную полку"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr "Отказано в доступе к изменению публичного статуса"
 
-#: cps/web.py:1587
+#: cps/web.py
 msgid "Shelf name is required"
 msgstr "Название полки обязательно"
 
-#: cps/web.py:1647
+#: cps/web.py
 msgid "Error updating shelf"
 msgstr "Ошибка обновления полки"
 
-#: cps/web.py:1652
+#: cps/web.py
 msgid "Edit Magic Shelf"
 msgstr "Редактировать умную полку"
 
-#: cps/web.py:1668
+#: cps/web.py
 msgid "Shelf not found"
 msgstr "Полка не найдена"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr "Отказано в доступе"
 
-#: cps/web.py:1704
+#: cps/web.py
 msgid "Shelf duplicated successfully"
 msgstr "Полка успешно продублирована"
 
-#: cps/web.py:1710
+#: cps/web.py
 msgid "Error duplicating shelf"
 msgstr "Ошибка дублирования полки"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
@@ -6351,106 +6255,104 @@ msgstr ""
 "Системные полки удалить нельзя. Вы можете скрыть их в настройках своего "
 "профиля пользователя."
 
-#: cps/web.py:1755
+#: cps/web.py
 msgid "Error deleting shelf"
 msgstr "Ошибка удаления полки"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 "Вы не можете скрыть свои полки. Вместо этого удалите их, если они вам не "
 "нужны."
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr "Полка уже скрыта"
 
-#: cps/web.py:1795
+#: cps/web.py
 msgid "Error hiding shelf"
 msgstr "Ошибка скрытия полки"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr "Полка не была скрыта"
 
-#: cps/web.py:1818
+#: cps/web.py
 msgid "Error unhiding shelf"
 msgstr "Ошибка отображения скрытой полки"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Скачивания"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Список форматов файлов"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Пожалуйста, сначала настройте параметры SMTP..."
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr "Пожалуйста, укажите в профиле корректный email для eReader."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "Успех! Книга поставлена в очередь отправки на %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Ошибка отправки книги: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr "Адреса электронной почты не выбраны"
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 "Добавление дополнительных адресов электронной почты для вашей учётной записи "
 "отключено."
 
-#: cps/web.py:2500
+#: cps/web.py
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr ""
 "Успех! Книга поставлена в очередь на отправку по выбранному адресу(ам)!"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr ""
 "Пожалуйста, подождите минуту перед регистрацией следующего пользователя"
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Регистрация"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr ""
 "Ошибка подключения к серверной части ограничителя. Пожалуйста, свяжитесь с "
 "администратором"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr "Почтовый сервер не настроен, свяжитесь с администратором."
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "Ваш email не разрешён."
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "Успех! Письмо с подтверждением отправлено."
 
-#: cps/web.py:2624
+#: cps/web.py
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
@@ -6458,7 +6360,7 @@ msgstr ""
 "Обнаружена циклическая ошибка аутентификации. Если у вас возникли проблемы "
 "со входом в систему, обратитесь к администратору."
 
-#: cps/web.py:2704
+#: cps/web.py
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
@@ -6466,28 +6368,28 @@ msgstr ""
 "Аутентификация OAuth настроена неправильно. Пожалуйста, свяжитесь с "
 "администратором."
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr "Не удалось активировать LDAP-аутентификацию"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr "Стандартный вход отключён."
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr "Пожалуйста, подождите минуту перед следующей попыткой входа"
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr "Имя пользователя не может быть пустым"
 
-#: cps/web.py:2756
+#: cps/web.py
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "вы вошли как: '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
@@ -6496,7 +6398,7 @@ msgstr ""
 "Добро пожаловать! Ваша учётная запись была создана автоматически. Вы вошли "
 "как: '%(nickname)s'"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
@@ -6504,7 +6406,7 @@ msgstr ""
 "Аутентификация прошла успешно, но создание учётной записи не удалось. "
 "Пожалуйста, свяжитесь с администратором."
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
@@ -6512,7 +6414,7 @@ msgstr ""
 "Аутентификация прошла успешно, но локальная учётная запись не найдена. "
 "Пожалуйста, обратитесь к администратору для создания учётной записи."
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6521,587 +6423,558 @@ msgstr ""
 "Резервный вход как: '%(nickname)s', LDAP-сервер недоступен или пользователь "
 "неизвестен"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr "Не удалось войти: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 msgid "Wrong Username or Password"
 msgstr "Неверное имя пользователя или пароль"
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr "Новый пароль был отправлен на ваш email"
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr "Произошла неизвестная ошибка. Пожалуйста, попробуйте позже."
 
-#: cps/web.py:2838
+#: cps/web.py
 msgid "Please enter valid username to reset password"
 msgstr "Пожалуйста, введите действительное имя пользователя для сброса пароля"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "Вы вошли как: '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 msgid "Success! Profile Updated"
 msgstr "Успех! Профиль обновлён"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "Учётная запись с этим email уже существует."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr "Метка пароля приложения должна состоять из 1-64 символов."
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr "Пароль приложения '%(label)s' аннулирован."
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr "Неверный ID книги."
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr "Тег не удалось удалить"
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr "Плагин синхронизации KOReader"
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "Не найден действительный файл gmail.json с информацией OAuth"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr "Синхронизация аннотаций с сервисами чтения"
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr "Синхронизация аннотаций"
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr "Автоматическое получение ID Hardcover"
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 msgid "Preparing to send to eReader..."
 msgstr "Подготовка к отправке на eReader..."
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr "Проверка доступных форматов..."
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 msgid "Sending to eReader..."
 msgstr "Отправка на eReader..."
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 msgid "Auto-send completed successfully"
 msgstr "Автоматическая отправка успешно завершена"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr "Автоматическая отправка"
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr "Удалить содержимое временной папки"
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "Книга «%(book)s» отправлена на E-Reader"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Calibre ebook-convert %(tool)s не найден"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "Формат %(format)s не найден на диске"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "Конвертер электронных книг завершился с неизвестной ошибкой"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Ошибка конвертера Kepubify: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "Сконвертированный файл не найден или в папке %(folder)s несколько файлов"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre завершился с ошибкой: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Ошибка конвертера электронных книг: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Переподключение к базе данных Calibre"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr "Очистить архивные ссылки на книги"
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan"
 msgstr "Сканирование дубликатов"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr "Сканирование дубликатов пропущено: выполняется импорт"
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr "Создание индекса дубликатов"
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr "Создание индекса дубликатов: %(processed)s/%(total)s книг"
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr "Создание индекса дубликатов: книг нет"
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 msgid "Finding duplicate groups"
 msgstr "Поиск групп дубликатов"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 msgid "Updating duplicate cache"
 msgstr "Обновление кэша дубликатов"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Ожидается сканирование дубликатов: требуется ручное сканирование"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr "Сканирование дубликатов завершено: %(count)s групп"
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr "Сканирование дубликатов завершено: %(count)s новых групп"
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 "Сканирование дубликатов завершено: %(count)s групп автоматически обработано"
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr "Синхронизация добавлений на полку с Hardcover"
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 msgid "Hardcover Sync"
 msgstr "Синхронизация с Hardcover"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "Электронная почта"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr "Резервное копирование метаданных"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr "Конвертация библиотеки - полный запуск"
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 msgid "Convert Library"
 msgstr "Конвертировать библиотеку"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr "EPUB Fixer - полный запуск"
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr "EPUB Fixer"
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "Сгенерировано миниатюр обложек: %(count)s"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "Миниатюры обложек"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "Сгенерировано миниатюр серий: {0}"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "Очистка кэша миниатюр обложек"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 msgid "Book organizer"
 msgstr "Управление книгами"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 msgid "Change sort order"
 msgstr "Изменить порядок сортировки"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 msgid "Select multiple books"
 msgstr "Выбрать несколько книг"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 msgid "Display settings"
 msgstr "Настройки отображения"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 msgid "Cover Settings"
 msgstr "Настройки обложки"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr "Скрывать значки полок на обложках"
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 msgid "Selection actions"
 msgstr "Действия с выделенным"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 msgid "Add to Shelf"
 msgstr "Добавить на полку"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Публичная)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr "Пометить"
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 msgid "Downloads, fewest first"
 msgstr "По количеству скачиваний (сначала меньше)"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 msgid "Downloads, most first"
 msgstr "По количеству скачиваний (сначала больше)"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 msgid "Date added, newest first"
 msgstr "По дате добавления (сначала новые)"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 msgid "Date added, oldest first"
 msgstr "По дате добавления (сначала старые)"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr "Название (А → Я)"
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr "Название (Я → А)"
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 msgid "Author A → Z"
 msgstr "Автор А → Я"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 msgid "Author Z → A"
 msgstr "Автор Я → А"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 msgid "Published, newest first"
 msgstr "По дате публикации (сначала новые)"
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 msgid "Published, oldest first"
 msgstr "По дате публикации (сначала старые)"
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr "Номер в серии, по возрастанию"
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr "Номер в серии, по убыванию"
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 msgid "Added to shelf, newest first"
 msgstr "По дате добавления на полку (сначала новые)"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 msgid "Added to shelf, oldest first"
 msgstr "По дате добавления на полку (сначала старые)"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr "Пользователи&nbsp;&nbsp;👤"
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "Email для отправки на eReader"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 msgid "Send to eReader Subject"
 msgstr "Отправить на eReader"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Просмотр книг"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Публичная полка"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr "Управление изображениями профилей"
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "Импорт пользователей LDAP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Настройки почтового сервера&nbsp;&nbsp;📬"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "Имя хоста SMTP"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "SMTP-порт"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "SMTP-логин"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Email отправителя"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr "Почтовый сервис"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail через Oauth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr "Конфигурация&nbsp;&nbsp;⚙️"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Каталог базы данных Calibre"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Уровень логирования"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Внешний порт"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Книг на странице"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Загрузки"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Анонимный просмотр"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Публичная регистрация"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Удалённый вход по Magic Link"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Вход через обратный прокси"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Имя заголовка обратного прокси"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr "Настройки NextGen"
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Редактировать основные настройки"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Редактировать настройки интерфейса"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Редактировать конфигурацию базы данных Calibre"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "Запланированные задания&nbsp;&nbsp;⌛"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "Время начала"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "Максимальная продолжительность"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr "Запланированное обновление миниатюр"
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "Сгенерировать миниатюры обложек серий"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Переподключить базу данных Calibre"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr "Сгенерировать файлы резервных копий метаданных"
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "Обновить кэш миниатюр"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr "Функции администратора NextGen&nbsp;&nbsp;⚡"
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr "Показать статистику NextGen"
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr "Проверить статус NextGen"
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 msgid "Setup KOReader Sync"
 msgstr "Настроить синхронизацию KOReader"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr "Служба конвертации библиотеки NextGen"
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr "Служба EPUB Fixer NextGen"
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr "GitHub NextGen"
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr "Сервер NextGen в Discord"
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr "Запустить автопоиск метаданных из сервиса Hardcover"
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Администрирование&nbsp;&nbsp;🚀"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
@@ -7109,88 +6982,87 @@ msgstr ""
 "Очищено: безопасно для прикрепления к публичным issue на GitHub. Пароли, "
 "токены, IP-адреса и пути установки удалены."
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr "Получить пакет поддержки"
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 "Полный неотредактированный пакет. Только для административного/частного "
 "использования - содержит секреты и IP-адреса."
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Скачать отладочный пакет"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Просмотр логов"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Перезапуск"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Выключение"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "Информация о версии&nbsp;&nbsp;📜"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Версия"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Подробности"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 msgid "Update available"
 msgstr "Доступно обновление"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 msgid "Update now"
 msgstr "Обновить сейчас"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Текущая версия"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Проверить обновления"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Выполнить обновление"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Вы уверены, что хотите перезапустить?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Вы уверены, что хотите завершить работу?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Обновление, пожалуйста, не перезагружайте эту страницу"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7203,7 +7075,7 @@ msgstr ""
 "сторонним способом (sideloaded) книги, которых нет в библиотеке, будут "
 "пропущены."
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
@@ -7211,182 +7083,169 @@ msgstr ""
 "Файл обрабатывается в оперативной памяти и удаляется после завершения "
 "импорта. Он никогда не сохраняется на сервере."
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr "KoboReader.sqlite"
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr "Импорт"
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr "Сводка импорта"
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr "импортированы новые выделения"
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr "уже импортировано (пропущено)"
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 msgid "for books not in this library (skipped)"
 msgstr "для книг, отсутствующих в этой библиотеке (пропущено)"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr "скрыто на устройстве (пропущено)"
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr "всего записей просмотрено"
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Загрузка..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 msgid "Import failed."
 msgstr "Сбой импорта."
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 msgid "Network error."
 msgstr "Ошибка соединения."
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr "Экспорт в Markdown"
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr "Экспорт в CSV"
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr "Экспорт в JSON"
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr "Открыть книгу"
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr "%(count)d выделений"
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr "Примечание:"
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr "Прогресс главы: %(pct)d%%"
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Source: %(s)s"
 msgstr "Источник: %(s)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr "К этой книге пока нет аннотаций."
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "через"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "В библиотеке"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "уменьшить"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Ещё от"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Удалить книгу"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Удалить форматы:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Конвертировать формат книги:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Конвертировать из:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr "выберите опцию"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Конвертировать в:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Конвертировать книгу"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Ошибка"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Формат загрузки"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "ID серии"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Дата публикации"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Тип идентификатора"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Значение идентификатора"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Удалить"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Добавить идентификатор"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
@@ -7394,54 +7253,54 @@ msgstr ""
 "Выберите обложку из любого источника, вставьте URL-адрес, загрузите файл или "
 "используйте встроенную обложку."
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Получить обложку по URL (JPEG - изображение будет скачано и сохранено в базе "
 "данных)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Загрузить обложку с локального диска"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 msgid "Hardcover Sync Blacklist"
 msgstr "Чёрный список синхронизации с Hardcover"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr "Исключить аннотации из синхронизации с Hardcover (чёрный список)"
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr "Исключить прогресс чтения из синхронизации с Hardcover (чёрный список)"
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Просмотреть книгу после сохранения"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Получить метаданные"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Ключевое слово"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "Поиск по ключевому слову"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr "Выбранные поля метаданных применены к форме редактирования."
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr "Ключи API"
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
@@ -7452,179 +7311,170 @@ msgstr ""
 "запросов. Ключи сохраняются один раз для всего экземпляра сервера - доступно "
 "только администраторам."
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Загрузка..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr "Сортировать по:"
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr "Порядок провайдеров (по умолчанию)"
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr "Размер обложки - сначала большие"
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr "Размер обложки - сначала маленькие"
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr "Применить"
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Ошибка поиска!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "Результатов не найдено! Попробуйте другое ключевое слово."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "Это поле обязательно"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr " Поменять автора и название местами"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 msgid "Select all"
 msgstr "Выбрать всё"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr "Очистить всё"
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 msgid "Update Title Sort automatically  "
 msgstr "Обновить сортировку названия автоматически  "
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Обновить сортировку автора автоматически"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Введите название"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Введите название для сортировки"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Сортировка по названию"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Введите автора для сортировки"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Автор (сортировка)"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Введите авторов"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Введите категории"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Введите серии"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Введите языки"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Дата публикации"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Введите издателей"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Введите комментарии"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Comments"
 msgstr "Комментарии"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 msgid "Archived?"
 msgstr "Архивировано?"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 msgid "Read?"
 msgstr "Прочитано?"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "Введите "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Вы действительно уверены?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "Книги с названием будут объединены из:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "В книгу с названием:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr "Следующие книги будут удалены:"
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr "Следующие книги будут архивированы:"
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr "Следующие книги будут разархивированы:"
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr "Следующие книги будут помечены как прочитанные:"
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr "Следующие книги будут помечены как непрочитанные:"
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Редактировать метаданные"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 "Отредактируйте поля, которые хотите изменить. Пустые поля будут "
 "проигнорированы:"
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
@@ -7633,31 +7483,30 @@ msgstr ""
 "нескольких значений. Используйте значения через запятую (например, «Имя1, "
 "Имя2»)."
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 msgid "Select a Shelf"
 msgstr "Выберите полку"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr "Пожалуйста, выберите полку для добавления выбранных книг:"
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr "-- Выберите полку --"
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Добавить"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr ""
 "Почтовый сервер еще не настроен, поэтому рассылка объявлений невозможна."
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
@@ -7666,20 +7515,20 @@ msgstr ""
 "ставятся в очередь и отправляются в фоновом режиме - проверьте статус "
 "доставки в Заданиях."
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr "Тема"
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr "Сообщение"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 "Напишите ваше объявление здесь. Разрешён HTML (ссылки, жирный текст, списки)."
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
@@ -7688,48 +7537,48 @@ msgstr ""
 "шрифт). Получатели с почтовыми клиентами, поддерживающими только обычный "
 "текст, автоматически получат текстовую версию."
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr "Использовать текущий текст баннера объявлений"
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr "Получатели"
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 msgid "Select all users with an email address"
 msgstr "Выбрать всех пользователей с email-адресом"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 "Ни у одного пользователя не задан адрес электронной почты, поэтому "
 "отправлять пока некому."
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr "Отправить объявление"
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 msgid "Send test to me"
 msgstr "Отправить тестовое письмо мне"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Назад"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr "Отправить это объявление _NUM_ получателю(ям)?"
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr "Устранение неполадок базы данных"
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
@@ -7739,17 +7588,17 @@ msgstr ""
 "проблема с подключением базы данных Calibre (metadata.db) или, реже, с "
 "файлом app.db."
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr "Распространённые причины:"
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 "NextGen и Calibre одновременно используют одну базу данных или библиотеку."
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
@@ -7758,7 +7607,7 @@ msgstr ""
 "NextGen или его часть работает через сетевой ресурс без включённого "
 "параметра %(network_share_mode)s в конфигурации Docker Compose."
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
@@ -7767,23 +7616,23 @@ msgstr ""
 "NextGen работает на %(unionfs)s или %(mergerfs)s без включённого параметра "
 "%(network_share_mode)s."
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr "Путь к базе данных Calibre изменился или указан неверно."
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr "Файл базы данных Calibre (metadata.db) отсутствует или повреждён."
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr "Права доступа к файлам не позволяют открыть базу данных Calibre."
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr "Чтобы устранить проблему, убедитесь, что:"
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
@@ -7791,7 +7640,7 @@ msgstr ""
 "Во время работы NextGen ни одно другое приложение, включая Calibre, не "
 "обращается к той же базе данных Calibre."
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
@@ -7800,13 +7649,13 @@ msgstr ""
 "При использовании сетевого ресурса, unionfs или mergerfs включите "
 "%(network_share_mode)s в конфигурации Docker Compose."
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 "Путь к базе данных Calibre (metadata.db) указан верно и доступен NextGen."
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
@@ -7814,11 +7663,11 @@ msgstr ""
 "Файл базы данных Calibre (metadata.db) существует и не повреждён. Попробуйте "
 "открыть его в Calibre, чтобы проверить целостность."
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr "У NextGen есть разрешение на доступ к файлу базы данных Calibre."
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
@@ -7826,7 +7675,7 @@ msgstr ""
 "Если после всех проверок проблема сохраняется, восстановите базу данных "
 "Calibre из резервной копии или создайте новую."
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
@@ -7834,11 +7683,11 @@ msgstr ""
 "Также можно использовать «Аварийное восстановление» внизу страницы, чтобы "
 "попытаться восстановить базу данных Calibre из файлов OPF в библиотеке."
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Расположение базы данных Calibre (файл metadata.db)"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7865,7 +7714,7 @@ msgstr ""
 "crocodilestick/Calibre-Web-Automated/wiki/Configuration#database-"
 "configuration\">читайте здесь</a>!"
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
@@ -7873,7 +7722,7 @@ msgstr ""
 "Поэтому при настройке вашего файла docker-compose для NextGen <b>НЕ "
 "ИЗМЕНЯЙТЕ ПУТИ В РАЗДЕЛЕ VOLUMES СПРАВА ОТ ДВОЕТОЧИЯ!</b>"
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7890,7 +7739,7 @@ msgstr ""
 "используйте <b>расположенную ниже опцию «Отделить файлы книг от библиотеки» "
 "и укажите там путь к остальной части библиотеки</b>"
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7906,11 +7755,11 @@ msgstr ""
 "<code>/books</code> в появившемся поле после того, как отметите опцию "
 "<b>\"Отделить файлы книг от библиотеки\"</b>."
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr "Функциональность разделения библиотеки"
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
@@ -7920,31 +7769,31 @@ msgstr ""
 "должен оставаться в <code>/calibre-library/</code>, однако сами файлы книг "
 "могут находиться где угодно"
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Использовать Google Drive?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Подключить Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Папка Calibre на Google Drive"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "ID канала наблюдения за метаданными"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Отозвать"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Крайняя мера: Восстановить базу данных Calibre (экспериментально)"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7961,90 +7810,90 @@ msgstr ""
 "сохранены в /config/backup перед любым деструктивным действием.</b> Журнал "
 "восстановления будет сохранён вместе с резервными копиями."
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 msgid "Are you sure? This cannot be undone."
 msgstr "Вы уверены? Это действие необратимо."
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Восстановить базу данных Calibre (крайняя мера)"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr ""
 "Новое расположение базы данных недействительно, укажите правильный путь"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Использовать стандартную аутентификацию"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Использовать LDAP-аутентификацию"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Использовать OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Конфигурация сервера"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Порт сервера"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "Расположение SSL-сертификата (оставьте пустым для серверов без SSL)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "Расположение SSL-ключа (оставьте пустым для серверов без SSL)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Канал обновлений"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Стабильный"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Ночные сборки"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "Доверенные хосты (через запятую)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Конфигурация журналов"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "Расположение и имя файла журнала (/dev/stdout по умолчанию)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Включить журнал доступа"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "Расположение и имя файла журнала доступа (access.log по умолчанию)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 msgid "Feature Configuration"
 msgstr "Конфигурация функций"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 "Преобразовывать неанглийские символы в названии и авторе при сохранении на "
 "диск"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
@@ -8052,40 +7901,40 @@ msgstr ""
 "Встраивать метаданные в файл электронной книги при скачивании/конвертации/"
 "отправке по email (требуются бинарники Calibre/Kepubify)"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Включить загрузки"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr ""
 "(Пожалуйста, убедитесь, что у пользователей также есть права на загрузку)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Разрешённые форматы файлов для загрузки"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Включить анонимный просмотр"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Включить публичную регистрацию"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "Использовать email как имя пользователя"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Включить удалённый вход по Magic Link"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr "Разрешить пользователям скрывать книги из своей личной библиотеки"
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -8098,45 +7947,45 @@ msgstr ""
 "собственного каталога, поиска и OPDS, не затрагивая других пользователей. "
 "Восстановить книги можно на странице профиля (ссылка «Скрытые книги»)."
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Проксировать неизвестные запросы в магазин Kobo"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Внешний порт сервера (для API-вызовов с перенаправлением портов)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 "Синхронизировать заметки Kobo с Hardcover (требуется API-ключ для каждого "
 "пользователя)"
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr "Дополнить обложки книг полями под соотношение сторон экрана Kobo"
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
@@ -8146,60 +7995,60 @@ msgstr ""
 "соотношение сторон не совпадает с экраном. Отступы добавляются на стороне "
 "сервера; исходные файлы обложек на диске остаются без изменений."
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr "Kobo Libra Color / Libra 2 (1264x1680)"
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr "2:3 (обложка издательства, без отступов для стандартных обложек)"
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr "Сплошная: самый частый цвет обложки"
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr "Сплошная: средний цвет обложки"
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr "Сплошная: свой цвет"
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr "Пользовательский цвет границы (hex)"
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 "Используется только в том случае, если выбран стиль заливки «Сплошная: свой "
 "цвет». Формат: #RRGGBB."
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Использовать Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "API-ключ Goodreads"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 msgid "Enable Hardcover Sync"
 msgstr "Включить синхронизацию с Hardcover"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 "Управляет автоматическим получением данных из Hardcover и синхронизацией "
 "прогресса чтения с помощью одной настройки."
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
@@ -8207,11 +8056,11 @@ msgstr ""
 "Управляется переменной HARDCOVER_SYNC_ENABLED; измените переменную "
 "окружения, чтобы включить или отключить синхронизацию с Hardcover."
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr "API-ключ Hardcover"
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
@@ -8219,7 +8068,7 @@ msgstr ""
 "Бесплатный ключ с https://hardcover.app/account/api - требуется для "
 "получения метаданных из Hardcover."
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
@@ -8227,7 +8076,7 @@ msgstr ""
 "В данный момент активен токен из переменной окружения HARDCOVER_TOKEN. Он "
 "здесь не отображается; ключ, введённый в это поле, перекроет его значение."
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
@@ -8235,31 +8084,31 @@ msgstr ""
 "В данный момент активен токен из файла, указанного в HARDCOVER_TOKEN_FILE. "
 "Он здесь не отображается; ключ, введённый в это поле, перекроет его значение."
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr "Статус токена: не настроен."
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr "Статус токена: действителен."
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 msgid "Token status: rejected or expired."
 msgstr "Статус токена: отклонён или истёк."
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr "Статус токена: указан; проверка временно недоступна."
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr "Срок действия: не указан для этого токена."
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 msgid "Google Books API Key"
 msgstr "API-ключ Google Books"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8268,15 +8117,15 @@ msgid ""
 msgstr ""
 "Необязательно. Без ключа для Google Books действует ограничение около 1000 "
 "запросов на IP-адрес в день, которое легко исчерпать на общих серверах "
-"(ошибка HTTP 429). Бесплатный ключ можно получить на [https://console.cloud."
-"google.com](https://console.cloud.google.com) — включите «Books API» и "
-"создайте API-ключ."
+"(ошибка HTTP 429). Бесплатный ключ можно получить на [https://"
+"console.cloud.google.com](https://console.cloud.google.com) — включите "
+"«Books API» и создайте API-ключ."
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Разрешить аутентификацию через обратный прокси"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
@@ -8286,11 +8135,11 @@ msgstr ""
 "аутентификации. Это метод аутентификации, отличающийся от настройки "
 "безопасности HTTPS ниже."
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr "Использовать через HTTPS"
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
@@ -8299,11 +8148,11 @@ msgstr ""
 "Включайте это ТОЛЬКО в том случае, если вы обращаетесь к серверу по HTTPS, "
 "иначе вы потеряете доступ."
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr "Автоматическое создание пользователей через обратный прокси-сервер"
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
@@ -8314,77 +8163,77 @@ msgstr ""
 "следует только в том случае, если аутентификация через обратный прокси-"
 "сервер надлежащим образом защищена."
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Тип входа"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr "Использовать OAuth (требуется HTTPS)"
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "Имя хоста или IP-адрес LDAP-сервера"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "Порт LDAP-сервера"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "Шифрование LDAP"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Путь к CA-сертификату LDAP (только для аутентификации клиентским "
 "сертификатом)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Путь к сертификату LDAP (только для аутентификации клиентским сертификатом)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Путь к файлу ключа LDAP (только для аутентификации клиентским сертификатом)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "Аутентификация LDAP"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Простая"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "Имя администратора LDAP"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "Пароль администратора LDAP"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "Уникальное имя LDAP (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "Фильтр объектов пользователей LDAP"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "LDAP-сервер - это OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr "Автоматическое создание пользователей из LDAP"
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
@@ -8393,43 +8242,43 @@ msgstr ""
 "аутентификации LDAP для новых пользователей. Рекомендуется для корпоративных "
 "сред."
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr "Следующие настройки необходимы для импорта пользователей"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "Фильтр объектов групп LDAP"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "Имя группы LDAP"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "Поле участников группы LDAP"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "Обнаружение фильтра пользователей-участников LDAP"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "Автоопределение"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "Пользовательский фильтр"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "Фильтр пользователей-участников LDAP"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr "Важно:"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
@@ -8437,29 +8286,29 @@ msgstr ""
 "Аутентификация OAuth требует доступа к этому серверу по HTTPS. Если вы "
 "используете HTTP, вход не будет выполнен."
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr "Универсальный провайдер OAuth"
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr "URL метаданных OAuth (для автоматического обнаружения)"
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 msgid "Test Metadata"
 msgstr "Проверить метаданные"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr "Оставьте пустым, чтобы использовать ручную настройку ниже"
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 "Использовать URL-адреса эндпоинтов вручную (отключает автоматическое "
 "обнаружение)"
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
@@ -8467,43 +8316,43 @@ msgstr ""
 "Отметьте это, чтобы вручную настроить отдельные эндпоинты OAuth вместо "
 "автоматического обнаружения"
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 msgid "Manual Endpoint Configuration"
 msgstr "Ручная конфигурация эндпоинтов"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr "Базовый URL OAuth"
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr "Endpoint авторизации"
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 msgid "Token Endpoint"
 msgstr "Эндпоинт токена"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr "Эндпоинт информации о пользователе"
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 msgid "Test Connection"
 msgstr "Проверить соединение"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 msgid "OAuth Scopes"
 msgstr "Области доступа OAuth (Scopes)"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr "Список областей OAuth, разделённых пробелами"
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr "Хост перенаправления OAuth"
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
@@ -8513,7 +8362,7 @@ msgstr ""
 "предотвратить ошибки \"invalid redirect URI\". Включите протокол (https://). "
 "Оставьте пустым для использования автоматического определения."
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
@@ -8521,39 +8370,39 @@ msgstr ""
 "Требуется, если: доступ осуществляется через несколько имен хостов, "
 "используется обратный прокси или возникают ошибки \"invalid redirect URI\"."
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 msgid "OAuth Client Id"
 msgstr "ID клиента OAuth"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 msgid "OAuth Client Secret"
 msgstr "Секрет клиента OAuth"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 msgid "Field Mapping Configuration"
 msgstr "Конфигурация сопоставления полей"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 msgid "Username Field"
 msgstr "Поле имени пользователя"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr "Поле JWT для извлечения имени пользователя"
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 msgid "Email Field"
 msgstr "Поле email"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr "Поле JWT для извлечения адреса электронной почты"
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 msgid "OAuth Group Claim"
 msgstr "Атрибут группы OAuth (Claim)"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
@@ -8561,11 +8410,11 @@ msgstr ""
 "Атрибут (Claim) OIDC, содержащий имена групп. Атрибут может быть списком или "
 "строкой, разделённой запятыми или пробелами."
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr "Требовать членство в группе OAuth"
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
@@ -8574,11 +8423,11 @@ msgstr ""
 "минимум одной разрешённой группы до создания учётной записи или входа в "
 "систему."
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr "Разрешённые группы OAuth"
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
@@ -8587,11 +8436,11 @@ msgstr ""
 "универсальный OAuth. Оставьте пустым, только если членство в группе не "
 "требуется."
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr "Группа OAuth для администратора"
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
@@ -8602,46 +8451,46 @@ msgstr ""
 "глобальную настройку в разделе \"Настройки безопасности\" для большего "
 "контроля."
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Права по умолчанию для новых пользователей Generic OAuth"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Разрешить скачивание"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Разрешить встроенную читалку"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Разрешить загрузки"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Разрешить редактирование"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Разрешить удаление книг"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Разрешить смену пароля"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Разрешить редактирование публичных полок"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
@@ -8652,54 +8501,54 @@ msgstr ""
 "права администратора, когда включено управление администраторами на основе "
 "групп OAuth. Существующие пользователи не изменяются."
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr "Текст кнопки входа"
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Получить учётные данные OAuth %(provider)s"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "ID клиента OAuth %(provider)s"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "Секретный ключ клиента OAuth %(provider)s"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Внешние исполняемые файлы"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr "Путь к исполняемым файлам Calibre"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 msgid "Calibre E-Book Converter Settings"
 msgstr "Настройки конвертера электронных книг Calibre"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Путь к конвертеру электронных книг Kepubify"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 msgid "Location of Unrar binary"
 msgstr "Расположение исполняемого файла Unrar"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 msgid "Security Settings"
 msgstr "Настройки безопасности"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr "Отключить стандартный вход (имя пользователя/пароль)"
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
@@ -8708,11 +8557,11 @@ msgstr ""
 "или LDAP. Убедитесь, что у вас есть работающий альтернативный метод входа, "
 "прежде чем включать эту опцию."
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr "Включить управление ролями администратора на основе групп OAuth"
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8724,89 +8573,89 @@ msgstr ""
 "вручную управлять ролями администратора в панели управления пользователями, "
 "предотвращая переопределение локальных ролей при входах через OAuth."
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr "Ограничить количество неудачных попыток входа"
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr "Настроить бэкенд для ограничителя"
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr "Настройки бэкенда лимитера"
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr "Проверять соответствие расширений файлов их содержимому при загрузке"
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 msgid "Session protection"
 msgstr "Защита сессии"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr "Основное"
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr "Надёжный"
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 msgid "User Password policy"
 msgstr "Политика паролей пользователей"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr "Минимальная длина пароля"
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr "Требовать цифры"
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr "Требовать строчные буквы"
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr "Требовать наличие заглавных букв"
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 "Требовать символы (необходимо для китайских/японских/корейских символов)"
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr "Требовать специальные символы"
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Просмотр конфигурации"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr "Название, отображаемое на вкладке браузера и в панели навигации."
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr "Количество книг, отображаемых на одной странице в виде списка (1-200)."
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Количество случайных книг для отображения"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr "Количество случайных книг, отображаемых на главной странице (1-30)."
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr ""
 "Количество авторов для отображения перед скрытием (0=отключить скрытие)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
@@ -8814,15 +8663,15 @@ msgstr ""
 "Максимальное количество авторов, отображаемых в деталях книги до скрытия. "
 "Установите 0 для отключения."
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 msgid "Default Theme"
 msgstr "Тема по умолчанию"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "caliBlur! Темная тема"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
@@ -8830,42 +8679,42 @@ msgstr ""
 "Тема по умолчанию для новых пользователей и анонимного просмотра. "
 "Пользователи могут выбрать предпочитаемую тему в своём профиле."
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Регулярное выражение для игнорирования столбцов"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 "Регулярное выражение (regex) для скрытия пользовательских столбцов в "
 "интерфейсе."
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Привязать статус «прочитано/не прочитано» к столбцу Calibre"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr ""
 "Синхронизировать статус прочитано/не прочитано с логическим (boolean) "
 "пользовательским столбцом Calibre."
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Ограничения просмотра на основе столбца Calibre"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 "Ограничить видимость книг на основе значений в пользовательском текстовом "
 "столбце Calibre."
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Регулярное выражение для сортировки по названию"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
@@ -8873,15 +8722,15 @@ msgstr ""
 "Регулярное выражение для удаления префиксов из названий для правильной "
 "сортировки (например, \"The\", \"A\", \"An\")."
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 msgid "Site Customization"
 msgstr "Настройка сайта"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr "Баннер серверных объявлений"
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
@@ -8889,7 +8738,7 @@ msgstr ""
 "Оставьте пустым, чтобы скрыть баннер. Отображается в верхней части каждой "
 "страницы, пока пользователь его не скроет."
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
@@ -8897,16 +8746,16 @@ msgstr ""
 "До 500 символов. HTML-теги экранируются. Каждый пользователь скрывает баннер "
 "независимо; редактирование текста снова покажет его всем."
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 msgid "Custom CSS"
 msgstr "Пользовательский CSS"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr "Например, .navbar { background: #2b2b2b; }"
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
@@ -8915,53 +8764,53 @@ msgstr ""
 "встроенные темы. Применяется ко всем пользователям. Оставьте пустым для "
 "отключения."
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Настройки по умолчанию для новых пользователей"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 "Эти настройки будут применены ко всем вновь созданным учётным записям "
 "пользователей."
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 msgid "Permissions"
 msgstr "Права доступа"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Пользователь-администратор"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 msgid "Language & Display"
 msgstr "Язык и отображение"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "Язык по умолчанию"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 msgid "Default interface language for new users."
 msgstr "Язык интерфейса по умолчанию для новых пользователей."
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "Отображаемый язык книг по умолчанию"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 msgid "Default book language filter for new users."
 msgstr "Фильтр языка книг по умолчанию для новых пользователей."
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr "Язык и регион OPDS по умолчанию для анонимных клиентов"
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr "(нет - использовать английский)"
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
@@ -8971,38 +8820,38 @@ msgstr ""
 "заголовок Accept-Language, а запрос не содержит переопределения ?lang=. "
 "Аутентифицированные пользователи сохраняют свою выбранную локаль."
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Настройки видимости по умолчанию для новых пользователей"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 "Выберите, какие разделы боковой панели будут отображаться по умолчанию для "
 "новых пользователей."
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Показывать случайные книги в детальном просмотре"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Добавить разрешённые/запрещённые теги"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Добавить разрешённые/запрещённые значения пользовательских столбцов"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr "Использовать URL"
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 msgid "Upload a file"
 msgstr "Загрузить файл"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
@@ -9013,12 +8862,12 @@ msgstr ""
 "запросов. Ключи сохраняются один раз для всего экземпляра сервера - доступно "
 "только администраторам."
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 "Показать, как каждая обложка будет выглядеть на вашей электронной книге"
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
@@ -9027,59 +8876,54 @@ msgstr ""
 "умолчанию находятся в разделе Администрирование → Настройки → Синхронизация "
 "Kobo."
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr "Возможные варианты"
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr "Загрузка возможных вариантов…"
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr "Заменить обложку этим вариантом?"
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr "Создание превью для e-reader:"
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run Archive"
 msgstr "Запустить архивацию"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 msgid "Download Log"
 msgstr "Скачать журнал"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Старт"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr "Каждые 5 минут"
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr "Каждые 15 минут"
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr "Конвертация библиотеки успешно запланирована"
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr "Ошибка планирования конвертации библиотеки"
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -9088,14 +8932,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -9103,86 +8947,85 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr "Запустить для одной книги"
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr "Поиск по названию/автору"
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on selected book"
 msgstr "Запустить для выбранной книги"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer scheduled successfully"
 msgstr "Запуск EPUB Fixer успешно запланирован"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error scheduling EPUB Fixer"
 msgstr "Ошибка планирования запуска EPUB Fixer"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 msgid "No matches found"
 msgstr "Результатов не найдено"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 msgid "Enter a search term"
 msgstr "Введите поисковый запрос"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 msgid "Failed to search library"
 msgstr "Не удалось выполнить поиск по библиотеке"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 msgid "Select a book first"
 msgstr "Сначала выберите книгу"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer started for selected book"
 msgstr "EPUB Fixer запущен для выбранной книги"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error starting EPUB Fixer"
 msgstr "Ошибка запуска EPUB Fixer"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Включить/Отключить службы Calibre-Web NextGen"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr "Включить автоконвертацию NextGen"
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -9194,13 +9037,13 @@ msgstr ""
 "умолчанию epub), <em>ЗА ИСКЛЮЧЕНИЕМ</em> тех форматов, которые вы явно "
 "указали NextGen игнорировать."
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 "Включить службу автоматического принудительного применения обложек и "
 "метаданных NextGen"
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -9218,11 +9061,11 @@ msgstr ""
 "файлам электронных книг. В настоящее время эта функция поддерживает только "
 "файлы в форматах EPUB или AZW3."
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr "Включить Kindle EPUB Fixer NextGen"
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -9238,21 +9081,21 @@ msgstr ""
 "свои устройства Kindle и сталкивались с проблемами отклонения файлов или "
 "ошибками форматирования."
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
-"Этот инструмент был адаптирован из утилиты <a href=\"https://kindle-epub-fix."
-"netlify.app/\">kindle-epub-fix.netlify.app</a>, созданной <a href=\"https://"
-"github.com/innocenat\">innocenat</a>."
+"Этот инструмент был адаптирован из утилиты <a href=\"https://kindle-epub-"
+"fix.netlify.app/\">kindle-epub-fix.netlify.app</a>, созданной <a "
+"href=\"https://github.com/innocenat\">innocenat</a>."
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr "Включить синхронизацию с KOReader (плагин NextGen)"
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
@@ -9262,22 +9105,22 @@ msgstr ""
 "совместимые с KOReader контрольные суммы в metadata.db для синхронизации "
 "прогресса. Требуется плагин KOReader на вашем устройстве."
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 "Примечание: Включение этой опции запускает службу фонового вычисления "
-"контрольных сумм при старте, что может временно заблокировать файл metadata."
-"db. Чтобы остановить запущенный процесс, отключите опцию и перезапустите "
-"контейнер."
+"контрольных сумм при старте, что может временно заблокировать файл "
+"metadata.db. Чтобы остановить запущенный процесс, отключите опцию и "
+"перезапустите контейнер."
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr "Включить агрессивный режим EPUB Fixer (более рискованный)"
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
@@ -9286,11 +9129,11 @@ msgstr ""
 "выполнить преобразование кодировки с меньшей степенью достоверности. "
 "Безопасный режим рекомендуется для большинства библиотек."
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 msgid "Enable Archived Book Cleanup"
 msgstr "Включить очистку архивированных книг"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
@@ -9299,116 +9142,116 @@ msgstr ""
 "больше не существует в библиотеке Calibre. Помогает поддерживать точность "
 "счетчиков архива."
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr "График очистки:"
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr "Частые интервалы"
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr "Каждые 15 минут"
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr "Каждые 30 минут"
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr "Каждый час"
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr "Каждые 2 часа"
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr "Каждые 4 часа"
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr "Каждые 6 часов"
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr "Каждые 12 часов"
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr "Ежедневно/Еженедельно/Ежемесячно"
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr "Ежедневно в заданное время"
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr "Еженедельно в указанный день"
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr "Ежемесячно в определённый день"
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr "По умолчанию: ежедневно в 03:00"
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr "День недели:"
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr "Понедельник"
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr "Вторник"
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr "Среда"
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr "Четверг"
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr "Пятница"
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr "Суббота"
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr "Воскресенье"
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr "День месяца:"
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr "(1-28)"
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr "Время суток:"
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr "(Часовой пояс сервера: %(tz)s)"
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr "Включить автоматическое получение метаданных для новых книг"
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9421,11 +9264,11 @@ msgstr ""
 "помогает улучшить качество информации о книгах, особенно при плохих или "
 "отсутствующих метаданных."
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr "Включить умное применение метаданных"
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9438,11 +9281,11 @@ msgstr ""
 "отключена, полученные метаданные заменят существующие данные как есть от "
 "предпочтительного провайдера."
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 msgid "Metadata Fields to Update"
 msgstr "Поля метаданных для обновления"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
@@ -9452,25 +9295,23 @@ msgstr ""
 "скачивании. Неотмеченные поля никогда не будут изменяться при автоматическом "
 "получении метаданных, сохраняя ваши существующие данные."
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr "Теги/Жанры"
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Идентификаторы (ISBN и т.д.)"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 msgid "Cover Image"
 msgstr "Изображение обложки"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr "Подсказка"
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
@@ -9481,15 +9322,15 @@ msgstr ""
 "выбранным полям, в то время как прямой режим заменит все выбранные поля "
 "данными от провайдера."
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr "Максимальный размер файла обложки (МБ):"
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr "Диапазон: 1-200 МБ (по умолчанию: 15)"
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
@@ -9498,11 +9339,11 @@ msgstr ""
 "провайдеров метаданных или по URL-адресам, чтобы предотвратить медленное или "
 "зависшее сохранение."
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr "Тайм-аут обработки Ingest"
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
@@ -9512,19 +9353,19 @@ msgstr ""
 "истечением тайм-аута. Файлы, для которых истёк тайм-аут, перемещаются в "
 "папку неудачных резервных копий для проверки."
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr "Тайм-аут (минуты):"
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr "Диапазон: 5-120 минут (по умолчанию: 15)"
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr "Очистка устаревших временных файлов"
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
@@ -9534,27 +9375,27 @@ msgstr ""
 "удалены по истечении заданного времени. Установка любого из значений на 0 "
 "отключает очистку. Изменения вступят в силу при следующем цикле очистки."
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr "Срок хранения временных файлов (минуты):"
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr "Диапазон: 0-10080 минут (по умолчанию: 120)"
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr "Интервал очистки устаревших временных файлов (в секундах):"
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr "Диапазон: 0-86400 секунд (по умолчанию: 600)"
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr "Задержка автоматической отправки новых книг"
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9566,19 +9407,19 @@ msgstr ""
 "обработки перед отправкой. Применяется только к пользователям, у которых "
 "включена функция автоматической отправки в профиле."
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr "Задержка (в минутах):"
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr "Диапазон: 1-60 минут (по умолчанию: 5)"
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr "Иерархия провайдеров для автоматического получения метаданных"
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
@@ -9588,25 +9429,25 @@ msgstr ""
 "метаданных для новых книг. Перетаскивайте поставщиков, чтобы изменить их "
 "порядок. Будут использоваться только включённые поставщики."
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 "Провайдеры проверяются по порядку сверху вниз. Перетащите для изменения "
 "порядка."
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr "Включённые поставщики метаданных"
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr "Неотмеченные провайдеры отключены глобально."
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Настройки автоматического получения из Hardcover"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
@@ -9616,11 +9457,11 @@ msgstr ""
 "ID Hardcover позволяют синхронизировать прогресс чтения и аннотации с "
 "Hardcover.app при использовании совместимых eReader."
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr "Требуется токен Hardcover"
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
@@ -9631,14 +9472,14 @@ msgstr ""
 "токен в разделе «Основные настройки». Без действующего токена эта функция "
 "останется отключённой."
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 "Синхронизация с Hardcover включена. Расписание ниже управляет автоматическим "
 "получением ID."
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
@@ -9646,7 +9487,7 @@ msgstr ""
 "Синхронизация с Hardcover отключена. Включите её один раз в основных "
 "настройках или установите HARDCOVER_SYNC_ENABLED=true."
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
@@ -9656,23 +9497,23 @@ msgstr ""
 "высокой степенью достоверности применяются автоматически; совпадения с "
 "низкой степенью ставятся в очередь на ручную проверку."
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr "Расписание запуска:"
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr "Как часто автоматически запускать задачу получения ID Hardcover"
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr "Минимальный порог достоверности:"
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr "Диапазон: 0.50-1.00 (по умолчанию: 0.85)"
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
@@ -9683,15 +9524,15 @@ msgstr ""
 "ручную проверку. Более высокие значения = меньше автоматических совпадений, "
 "но выше точность."
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr "Размер пакета:"
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr "Диапазон: 10-200 книг за запуск (по умолчанию: 50)"
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
@@ -9700,15 +9541,15 @@ msgstr ""
 "партии снижают нагрузку на API; крупные партии быстрее обрабатывают вашу "
 "библиотеку."
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr "Задержка ограничения запросов (в секундах):"
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr "Диапазон: 0-60 секунд (по умолчанию: 5.0)"
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
@@ -9716,7 +9557,7 @@ msgstr ""
 "Задержка между API-запросами к Hardcover. Предотвращает превышение лимитов и "
 "защищает ваш API-ключ. Использует экспоненциальную задержку при ошибках."
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
@@ -9727,15 +9568,15 @@ msgstr ""
 "увидеть прогресс и просмотреть ожидающие совпадения, требующие ручного "
 "одобрения."
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 msgid "Web UI Settings"
 msgstr "Настройки веб-интерфейса"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr "Включить уведомления об обновлениях NextGen"
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
@@ -9743,11 +9584,11 @@ msgstr ""
 "Когда функция активна, вы будете получать уведомления в веб-интерфейсе при "
 "выходе новой версии NextGen"
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 msgid "Automatic updates"
 msgstr "Автоматические обновления"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9760,7 +9601,7 @@ msgstr ""
 "вспомогательная программа Watchtower: она отслеживает появление нового "
 "образа и безопасно заменяет NextGen, оставляя другие ваши контейнеры в покое."
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
@@ -9769,13 +9610,12 @@ msgstr ""
 "\"docker compose up -d\". После этого вы будете автоматически обновляться - "
 "никаких дополнительных действий не потребуется."
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr "Скопировано!"
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
@@ -9785,7 +9625,7 @@ msgstr ""
 "Интервал 86400 означает проверку раз в день; \"cleanup\" удаляет старый "
 "образ после каждого обновления."
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
@@ -9794,11 +9634,11 @@ msgstr ""
 "- руководство по настройке появится после того, как мы проверим его с этим "
 "образом."
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr "Включить уведомления о необходимости помочь с переводами"
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -9808,11 +9648,11 @@ msgstr ""
 "интерфейсе при использовании языка, отличного от английского, если переводы "
 "для выбранного языка неполные."
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Синхронизировать умные полки с Kobo"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
@@ -9821,11 +9661,11 @@ msgstr ""
 "синхронизироваться с устройством Kobo как коллекции. Примечание: вы также "
 "должны включить синхронизацию Kobo в основных настройках."
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Включить размытие фона на мобильных устройствах (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -9833,15 +9673,15 @@ msgstr ""
 "Когда функция активна, эффект размытого фона обложки также отображается на "
 "маленьких экранах. Отключите, если заметите задержку прокрутки или анимации."
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 msgid "Automatic Backup Settings"
 msgstr "Настройки автоматического резервного копирования"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr "Включить автоматическое резервное копирование импорта NextGen"
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -9849,11 +9689,11 @@ msgstr ""
 "Когда функция активна, копия всех импортированных файлов будет сохраняться в "
 "<i>/config/processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr "Включить автоматическое резервное копирование конвертаций NextGen"
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -9861,11 +9701,11 @@ msgstr ""
 "Когда функция активна, оригиналы импортированных файлов, которые проходят "
 "конвертацию, будут сохраняться в /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr "Включить автоматическое резервное копирование EPUB Fixer NextGen"
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
@@ -9874,11 +9714,11 @@ msgstr ""
 "Kindle EPUB Fixer, будут сохраняться в /config/processed_books/"
 "fixed_originals"
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr "Включить автоматическое создание ZIP-резервных копий NextGen"
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9891,11 +9731,11 @@ msgstr ""
 "подкаталогах /config/processed_books и минимизировать использование "
 "дискового пространства."
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr "Целевой формат автоконвертации NextGen - EPUB по умолчанию"
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -9905,11 +9745,11 @@ msgstr ""
 "будут автоматически конвертированы в выбранный здесь формат (за исключением "
 "форматов, указанных в списке игнорируемых ниже)."
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 msgid "Choose a target format:"
 msgstr "Выберите целевой формат:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
@@ -9919,11 +9759,11 @@ msgstr ""
 "время поддерживает только файлы в форматах EPUB и AZW3. Файлы в других "
 "форматах будут просто проигнорированы этой службой"
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr "Автоконвертация NextGen - Игнорируемые форматы"
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
@@ -9931,11 +9771,11 @@ msgstr ""
 "Выбранные здесь форматы будут игнорироваться функцией автоконвертации "
 "NextGen, когда она активна, то есть они будут импортированы как есть."
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr "Автоконвертация NextGen - Сохраняемые форматы"
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9947,21 +9787,21 @@ msgstr ""
 "\"Автообработка Ingest NextGen - Игнорируемые форматы\", он не будет "
 "импортирован. Обратите внимание, что целевой формат всегда сохраняется."
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr "Автоматическое объединение Ingest NextGen"
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "Calibre может обнаруживать дублирующиеся названия книг при импорте и в "
 "зависимости от"
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr "автослияние"
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -9969,23 +9809,23 @@ msgstr ""
 "настройка. Можно выбрать удаление любой из копий дублированной книги или "
 "сохранение обеих (по умолчанию)."
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Отбрасывает дублирующий импорт, сохраняет копию в библиотеке"
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr "Перезаписывает копию в библиотеке новым импортированным файлом"
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Создаёт дубликат записи, сохраняя обе копии"
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr "Автообработка Ingest NextGen - Игнорируемые форматы"
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
@@ -9995,11 +9835,11 @@ msgstr ""
 "Ingest) NextGen, то есть файлы в этих форматах не будут добавляться в "
 "библиотеку во время процесса обработки"
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr "Система обнаружения дубликатов NextGen"
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
@@ -10008,33 +9848,33 @@ msgstr ""
 "сканирование дубликатов не будет выполняться и уведомления не будут "
 "отображаться."
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Detection"
 msgstr "Включить обнаружение дубликатов"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 "Когда функция включена, NextGen будет сканировать на наличие дубликатов книг "
 "после каждого импорта"
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr "Метод обнаружения дубликатов"
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr "Гибридный (SQL-префильтр + проверка Python)"
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr "Только Python (самый медленный, но самый надёжный)"
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr "Только устаревший SQL (экспериментально)"
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
@@ -10043,11 +9883,11 @@ msgstr ""
 "возможных вариантов, после чего для получения окончательных результатов "
 "применяется надёжная логика Python."
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 msgid "Automatic Duplicate Scanning"
 msgstr "Автоматическое сканирование дубликатов"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
@@ -10055,27 +9895,27 @@ msgstr ""
 "Настройте фоновое сканирование на наличие дубликатов. Оно будет выполняться "
 "автоматически, не блокируя пользовательский интерфейс."
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr "Включить автоматическое сканирование дубликатов"
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr "Сканирование после импорта"
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr "Запускать после каждого импорта (с задержкой)"
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr "Только вручную"
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr "Задержка после импорта (в секундах)"
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
@@ -10083,15 +9923,15 @@ msgstr ""
 "Подождать указанное количество секунд после последнего импорта перед "
 "запуском фонового сканирования."
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr "Запланированные сканирования (выражение cron)"
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr "Оставьте пустым, чтобы отключить сканирование по расписанию. Пример:"
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
@@ -10100,15 +9940,15 @@ msgstr ""
 "сканирования по расписанию (cron). Используйте «Только вручную», чтобы "
 "отключить сканирование после импорта, сохранив расписание cron."
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr "Следующее запланированное сканирование:"
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr "Критерии обнаружения дубликатов NextGen"
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
@@ -10118,31 +9958,31 @@ msgstr ""
 "ли книги дубликатами. Книги должны соответствовать ВСЕМ выбранным критериям, "
 "чтобы считаться дубликатами."
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr "Учитывать названия книг при поиске дубликатов"
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr "Учитывать авторов книг при поиске дубликатов"
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr "Учитывать язык книги при поиске дубликатов"
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr "Учитывать серию книги при поиске дубликатов"
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr "Учитывать издателя книги при поиске дубликатов"
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr "Учитывать формат файла при поиске дубликатов"
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
@@ -10150,11 +9990,11 @@ msgstr ""
 "Необходимо выбрать хотя бы один критерий. В качестве основных критериев "
 "рекомендуется указать название и автора."
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr "Приоритет форматов при поиске дубликатов"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
@@ -10165,11 +10005,11 @@ msgstr ""
 "чтобы изменить порядок форматов по приоритету (чем выше приоритет, тем "
 "лучше)."
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr "Подсказка:"
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
@@ -10179,11 +10019,11 @@ msgstr ""
 "книги с форматами более высокого ранга будут сохранены. Форматы с более "
 "низким приоритетом будут удалены."
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr "Уведомления о дубликатах и автоматическая обработка"
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
@@ -10191,11 +10031,11 @@ msgstr ""
 "Настройте способ уведомления о дубликатах книг и, при необходимости, "
 "включите автоматическую обработку."
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Notifications"
 msgstr "Включить уведомления о дубликатах"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
@@ -10206,15 +10046,15 @@ msgstr ""
 "значок на кнопке «Дубликаты» на боковой панели и всплывающее уведомление при "
 "входе в систему."
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Включить автоматическую обработку дубликатов"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr "Предупреждение:"
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
@@ -10222,72 +10062,72 @@ msgstr ""
 "Это автоматически удалит книги на основе выбранной ниже стратегии. "
 "Оригинальные файлы будут сохранены (бекап) в"
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr "Стратегия автоматической обработки"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr "Оставить самую новую"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr "Удалить старые копии, оставить добавленную последней"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr "Оставить самую старую"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr "Удалить новые копии, оставить добавленную первой"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge Formats"
 msgstr "Объединить форматы"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr "Объединить форматы в самую новую книгу, удалить остальные"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr "Оставить формат наивысшего качества"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr "Предпочитать форматы на основе вашего приоритета форматов дубликатов"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep Most Metadata"
 msgstr "Оставить максимум метаданных"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr "Оставить книгу с наиболее полной информацией"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr "Оставить наибольший размер файла"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr "Оставить книгу с наибольшим общим размером файла"
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 "Выберите, какую книгу оставить при автоматической обработке дубликатов."
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 msgid "Rate Limiting"
 msgstr "Ограничение запросов"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr "Период задержки (в минутах)"
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
@@ -10295,7 +10135,7 @@ msgstr ""
 "Минимальное время между автоматическими обработками (0 для отключения). "
 "Предотвращает массовые удаления во время пакетного импорта."
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -10304,28 +10144,20 @@ msgstr ""
 "сканировании. Отклоненные группы дубликатов никогда не обрабатываются "
 "автоматически."
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr "Просмотреть %(count)s ожидающих совпадения(ий)"
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr "Показать больше"
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr "Перед уходом - почему вы решили вернуться к старой версии?"
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
@@ -10333,64 +10165,64 @@ msgstr ""
 "Необязательно и полностью анонимно. Это поможет нам сделать новый интерфейс "
 "лучше."
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr "Что-то сломалось или глючит"
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr "Я предпочитаю классический вид"
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr "Нужная мне функция отсутствует"
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr "Слишком непривычно / сложно что-то найти"
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr "Он работал медленно"
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr "Нет, спасибо"
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Далее"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr "Хотите что-нибудь добавить?"
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr "Необязательно - пары предложений будет достаточно."
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr "Что заставило бы вас остаться на новом интерфейсе?"
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr "Отправить отзыв"
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr "Спасибо"
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr "Ваш отзыв был отправлен анонимно. Мы читаем каждое сообщение."
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr "Не удалось отправить прямо сейчас"
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
@@ -10398,21 +10230,21 @@ msgstr ""
 "Нет проблем - ваш отзыв нигде не был сохранён. Вы можете закрыть это окно "
 "или попробовать снова."
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr "Попробовать снова"
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr "Анонимизировать мой отзыв"
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 "Никакие данные аккаунта, имена, IP-адреса, версии или информация об "
 "устройстве не отправляются и не сохраняются."
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
@@ -10423,7 +10255,7 @@ msgstr ""
 "ваш IP-адрес для защиты от спама; мы используем только его односторонний хеш "
 "в течение примерно одной минуты и никогда его не храним."
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
@@ -10431,156 +10263,152 @@ msgstr ""
 "Поскольку вы отключили анонимизацию, версия вашего приложения будет включена "
 "в отчет для помощи в воспроизведении ошибок."
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Пометить как непрочитанное"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Пометить как прочитанное"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 msgid "Marked as read"
 msgstr "Отмечено как прочитанное"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 msgid "Marked as unread"
 msgstr "Отмечено как непрочитанное"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 msgid "Added to favorites"
 msgstr "Добавлено в избранное"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 msgid "Removed from favorites"
 msgstr "Удалено из избранного"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Восстановить из архива"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Добавить в архив"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 msgid "Restored from archive"
 msgstr "Восстановлено из архива"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr "Метаданные перезагружены с диска"
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr "Метаданные на диске совпадают - нет данных для обновления"
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr "Отображать  в вашей библиотеке"
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Hide from your library"
 msgstr "Скрыть из вашей библиотеки"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr "Не скрыто"
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 msgid "Rating updated"
 msgstr "Рейтинг обновлён"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 msgid "Rating cleared"
 msgstr "Рейтинг удалён"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "Книга %(index)s из %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr "ID"
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr "UUID"
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr "UUID скопирован в буфер обмена"
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr "Не удалось скопировать UUID"
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr "Копировать UUID"
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr "Размеры шрифта"
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Описание:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 msgid "Select eReader Email Addresses"
 msgstr "Выбрать email-адреса eReader"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 msgid "Choose email addresses:"
 msgstr "Выберите адреса электронной почты:"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 msgid "Select All"
 msgstr "Выбрать всё"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr "Читалки (eReaders) других пользователей:"
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr "Дополнительные адреса электронной почты:"
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr "Введите дополнительные адреса электронной почты (через запятую):"
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr "example@domain.com, another@domain.com"
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr "Введите один или несколько email-адресов через запятую"
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 msgid "Select format:"
 msgstr "Выберите формат:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 msgid "Failed to update tags"
 msgstr "Не удалось обновить теги"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 msgid "Failed to update shelves"
 msgstr "Не удалось обновить полки"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr "Менеджер дубликатов NextGen"
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
@@ -10588,31 +10416,31 @@ msgstr ""
 "Книги с совпадающими названиями, авторами и языками. Книги на разных языках "
 "не считаются дубликатами."
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 msgid "Run Full Duplicate Scan"
 msgstr "Выполнить полное сканирование дубликатов"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 msgid "Scan for Duplicates Now"
 msgstr "Сканировать на дубликаты сейчас"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr "Выбрать дубликаты"
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 msgid "Select None"
 msgstr "Снять выделение"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 msgid "Delete Selected"
 msgstr "Удалить выбранное"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr "Для сканирования дубликатов требуется однократное полное сканирование."
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
@@ -10622,7 +10450,7 @@ msgstr ""
 "при импорте и изменении метаданных. Перед запуском инкрементального "
 "сканирования необходимо создать базовый индекс."
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
@@ -10631,23 +10459,23 @@ msgstr ""
 "его. Для больших библиотек это может занять несколько минут, и вы можете "
 "продолжать использовать CWA во время выполнения."
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 msgid "Duplicate scan is running."
 msgstr "Выполняется сканирование дубликатов."
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr "Вы можете продолжать использовать CWA, пока оно выполняется."
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr "Просмотр фоновых задач"
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr "Автоматическая обработка дубликатов"
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
@@ -10655,27 +10483,27 @@ msgstr ""
 "Автоматически обрабатывать все группы дубликатов, оставляя одну книгу и "
 "удаляя остальные в соответствии со стратегией."
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr "Стратегия:"
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 "Оставить самую новую - удалить старые копии, оставить добавленную последней"
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 "Оставить самую старую - удалить новые копии, оставить добавленную первой"
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 "Объединить форматы - объединить форматы в самую новую книгу, удалить "
 "остальные"
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
@@ -10683,60 +10511,60 @@ msgstr ""
 "Оставить формат наивысшего качества - выбирать форматы на основе заданного "
 "вами приоритета форматов дубликатов"
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 "Оставить максимум метаданных - оставить книгу с наиболее полной информацией"
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 "Оставить наибольший размер файла - оставить книгу с наибольшим общим "
 "размером файла"
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 msgid "Preview"
 msgstr "Предварительный просмотр"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr "Выполнить обработку"
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 "Это навсегда удалит книги. Оригинальные файлы будут сохранены (бекап) в"
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 msgid "Merge Selected"
 msgstr "Объединить выбранное"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr "Скрыть эту группу дубликатов"
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 msgid "View book details"
 msgstr "Подробнее о книге"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 msgid "Edit book metadata"
 msgstr "Редактировать метаданные книги"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 msgid "Archive/delete book"
 msgstr "Архивировать/удалить книгу"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 msgid "No Duplicate Books Found"
 msgstr "Дубликаты книг не найдены"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 "В вашей библиотеке нет книг с одинаковыми сочетаниями названия и автора."
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
@@ -10744,11 +10572,11 @@ msgstr ""
 "Этот поиск ищет книги с одинаковыми названиями И авторами, чтобы избежать "
 "ложных срабатываний."
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr "Выполнить автоматическую обработку"
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
@@ -10756,76 +10584,76 @@ msgstr ""
 "CWA выполнит обработку групп дубликатов с использованием выбранной стратегии "
 "и безвозвратно удалит повторяющиеся книги."
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 msgid "Selected strategy:"
 msgstr "Выбранная стратегия:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr "Это действие нельзя отменить!"
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 msgid "The following books will be permanently deleted:"
 msgstr "Следующие книги будут безвозвратно удалены:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Merge Books"
 msgstr "Объединить книги"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 msgid "The following book will be kept:"
 msgstr "Следующая книга будет сохранена:"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "Следующие книги будут объединены с ней (а затем удалены):"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 "Примечание: Форматы файлов из исходных книг будут добавлены к целевой книге."
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr "Предварительный просмотр обработки"
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr "Успешно"
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr "Выбранные дубликаты книг успешно удалены!"
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr "Произошла ошибка при обработке вашего запроса."
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "Тип учётной записи email"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr "Стандартная учётная запись email"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr "Учётная запись Gmail"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr "Настроить учётную запись Gmail"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Отозвать доступ Gmail"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "Пароль SMTP"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
@@ -10834,35 +10662,35 @@ msgstr ""
 "письмах. Отправляется в виде обычного текста на любом языке. Оставьте "
 "пустым, чтобы использовать значение по умолчанию."
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Ограничение размера вложения"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 msgid "Save and Send Test Email"
 msgstr "Сохранить и отправить тестовое письмо"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Разрешённые домены (белый список)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Добавить домен"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Введите доменное имя"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Запрещённые домены (чёрный список)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr "(Умные)"
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10870,23 +10698,23 @@ msgstr ""
 "Откройте файл .kobo/Kobo/Kobo eReader.conf в текстовом редакторе и добавьте "
 "(или отредактируйте):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Токен Kobo:"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "Список"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr "Проверка совпадений Hardcover 🔖"
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr "Всё готово!"
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
@@ -10894,15 +10722,15 @@ msgstr ""
 "Нет ожидающих совпадений Hardcover, требующих проверки. Новые совпадения "
 "появятся здесь после запуска задачи автопоиска."
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr "Вернуться в панель администратора"
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr "Требуется проверка"
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
@@ -10912,11 +10740,11 @@ msgstr ""
 "Пожалуйста, просмотрите каждое совпадение и выберите правильный результат "
 "или пропустите/отклоните, если подходящего совпадения нет."
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr "Ожидающие совпадения"
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
@@ -10926,66 +10754,60 @@ msgstr ""
 "книг. Совпадения с высокой достоверностью применяются автоматически; эти "
 "требуют ручной проверки."
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 msgid "Reject All Pending"
 msgstr "Отклонить все ожидающие"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 msgid "Search Query"
 msgstr "Поисковый запрос"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr "Возможные совпадения"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr "Лучшие %(count)s"
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr "Достоверность"
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr "Причина совпадения"
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 msgid "View on Hardcover"
 msgstr "Смотреть на Hardcover"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr "Выбрать это совпадение"
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 msgid "Reject All"
 msgstr "Отклонить всё"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr "Пропустить пока"
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 msgid "Processing..."
 msgstr "Обработка..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr "✓ Выбрать это совпадение"
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr "Не удалось применить совпадение"
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
@@ -10993,100 +10815,97 @@ msgstr ""
 "Вы уверены, что хотите отклонить все совпадения для этой книги? Это действие "
 "необратимо."
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr "✗ Отклонить все совпадения"
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject match"
 msgstr "Не удалось отклонить совпадение"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr ""
 "Вы уверены, что хотите отклонить все ожидающие совпадения? Это действие "
 "нельзя отменить."
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Pending"
 msgstr "✗ Отклонить все ожидающие обработки"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject all pending matches"
 msgstr "Не удалось отклонить все ожидающие совпадения"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr "→ Пока пропустить"
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr "Не удалось пропустить совпадение"
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "Экземпляр Calibre-Web NextGen не настроен, свяжитесь с администратором"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Создать issue"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Вернуться на главную"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "Завершить сеанс пользователя"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr "Уведомление для мобильных устройств"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 "Редактирование умных полок лучше всего работает на компьютерах или планшетах."
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr "Обновите полку, чтобы увидеть последние изменения"
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 msgid "Edit shelf rules"
 msgstr "Редактировать правила полки"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr "Скрыть эту полку на боковой панели"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Show this shelf in your sidebar"
 msgstr "Показывать эту полку на боковой панели"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 msgid "Show Shelf"
 msgstr "Показать полку"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 msgid "Hide Shelf"
 msgstr "Скрыть полку"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 msgid "Add Series to Shelf"
 msgstr "Добавить серию на полку"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr "Синхронизация KOReader отключена."
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
@@ -11094,201 +10913,200 @@ msgstr ""
 "Включите это в настройках NextGen для активации endpoint-ов /kosync и "
 "генерации контрольных сумм."
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr "Открыть настройки NextGen"
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 "Скачивание доступно после включения синхронизации KOReader в настройках "
 "NextGen."
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Главная"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Переключить навигацию"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Поиск в библиотеке"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Переключиться на новый интерфейс Calibre-Web NextGen"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr "Перейти на новый интерфейс"
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Выйти"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr "Поддержать Calibre-Web NextGen"
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 msgid "Settings"
 msgstr "Настройки"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 msgid "Refresh Library"
 msgstr "Обновить библиотеку"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr "Поддержать"
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 msgid "New interface available"
 msgstr "Доступен новый интерфейс"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Новый, более быстрый интерфейс Calibre-Web NextGen готов к работе."
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr "Ваш классический вид остаётся по умолчанию, пока вы не переключитесь."
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr "Попробовать новый интерфейс"
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr "Смотреть историю изменений"
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 msgid "Open Duplicates"
 msgstr "Открыть дубликаты"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr "Внести вклад можно здесь!"
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Пожалуйста, не обновляйте страницу"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 msgid "Create Shelf"
 msgstr "Создать полку"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr "Умные полки ✨"
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Предыдущий"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Подробнее о книге"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 msgid "This cannot be undone."
 msgstr "Это действие нельзя отменить."
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 msgid "Will be deleted"
 msgstr "Будут удалены"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 msgid "Formats:"
 msgstr "Форматы:"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr "Будут сохранены"
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr "Конфликты форматов - выберите действие:"
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 msgid "Result will have formats:"
 msgstr "Результат будет иметь форматы:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr "Объединить и удалить источник"
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 msgid "Duplicate Books Detected"
 msgstr "Обнаружены дубликаты книг"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr "В вашей библиотеке есть необработанные дубликаты книг"
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 msgid "Duplicate Groups Found"
 msgstr "Найдены группы дубликатов"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr "Напомнить позже"
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr "Просмотр и устранение дубликатов"
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 msgid "Scroll to top"
 msgstr "Прокрутить наверх"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 msgid "Top"
 msgstr "Наверх"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 msgid "Confirm"
 msgstr "Подтвердить"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Добавлено {n} книг на полку {shelf}"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 "Добавлено {ok} из {n} книг на полку {shelf} (остальные уже были на ней)"
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr "Все {n} книг уже были на полке «{shelf}»."
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Отмечено {n} книг как прочитанные"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Отмечено {n} книг как непрочитанные"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Удалено {n} книг"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 msgid "Delete books?"
 msgstr "Удалить книги?"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -11297,91 +11115,91 @@ msgstr ""
 "Это навсегда удалит {n} книг(у) из вашей библиотеки. Это действие нельзя "
 "отменить."
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 msgid "Select at least one book first."
 msgstr "Сначала выберите хотя бы одну книгу."
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Сбой запроса: {err}"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr "Фильтр по первой букве"
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "Сетка"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 msgid "Show Password"
 msgstr "Показать пароль"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Запомнить меня"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Забыли пароль?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Войти по Magic Link"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 msgid "Log in with SSO"
 msgstr "Войти через SSO"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 "Стандартный вход отключён. Пожалуйста, используйте один из альтернативных "
 "методов входа."
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Показать журнал Calibre-Web: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Calibre-Web Log: "
 msgstr "Журнал Calibre-Web: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Потоковый вывод, не может быть отображён"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Показать журнал доступа: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Скачать журнал Calibre-Web"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "Скачать журнал доступа"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr "Системный шаблон"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 "Это предварительно настроенный шаблон полки. Вы можете свободно его "
 "редактировать."
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 msgid "Share with Everyone (Public)"
 msgstr "Поделиться со всеми (Публично)"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
@@ -11389,52 +11207,52 @@ msgstr ""
 "Другие пользователи могут просматривать эту полку. Пользователи с "
 "разрешением «Редактировать публичные полки» могут её редактировать/удалять."
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Выбрать разрешённые/запрещённые теги"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Выбрать разрешённые/запрещённые значения пользовательских столбцов"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Выбрать разрешённые/запрещённые теги пользователя"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr ""
 "Выбрать разрешённые/запрещённые значения пользовательских столбцов "
 "пользователя"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Введите тег"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Добавить ограничение просмотра"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "Этот формат книги будет окончательно удалён из базы данных"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Эта книга будет окончательно удалена из базы данных"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "и жёсткий диск"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Важное примечание для Kobo: удалённые книги останутся на любом подключённом "
 "устройстве Kobo."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11442,279 +11260,279 @@ msgstr ""
 "Перед безопасным удалением книги необходимо сначала заархивировать её и "
 "синхронизировать устройство."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Выберите местоположение файла"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "тип"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "имя"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "размер"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "Родительская папка"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "ОК"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Каталог электронных книг Calibre-Web NextGen"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "читалка EPUB"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 msgid "Annotations"
 msgstr "Аннотации"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr "Открыть страницу аннотаций"
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "Чёрный"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "Размеры шрифта"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 msgid "Text margin"
 msgstr "Поля текста"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr "Шрифт"
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 msgid "Default"
 msgstr "По умолчанию"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr "Yahei"
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr "SimSun"
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 msgid "KaiTi"
 msgstr "KaiTi"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 msgid "Arial"
 msgstr "Arial"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 msgid "Spread"
 msgstr "Разворот"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr "Две колонки"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr "Одна колонка"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Переносить текст при открытых боковых панелях."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr "Примечание"
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr "Добавить примечание (необязательно)"
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr "Выберите текст внутри абзаца для выделения."
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Читалка для комиксов"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Горячие клавиши"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Предыдущая страница"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Следующая страница"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 msgid "Single Page Display"
 msgstr "Одностраничный режим"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr "Режим длинной ленты"
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Оптимальный масштаб"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Масштаб по ширине"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Масштаб по высоте"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Оригинальный масштаб"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Повернуть вправо"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Повернуть влево"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Отразить изображение"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "Отображение"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 msgid "Single Page"
 msgstr "Одна страница"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr "Длинная лента"
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Масштаб"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Лучшее"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Ширина"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Высота"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Нативный"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Поворот"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Отразить"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Горизонтально"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Вертикально"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 msgid "Direction"
 msgstr "Направление"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Слева направо"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Справа налево"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr "Сбросить в начало"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 msgid "Remember Position"
 msgstr "Запомнить позицию"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "Полоса прокрутки"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "Показать"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "Читалка DJVU"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "PDF-ридер"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "программа для чтения TXT"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Регистрация новой учётной записи"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Выберите имя пользователя"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Ваш Email"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Magic Link - авторизация нового устройства"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "На другом устройстве войдите в систему и перейдите по ссылке:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "После проверки вы автоматически войдёте на этом устройстве."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Срок действия ссылки для проверки истечёт через 10 минут."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
@@ -11723,254 +11541,250 @@ msgstr ""
 "обслуживания. Миниатюры всегда генерируются по запросу, независимо от этой "
 "настройки."
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "Сгенерировать миниатюры обложек серий"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Результатов не найдено"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Поисковый запрос:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Результаты для:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Дата публикации с"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Дата публикации по"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr "Пусто"
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Исключить теги"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Исключить серии"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "Исключить полки"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Исключить языки"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Расширения"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Исключить расширения"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Рейтинг выше"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Рейтинг ниже"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "От:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "Кому:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Удалить эту полку"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "Редактировать свойства полки"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 msgid "Add Books"
 msgstr "Добавить книги"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "Упорядочить книги вручную"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "Отключить изменение порядка"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "Включить изменение порядка"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, python-format
 msgid "%(count)s selected"
 msgstr "%(count)s выбрано"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, python-format
 msgid "Add %(count)s"
 msgstr "Добавить %(count)s"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 msgid "No books found."
 msgstr "Книги не найдены."
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 msgid "Already on this shelf"
 msgstr "Уже на этой полке"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr "Не удалось добавить книги. Пожалуйста, попробуйте снова."
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 msgid "Add books to"
 msgstr "Добавить книги в"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 msgid "Search your library…"
 msgstr "Поиск по библиотеке…"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 msgid "Search your library"
 msgstr "Поиск по библиотеке"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Поделиться со всеми"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "Синхронизировать эту полку с устройством Kobo"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr "Показывать эту полку в моём OPDS-каталоге"
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr "Перетащите обложку на новое место - порядок сохранится автоматически."
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 "Клавиатура: выберите обложку с помощью клавиши Tab, затем перемещайте её "
 "стрелками."
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr "Порядок сохранён"
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr "Не удалось сохранить порядок - нажмите здесь для повторной попытки"
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr "Перемещено на позицию %(num)s из %(total)s"
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 msgid "Shelf order"
 msgstr "Порядок полок"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Скрытая книга"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr "Сортировать по"
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr "У вас пока нет полок для изменения порядка."
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr "Перетащите, чтобы изменить порядок полок на боковой панели."
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 "Порядок сохранён. Боковая панель отобразит новый порядок при следующей "
 "загрузке страницы."
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Статистика библиотеки"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Книги в этой библиотеке"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Авторы в этой библиотеке"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Категории в этой библиотеке"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Серии в этой библиотеке"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Статистика системы"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "Программа"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Установленная версия"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr "Обзор фоновых задач"
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Время выполнения"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr "Действия"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr "Предстоящие запланированные отправки"
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr "Запланированное время"
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 msgid "State"
 msgstr "Состояние"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
@@ -11978,15 +11792,15 @@ msgstr ""
 "Предстоящие отправки сохраняются и будут добавлены в очередь заданий в "
 "назначенное время. Вы можете отменить ожидающую отправку до её выполнения."
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr "Предстоящие запланированные операции"
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr "Тип"
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
@@ -11994,14 +11808,14 @@ msgstr ""
 "Запланированные здесь задачи конвертации библиотеки и EPUB Fixer сохраняются "
 "после перезапуска сервера. Отмените их, чтобы предотвратить запуск."
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 "Эта задача будет отменена. Весь прогресс, достигнутый в задаче, будет "
 "сохранён."
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
@@ -12009,19 +11823,19 @@ msgstr ""
 "Если это запланированная задача, она будет повторно запущена в следующее "
 "запланированное время."
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 msgid "Scheduled item cancelled successfully"
 msgstr "Запланированное задание успешно отменено"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr "Ошибка отмены запланированного задания"
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 msgid "Update Calibre-Web NextGen"
 msgstr "Обновить Calibre-Web NextGen"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
@@ -12032,40 +11846,40 @@ msgstr ""
 "в безопасности — они хранятся в примонтированных томах, а не в самом "
 "контейнере."
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr "В какой среде вы запускаете Calibre-Web NextGen?"
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr "Тип установки"
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr "Docker Compose"
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr "docker run"
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr "Unraid"
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr "Portainer / Synology"
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr "Запустите это из папки, в которой находится ваш файл compose:"
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 "Замените calibre-web-nextgen именем вашего сервиса, если оно отличается."
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
@@ -12073,7 +11887,7 @@ msgstr ""
 "Скачайте новый образ (pull), затем пересоздайте контейнер с теми же "
 "параметрами, с которыми вы его запускали:"
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
@@ -12082,11 +11896,11 @@ msgstr ""
 "вашей обычной команды docker run. Ваши примонтированные тома сохранят все "
 "данные."
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr "Откройте вкладку Docker в веб-интерфейсе Unraid."
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
@@ -12095,7 +11909,7 @@ msgstr ""
 "обновление» (предварительно проверьте наличие обновлений, если хотите "
 "увидеть, что изменилось)."
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
@@ -12103,11 +11917,11 @@ msgstr ""
 "Для автоматических обновлений установите плагин «CA Auto Update "
 "Applications» из Community Applications."
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr "Portainer:"
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
@@ -12116,11 +11930,11 @@ msgstr ""
 "выберите Calibre-Web NextGen -> Пересоздать (Recreate) с включённой опцией "
 "\"Повторно скачать образ\" (Re-pull image)."
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr "Synology Container Manager:"
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
@@ -12128,46 +11942,46 @@ msgstr ""
 "Реестр (Registry) -> скачайте образ ниже (тег: latest), затем остановите "
 "контейнер -> Действие (Action) -> Сбросить (Reset) для его пересоздания."
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr "Настроить автоматические обновления"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "Your Profile"
 msgstr "Ваш профиль"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "User Settings"
 msgstr "Настройки пользователя"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr "Информация об учётной записи"
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 "Если вам нужно изменить свой адрес электронной почты или пароль, вы можете "
 "сделать это здесь."
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Сбросить пароль пользователя"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 msgid "eReader Configuration"
 msgstr "Конфигурация eReader"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 msgid "Send to eReader Email Address"
 msgstr "Email-адрес eReader для отправки"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr "Используйте запятую для разделения нескольких адресов"
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
@@ -12175,11 +11989,11 @@ msgstr ""
 "Адреса электронной почты для ваших устройств eReader. Разделяйте несколько "
 "адресов запятыми."
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr "Включить всплывающее окно отправки на eReader"
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
@@ -12189,7 +12003,7 @@ msgstr ""
 "позволяет пользователям вводить дополнительные адреса электронной почты и "
 "отправлять книги только на выбранные сохранённые адреса."
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
@@ -12197,11 +12011,11 @@ msgstr ""
 "Когда функция отключена, письма будут отправляться на все настроенные адреса "
 "eReader без дополнительных запросов."
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr "Автоматически отправлять новые книги на мои eReader"
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
@@ -12209,73 +12023,73 @@ msgstr ""
 "Когда функция включена, новые добавленные книги будут автоматически "
 "отправляться на все настроенные выше email-адреса eReader."
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr "Настройки языка и темы"
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 msgid "Interface Language"
 msgstr "Язык интерфейса"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Язык книг"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 "Отфильтровать библиотеку, чтобы показывать книги только на определенном "
 "языке."
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 msgid "Book Language Filter"
 msgstr "Фильтр языка книги"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr "Интеграции OAuth и API"
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "Настройки OAuth"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Ссылка"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Отвязать"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr "Токен API Hardcover"
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr "API-токен для интеграции с провайдером метаданных Hardcover."
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Токен синхронизации Kobo"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Создать/Просмотреть"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "Принудительная полная синхронизация с Kobo"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr "Повторно отправить одну книгу на этот Kobo"
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr "Отправить повторно"
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
@@ -12284,35 +12098,35 @@ msgstr ""
 "заново при следующей синхронизации. Идентификатор книги можно найти в URL-"
 "адресе страницы с подробной информацией о книге."
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "Синхронизировать с Kobo только книги из выбранных полок"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr "Отображение полок в OPDS"
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "Показывать в OPDS только книги из выбранных полок"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 msgid "Sidebar Display Settings"
 msgstr "Настройки отображения боковой панели"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr "Выберите, какие разделы отображать в боковой панели навигации."
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Добавить разрешённые/запрещённые значения пользовательских столбцов"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr "Порядок каталога OPDS"
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
@@ -12321,7 +12135,7 @@ msgstr ""
 "порядке. Неизвестные ID игнорируются, а отсутствующие записи добавляются "
 "автоматически."
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
@@ -12329,73 +12143,73 @@ msgstr ""
 "Перетащите для изменения порядка корневых записей OPDS. Отсутствующие записи "
 "добавляются автоматически."
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr "Права доступа пользователя"
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr "Настройте, какие действия разрешены этому пользователю."
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Order"
 msgstr "Порядок умных полок"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr "Выберите порядок расположения ваших умных полок на боковой панели."
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr "Режим сортировки"
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr "Вручную (перетащите для изменения порядка)"
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr "Название (А-Я)"
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr "Название (Я-А)"
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr "По количеству книг (по убыванию)"
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr "По количеству книг (по возрастанию)"
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr "По дате создания (сначала новые)"
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr "По дате создания (сначала старые)"
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 msgid "Recently modified"
 msgstr "Недавно изменённые"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr "По дате изменения (сначала старые)"
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 "Ручной порядок используется только тогда, когда режим сортировки установлен "
 "на «Вручную»."
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr "Видимость умных полок"
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
@@ -12404,33 +12218,33 @@ msgstr ""
 "Системные полки нельзя удалить, только скрыть. Публичные полки других "
 "пользователей также можно скрыть."
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr "Системные полки по умолчанию:"
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 msgid "Public Shelves:"
 msgstr "Публичные полки:"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr "Отображается %(visible)s из %(total)s стандартных полок"
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr "Отображается %(visible)s из %(total)s публичных полок"
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Удалить пользователя"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr "Пароли приложений для синхронизации OPDS / KOReader"
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12444,11 +12258,11 @@ msgstr ""
 "отозвать любой пароль приложения в любое время, не прерывая вашу активную "
 "веб-сессию."
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 msgid "New app password"
 msgstr "Новый пароль приложения"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
@@ -12456,139 +12270,139 @@ msgstr ""
 "Создан пароль приложения для '%(label)s'. Скопируйте его сейчас - вы его "
 "больше не увидите."
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr "Новый пароль приложения (в открытом виде)"
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr "Например, Kobo Forma, KOReader iPad"
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 msgid "Create app password"
 msgstr "Создать пароль приложения"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr "Метка"
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 msgid "Created"
 msgstr "Создано"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr "Последнее использование"
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr "Никогда"
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr "Отозвать этот пароль приложения?"
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Сгенерировать URL авторизации Kobo"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr "Видимый"
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Выбрать..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Удалить выбранное"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "Редактировать пользователя"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "Введите имя пользователя"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 msgid "Enter Email"
 msgstr "Введите Email"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "Enter eReader Email"
 msgstr "Введите Email eReader"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "eReader Email"
 msgstr "Email eReader"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 msgid "Enter eReader Email Subject"
 msgstr "Введите тему письма для eReader"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 msgid "eReader Email Subject"
 msgstr "Тема письма для eReader"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Язык и регион"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "Видимые языки книг"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "Редактировать разрешённые теги"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Разрешённые теги"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Редактировать запрещённые теги"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Запрещённые теги"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "Редактировать разрешённые значения столбцов"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "Разрешённые значения столбцов"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "Редактировать запрещённые значения столбцов"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "Запрещённые значения столбцов"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "Изменить пароль"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "Редактировать публичные полки"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "Синхронизировать выбранные полки с Kobo"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 msgid "Expose selected Shelves to OPDS"
 msgstr "Показывать выбранные полки в OPDS"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 msgid "Show Read/Unread Section"
 msgstr "Показать раздел прочитанного/непрочитанного"
 
@@ -12823,9 +12637,9 @@ msgstr "Показать раздел прочитанного/непрочит�
 #~ "metadata.db при запуске. Если найдена только одна библиотека, она "
 #~ "монтируется автоматически; если найдено несколько, по умолчанию будет "
 #~ "смонтирована самая большая, а если ни одной нет, будет автоматически "
-#~ "создана и смонтирована новая. Для подробностей, <a href=\"https://github."
-#~ "com/crocodilestick/Calibre-Web-Automated/wiki/Configuration#database-"
-#~ "configuration\">см. здесь</a>!"
+#~ "создана и смонтирована новая. Для подробностей, <a href=\"https://"
+#~ "github.com/crocodilestick/Calibre-Web-Automated/wiki/"
+#~ "Configuration#database-configuration\">см. здесь</a>!"
 
 #~ msgid ""
 #~ "Therefore, when configuring your docker-compose file for CWA, <b>DO NOT "

--- a/cps/translations/sk/LC_MESSAGES/messages.po
+++ b/cps/translations/sk/LC_MESSAGES/messages.po
@@ -19,259 +19,257 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Štatistika"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 msgid "Server restarted, please reload page."
 msgstr "Server bol reštartovaný, znovu načítajte stránku."
 
-#: cps/admin.py:210
+#: cps/admin.py
 msgid "Performing Server shutdown, please close window."
 msgstr "Vypínam server, zavrite prosím okno."
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "Spojenie s databázovo bolo úspešne znovu naviazané"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Neznámy príkaz"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 "Úspech! Knihy boli zaradená do zálohovania metadát, skontrolujte si Úlohy na "
 "kontrolu"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr ""
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 
-#: cps/admin.py:414
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover ID applied successfully"
 msgstr "Zmazaných {} používateľov"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr ""
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr ""
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr ""
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr ""
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr ""
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Stránka správcu"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "Nastavenia OAuth"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Základná konfigurácia"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Konfigurácia používateľského rozhrania"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 "Používateľom definovaný stĺpec č. %(column)d v Calibre databáze neexistuje"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Upraviť používateľov"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Všetko"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Používateľ sa nenašiel"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "Zmazaných {} používateľov"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Zobraziť všetko"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Chybne vytvorená žiadosť"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "Meno hosťa nie je možné zmeniť"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "Hosť nemôže mať túto rolu"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr "Nezostáva žiadny správca, nie je možné odobrať rolu správcu"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "Hodnota musí byť pravda alebo nepravda"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Neplatná rola"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "Hosť nemôže mať toto zobrazenie"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "Neplatné zobrazenie"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 "Nastavenie jazyka pre hosťa sa určí automaticky a nie je možné ho nastaviť"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Nebolo poskytnuté platné nastavenie jazyka"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Nebolo poskytnuté platné jazykové nastavenie pre knihu"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Parameter sa nenašiel"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "Nie je možné zapisovať do databázy nastavení"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Neplatný stĺpec na čítanie"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Neplatný stĺpec na obmedzenie"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Naozaj chcete zmazať Kobo-žetón?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "Naozaj chcete zmazať túto doménu?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "Naozaj chcete zmazať tohot používateľa?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Naozaj chcete zmazať túto poličku?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr "Naozaj chcete zmeniť nastavenia jazykov pre vybraných používateľov?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "Naozaj chcete zmeniť viditeľné jazkyky pre knihy pre vybraných používateľov?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr "Naozaj chcete zmeniť vybrané role pre vybraných používateľov?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
 msgstr "Naozaj chcete zmeniť vybrané obmedzenia pre vybraných používateľov?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -279,14 +277,14 @@ msgstr ""
 "Naozaj chcete zmeniť vybrané obmedzenia viditeľnosti pre vybraných "
 "používateľov?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "Naozaj chcete zmeniť synchronizačné správanie sa police pre vybraných "
 "používateľov?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
@@ -294,128 +292,123 @@ msgstr ""
 "Naozaj chcete zmeniť synchronizačné správanie sa police pre vybraných "
 "používateľov?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Naozaj chcete zmenit umiestnenie pre knižnicu Calibre?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Odmietnuť"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Povoliť"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "Zmazalo sa {} synchronizačných položiek"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Žetón sa nenašiel"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Štítok sa nenašiel"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Neplatná akcia"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json nie je nakonfiguraovaný pre webovú aplikáciu"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Umiestnenie denníkového súboru je neplatné, zadajte prosím správnu cestu"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Umiestnenie súbor denníka prístupov nie je platné, zadajte prosím správnu "
 "cestu"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 "Zadajte prosím poskytovateľa LDAP, port, DN a identifikátor používateľa"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Zadajte prosím konto a heslo pre LDAP službu"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "Zadajte prosím konto pre LDAP službu"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Filter pre LDAP objekt skupiny potrebuje jeden \"%s\" formátový identifikátor"
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "Filter pre LDAP objekt skupiny má nezhodu v zátvorkách"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Filter pre LDAP objekt používateľa potrebuje jeden \"%s\" formátový "
 "identifikátor"
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "Filter pre LDAP objekt používateľa má nezhodu v zátvorkách"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Filter pre LDAP členstvo používateľa potrebuje jeden \"%s\" formátový "
 "identifikátor"
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "Filter pre LDAP členstvo používateľa má nezhodu v zátvorkách"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -423,29 +416,24 @@ msgstr ""
 "LDAP CA-certifikát, certifikát alebo umiestnenie kľúča nie je platné. "
 "Zadajte prosím správnu cestu"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Pridať nového používateľa"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Upraviť nastavenie pre poštový server"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "Úspech! Gmail konto bolo verifikované."
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Chyba databázy: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -453,53 +441,53 @@ msgstr ""
 "Testovací e-mail bol zaradený na odoslanie na %(email)s, skontrolujte si "
 "výsledok v sekcii Úlohy"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Pri odosielaní testovacieho e-mailu sa vyskytla chyba: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Prosím, najskôr si nastavte e-mailovú adresu..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Nastavenia poštového servera boli aktualizované"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "Upraviť používateľov"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Najskôr nastavte poštový server, prosím..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "Prosím, najskôr si nastavte e-mailovú adresu..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "Na vašu e-mailovú adresu bolo odoslané nové heslo"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -507,7 +495,7 @@ msgstr ""
 "Testovací e-mail bol zaradený na odoslanie na %(email)s, skontrolujte si "
 "výsledok v sekcii Úlohy"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -516,926 +504,911 @@ msgstr ""
 "Testovací e-mail bol zaradený na odoslanie na %(email)s, skontrolujte si "
 "výsledok v sekcii Úlohy"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "Upraviť nastavenia naplánovaných úloh"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "Bol uvedený neplatný čas spustenia"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "Bol uvedený neplatný doba behu"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "Nastavenia naplánovaných úloh boli aktualizované"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Vyskytla sa neočakávaná chyba. Prosím, skúste to opäť neskôr."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "Názov"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Upraviť používateľa %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Úspech! Heslo pre používateľa %(user)s bolo resetované"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Nastavte prosím poštový server."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Prezerač denníkového súboru"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Žiadosť o aktualizačný balík"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Sťahuje sa aktualizačný balík"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Rozbaľuje sa aktualizačný balík"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Nahradzujú sa súbory"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Spojenia s databázou sú uzavreté"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Zastavuje sa server"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Aktualizácia dokončená, stlačte prosím OK a znovu načítajte stránku"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Aktualizácia zlyhala:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "HTTP chyba"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Chyba spojenia"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Časový limit pre naviazanie spojenia vypršal"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Všeobecná chyba"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr "Súbor aktualizácie nebolo možné uložiť do dočasného adresára"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "Nebolo možné nahradiť súbory počas aktualizácie"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "Extrakcia minimálne jedného LDAP používateľa zlyhala"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Vytvorenie minimálne jedného LDAP používateľa zlyhalo"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Chyba: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Chyba: Odpoveď LDAP servera neobsahuje žiadneho používateľa"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "Minimálne jeden LDAP používateľ sa nenachádza v databáze"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} používateľ bol naimportovaný"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr ""
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "Umiestnenie databáze nie je platné, zadajte prosím správnu cestu"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "Do databázy nie je možné zapisovať"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Umiestnenie súboru s kľúčmi nie je platné, zadajte prosím správnu cestu"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Umiestnenie súboru s certifikátmi nie je platné, zadajte prosím správnu cestu"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr "Heslo musí byť dlhé 1 až 40 znakov"
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "Nastavenia databáze boli aktualizované"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "Konfigurácia databázy"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Vyplňte prosím všetky polia."
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "E-mail nie je z platnej domény"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Pridať nového používateľa"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Používateľ '%(user)s' bol vytvorený"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "Účet s týmto menom alebo e-mailovou adresou už existuje."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Používateľ '%(nick)s' bol zmazaný"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "Nie je možné zmazať používateľa Hosť"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "Nezostáva žiadny používateľ, nie je možné odobrať rolu správcu"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "E-mailová adresa nemôže byť prázdna a musí byť platná"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Používateľ '%(nick)s' bol aktualizovaný"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr ""
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr ""
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Chyba spojenia"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr ""
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "Nie je dostupná informácia o vydaní"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr ""
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr ""
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr ""
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "Vyskytla sa neočakávaná chyba. Prosím, skúste to opäť neskôr."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "Chyba spojenia"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Chyba spojenia"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "Súbor %(file)s bol nahraný"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr ""
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr ""
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr ""
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr ""
 
-#: cps/constants.py:265
+#: cps/constants.py
 #, fuzzy
 msgid "Finnish"
 msgstr "Hotová"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr ""
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr ""
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr ""
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr ""
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr ""
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr ""
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr ""
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr ""
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr ""
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr ""
 
-#: cps/constants.py:276
+#: cps/constants.py
 #, fuzzy
 msgid "Polish"
 msgstr "Vydavateľ"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr ""
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr ""
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr ""
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr ""
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr ""
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr ""
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr ""
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr ""
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr ""
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr ""
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "nie je naištalované"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Chýba právo na vykonanie"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, fuzzy, python-format
 msgid "Change cover — %(title)s"
 msgstr "Vymeniť autora a názov"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Chyba spojenia"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr ""
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Book ID"
 msgstr "Knihy"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Názov knihy"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "Autor"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr ""
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "Súborové formáty"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filename"
 msgstr "meno"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr ""
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr ""
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "Formát nahrávania"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "Neznámy"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr ""
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "Neplatná rola"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "Zlúčiť vybrané knihy"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "Formát %(format)s sa nenachádza na disku"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB Fixer started for selected book."
 msgstr "Zlúčiť vybrané knihy"
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr ""
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr ""
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid image data format."
 msgstr "Neplatný formát poštovej adresy"
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Profile picture updated successfully."
 msgstr "Zmazaných {} používateľov"
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Žiadne"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "Zmazať knihu"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "Zmazať knihu"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "Zmazať knihu"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "Nič sa nenašlo"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 #, fuzzy
 msgid "Invalid resolution strategy"
 msgstr "Neplatná rola"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Nahrávanie ukončené, spracováva sa, počkajte prosím..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 #, fuzzy
 msgid "Failed to queue upload for processing"
 msgstr "Vytváranie cesty k obálke knihy zlyhalo"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Chýba zdrojový alebo cieľový formát pre prevod"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "Kniha bola úspešne zaradená na prevod do %(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Vyskytla sa chyba pri prevode tejto knihy: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 #, fuzzy
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "Prípona súboru '%(ext)s' nemôže byť nahraná na tento server"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr "Prípona súboru '%(ext)s' nemôže byť nahraná na tento server"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "Súbor ktorý sa má nahrať musí mať príponu"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 "Vybraná kniha nie je dostupná. Súbor neexistuje alebo sa k nemu nedá "
 "pristupovať"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "Používateľ nemá práva nahrať obálku knihy"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 "Identifikátory nerozlišujú malé a veľké písmená, prepisuje sa starý "
 "identifikátor"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "'%(langname)s' nie je platný jazyk"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Metadáta boli úspešne aktualizované"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "Chyba pri úprave knihy: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Neznámy"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1443,96 +1416,96 @@ msgstr ""
 "Nahrávaná kniha pravdepodobne existuje v knižnici, zvážte zmenu pred "
 "nahraním novej: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "Súbor %(filename)s nebolo možné uložiť do dočasného adresára"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Zlyhal presun súboru obalky %(file)s: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Kniha s formátom bola úspešne zmazaná"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Kniha bola úspešne zmazaná"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "Nemáte oprávnenia na mazanie kníh"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "upraviť metadáta"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "%(seriesindex)s nie je platné číslo, preskakuje sa"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr "Používateľ nemá práva na nahranie dodatočných súborových formátov"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Nebolo možné vytvoriť cestu %(path)s (Povolenie zamietnuté)."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Zlyhalo uloženie súboru: %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Súborový formát %(ext)s bol pridaný k %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Žetón sa nenašiel"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "Formát %(format)s sa nenachádza na disku"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1540,7 +1513,7 @@ msgstr ""
 "Nastavenie Google Drive nie je dokončené, skúste deaktivovať a znovu "
 "aktivovať Google Drive"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1548,99 +1521,98 @@ msgstr ""
 "Doména spätného volania nie je verifikovaná, prosím, vykonajte kroky na "
 "verifikáciu domény v konzole Google vývojára"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "Formát %(format)s sa nenašiel pre knihu s ID: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(format)s sa nenašiel na Google Drive: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s sa nenašiel: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "Poslať do čítačky"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "Formát %(format)s sa nenašiel pre knihu s ID: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "Formát %(format)s sa nenašiel pre knihu s ID: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 msgid "Test Email"
 msgstr "Testovací e-mail"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Registračný e-mail pre používateľa: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Previesť %(orig)s na %(format)s a odoslať do čítačky"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Odoslať %(format)s do čítačky"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s odoslaná do čítačky"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "Požadovaný súbor sa nedá čítať. Možne zlé oprávnenia?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "Status čítania nie je možné nastaviť: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
 msgstr ""
 "Mazanie zložky pre knihu %(id)s zlyhalo, cesta má vnorené adresáre: %(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "Mazanie knihy %(id)s zlyhalo: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1649,70 +1621,70 @@ msgstr ""
 "Mazanie knihy %(id)s iba z databázy, cesta ku knihe v databáze nie je "
 "platná: %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Premenovanie autora z: '%(src)s' na '%(dest)s' zlyhalo s chybou: %(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Súbor %(file)s sa nenašiel na Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Zmena názvu knihy z: '%(src)s' na '%(dest)s' zlyhalo s chybou: %(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Cesta ku knihe %(path)s sa nenašla na Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr "Pre túto poštovú adresu sa našiel existujúci účet"
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Toto meno používateľa sa už používa"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr "Neplatný formát poštovej adresy"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr "Heslo nedodržiava pravidlá validácie"
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 "Python modul 'advocate' nie je nainštalovaný ale je potrebný pre nahrávanie "
 "obálok kníh"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Chyba pri sťahovaní obálky knihy"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr "Súbor obálky knihy nie je platný súbor s obrázkom alebo nie je uložený"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Chyba formátu obálky knihy"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
@@ -1720,133 +1692,133 @@ msgstr ""
 "Nemáte povolené pristupovať na lokálneho hostiteľa alebo lokálnu sieť na pre "
 "nahrávanie obálok kníh"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Vytváranie cesty k obálke knihy zlyhalo"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "Ako súbor obálky knihy sú podporované iba súbory jpg/jpeg/png/webp/bmp"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "Neplatný obsah súboru obalky knihy"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Ako súbor obálky knihy sú podporované iba súbory jpg/jpeg"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr "Obálka knihy"
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "Binárny súbor pre UnRar sa nenašiel"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr "Chyba pri spustení UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr ""
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr ""
 
-#: cps/helper.py:2125
+#: cps/helper.py
 #, fuzzy
 msgid "Calibre binaries not viable"
 msgstr "Do databázy nie je možné zapisovať"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Chýba právo na vykonanie"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing Calibre"
 msgstr "Chyba pri spustení UnRar"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr "Zaradiť všetky knihy na zálohovanie metadát"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Nastavenie Kobo"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Zaregistrovať s %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "Poštový server nie je nastavený, kontaktujte prosím správcu."
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1854,35 +1826,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "Úspech! Teraz ste prihlásený ako: %(nickname)s"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Spojenie na %(oauth)s bolo úspešné"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1890,4139 +1862,4071 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr "Poštový server nie je nastavený, kontaktujte prosím správcu."
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "Odpojenie z %(oauth)s bolo úspešné"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Odpojenie z %(oauth)s zlyhalo"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "Nie je pripojený k %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Prihlásenie na GitHub zlyhalo."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Získanie používateľa z GitHub-u zlyhalo."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Prihlásenie na Google zlyhalo."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Získanie používateľa z Google zlyhalo."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "Failed to log in with Generic OAuth."
 msgstr "Prihlásenie na GitHub zlyhalo."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "Chyba GitHub OAuth, skúste to prosím neskôr."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "Chyba GitHub OAuth: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Chyba Google OAuth, skúste to prosím neskôr."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Chyba Google OAuth: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, fuzzy, python-brace-format
 msgid "OAuth error: {}"
 msgstr "Chyba GitHub OAuth: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "Knihy podľa abecedy"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "Knihy zotriedené podľa abecedy"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Horúce knihy"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "Populárne publikácie z tohoto katalógu založené na počte stiahnutí."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Najlepšie hodnotené knihy"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Populárne publikácie z tohoto katalógu založené na hodnotení."
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "Stiahnuté knihy"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Najnovšie knihy"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Náhodné knihy"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Zobraziť náhodné knihy"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Prečítané knihy"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Aktuálna verzia"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Neprečítané knihy"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Autori"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Knihy usporiadané podľa autora"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Vydavatelia"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Knihy usporiadané podľa vydavateľa"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Kategórie"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Knihy usporiadané podľa kategórie"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Série"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Knihy usporiadané podľa série"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Jazyky"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Knihy usporiadané podľa jazyka"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Hodnotenia"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Knihy usporiadané podľa hodnotenia"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Súborové formáty"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Knihy usporiadané podľa súborových formátov"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Police"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "Knihy organizované v policiach"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Synchronizovať vybrané police s Kobo"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Knihy organizované v policiach"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "Popis"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} Hviezdičiek"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Hľadať"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Prihlásiť sa"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Žetón sa nenašiel"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Žetón expiroval"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Úspech! Vráťte sa k vašemu zariadeniu"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Knihy"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Zobraziť nedávno čítané knihy"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Zobraziť horúce knihy"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Stiahnuté knihy"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Zobraziť stiahnuté knihy"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Zobraziť najlepšie hodnotené knihy"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 msgid "Show Read and Unread"
 msgstr "Zobraziť prečítané a neprečítané"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Zobraziť neprečítané"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Objaviť"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Category Section"
 msgstr "Zobraziť časť Kategórie"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Series Section"
 msgstr "Zobraziť časť Série"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Author Section"
 msgstr "Zobraziť časť Autori"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Publisher Section"
 msgstr "Zobraziť časť vydavatelia"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Language Section"
 msgstr "Zobraziť časť Jazyky"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Ratings Section"
 msgstr "Zobraziť časť Hodnotenia"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show File Formats Section"
 msgstr "Zobraziť časť Súborové formáty"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Archivované knihy"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Archived Books"
 msgstr "Zobraziť archivované knihy"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Zoznam kníh"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Zobraziť zoznam kníh"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr ""
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Zobraziť najlepšie hodnotené knihy"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Vydané po "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Vydané pred "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Hodnotenie <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Hodnotenie >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, fuzzy, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Status čítania = %(status)s"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 "Chyba pri čítaní používateľom definovaných stĺpcov, reštartujte prosím "
 "Calibre-Web"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Rozšírené hľadanie"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Vybraná neplatná polica"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "Ľutujeme, do tejto police nemôžete pridať knihu"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "Kniha je už na polici: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "Kniha bola pridaná do police: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "Nemáte povolené pridať knihu do tejto police"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Táto polica už obssahuje knihu: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "Do police sa pridala kniha: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Nemôžem pridať knihu do police: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "Vybraná neplatná polica"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Nemôžem pridať knihu do police: %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Táto polica už obssahuje knihu: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "Do police sa pridala kniha: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "Kniha bola odstránená z police: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "Ľutujeme, ale nie ste oprávnený odstrániť knihu z tejto police"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Vytvoriť policu"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Ľutujeme, ale nie ste oprávnený upravovať túto policu"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Upraviť policu"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "Chyba pri mazaní police"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "Polica bol úspešne vymazaná"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Zmeniť poradie police: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "Ľutujeme, ale nie ste oprávnený vytvoriť verejnú policu"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Polica %(title)s bola vytvorená"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Polica %(title)s bola zmenená"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Nastala chyba"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "Verejná polica s názvom '%(title)s' už existuje."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "Súkromná polica s názvom '%(title)s' už existuje."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Polica: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Chyba pri otváraní police. Polica neexistuje alebo je neprístupná"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Vylúčiť police"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Anonymný"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Neautentifikovaný"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Áno"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Nie"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Stav čítania"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Téma"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Svetlé"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Tmavé"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "Sépia"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Pridať do police"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Autor"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Prechádzať"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Zatvoriť"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Zmazať"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Zlúčiť"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Vydavateľ"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Čítať"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Názov"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Nahrať"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Účet"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Správca"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Vydané"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Zdroj"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "O programe"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Archivovaný"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "Previesť"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Popis"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Stiahnuť"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Upraviť"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "E-mail"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Povoliť synchronizáciu Kobo"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Šifrovanie"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "Skryť"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Identifikátory"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Jazyk"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Heslo"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Pokrok"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Hodnotenie"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Uložiť"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "Vybrať"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Stav"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Značka"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Úloha"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Úlohy"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Používateľ"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Meno používateľa"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Zobraziť"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Čakajúca"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Neúspešná"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Spustená"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Hotová"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "Ukončená"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "Zrušená"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Neznámy stav"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Čítanie aktualizačnej informácie narazilo na neočakávané údaje"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr ""
 "Nie je dostupná žiadna aktualizácia. Máte nainštalovanú najnovšiu verziu"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6030,17 +5934,17 @@ msgstr ""
 "Je dostupná nová aktualizácia. Ak chcete aktualizovať na najnovšiu verziu, "
 "kliknite na tlačidlo dolu."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Nebolo možné stiahnuť aktualizačnú informáciu"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr ""
 "Ak chcete aktualizovať na najnovšiu stabilnú verziu, kliknite na tlačidlo "
 "dolu."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6049,265 +5953,263 @@ msgstr ""
 "Je dostupná nová aktualizácia. Kliknite na tlačidlo dolu, ak chcete "
 "aktualizovať na verziu: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Nie je dostupná informácia o vydaní"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Objaviť (Náhodné knihy)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Horúce knihy (Najviac sťahované)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "Knihy stiahnuté: %(user)s"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Author: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Vydavateľ: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Série: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "Hodnotenie: Žiadne"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Hodnotenie: %(rating)s hviezdičiek"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Súborový formát: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Kategória: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Jazyk: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Horúce knihy"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Skryté chyby"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "Chyba pri mazaní police"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "Neplatný formát poštovej adresy"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 #, fuzzy
 msgid "Invalid request"
 msgstr "Neplatná rola"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr ""
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 #, fuzzy
 msgid "Error creating shelf"
 msgstr "Chyba pri mazaní police"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Vytvoriť policu"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 #, fuzzy
 msgid "Shelf name is required"
 msgstr "Toto pole je povinné"
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "Chyba pri mazaní police"
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "Upraviť policu"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "Používateľ sa nenašiel"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "Zmazaných {} používateľov"
 
-#: cps/web.py:1710
+#: cps/web.py
 #, fuzzy
 msgid "Error duplicating shelf"
 msgstr "Chyba pri mazaní police"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 #, fuzzy
 msgid "Error deleting shelf"
 msgstr "Chyba pri mazaní police"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "Chyba pri mazaní police"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 #, fuzzy
 msgid "Error unhiding shelf"
 msgstr "Chyba pri mazaní police"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Stiahnutia"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Zoznam súborových formátov"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Najskôr nastavte poštový server, prosím..."
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr "Nastavte vo vašom profile platnú e-mailovú adresu pre vašu čítačku."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "Úspech! Kniha bola zaradená na odoslanie do %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Vyskytla sa chyba pri posielaní knihy: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "Úspech! Kniha bola zaradená na odoslanie do %(eReadermail)s"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr "Počkajte, prosím minútku pred registráciou ďalšieho používateľa"
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Registrovať"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 #, fuzzy
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr "Poštový server nie je nastavený, kontaktujte prosím správcu."
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr "Poštový server nie je nastavený, kontaktujte prosím správcu."
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "Vaša e-mailová adresa nie je povolená."
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "Úspech! Potvrdzujúci e-mail bol odoslaný."
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
@@ -6315,42 +6217,42 @@ msgid ""
 msgstr ""
 "Inštancia Calibre-Web nie je nastavené, kontaktujte prosím vašeho správcu"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "Poštový server nie je nastavený, kontaktujte prosím správcu."
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr "Nie je možné aktivovať LDAP autentifikáciu"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr "Počkajte, prosím minútku pred opätovným prihlásením"
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "ste prihlásený ako: '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "Úspech! Teraz ste prihlásený ako: %(nickname)s"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
@@ -6358,13 +6260,13 @@ msgid ""
 msgstr ""
 "Inštancia Calibre-Web nie je nastavené, kontaktujte prosím vašeho správcu"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6373,706 +6275,676 @@ msgstr ""
 "Záložné prihlásenie ako: '%(nickname)s', LDAP server je nedostupný alebo "
 "používateľ je neznámy"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr "Nemôžem prihlásiť: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 msgid "Wrong Username or Password"
 msgstr "Nesprávne používateľské meno alebo heslo"
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr "Na vašu e-mailovú adresu bolo odoslané nové heslo"
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr "Vyskytla sa neočakávaná chyba. Prosím, skúste to opäť neskôr."
 
-#: cps/web.py:2838
+#: cps/web.py
 msgid "Please enter valid username to reset password"
 msgstr "Na resetovanie hesla zadajte platné používateľské meno"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "Teraz ste prihlásený ako: '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 msgid "Success! Profile Updated"
 msgstr "Úspech! Profil bol aktualizovaný"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "Účet s touto e-mailovou adresou už existuje."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 #, fuzzy
 msgid "Invalid book ID."
 msgstr "Neplatná rola"
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr ""
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "Nenašiel sa súbor gmail.json s OAuth informáciou"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "%(book)s odoslaná do čítačky"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "Poslať do čítačky"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-send completed successfully"
 msgstr "Zmazaných {} používateľov"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr ""
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr ""
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s bol odoslaný do čítačky"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Nástroj pre prevod ebook-convert %(tool)s sa nenašiel"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "Formát %(format)s sa nenachádza na disku"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "Prevádzač e-kníh zlyhal s neznámou chybou"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Prevádzač Kepubify zlyhal: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "Prevádzaný súbor sa nenašiel alebo viac ako jeden súbor v zložke %(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre zlyhal s chybou: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Prevádzač e-kníh zlyhal: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Spojenie s databázou sa znovu naväzuje"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "Zmazať knihu"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Zmazať knihu"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Rozbaľuje sa aktualizačný balík"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Nič sa nenašlo"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Povoliť synchronizáciu Kobo"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "E-mail"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr "Zálohovať metadáta"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "V knižnici"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "Bolo vygenerovaných %(count)s náhľadov obálok kníh"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "Náhľad obálky knihy"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "Bolo vygenerovaných {0} náhľadov pre série"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "Vyrovnávacia pamäť pre obálky kníh sa vyprázdňuje"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "Knihy organizované v policiach"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Zmeniť heslo"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Vytvoriť policu"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "Bezpečnostné nastavenia"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Nastavenia"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "vybrať možnosť"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "Pridať do police"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Verejné)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "Stiahnutia"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Stiahnutia"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "Triediť podľa dátumu knihy, najnovšie najskôr"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "Triediť podľa dátumu knihy, najstaršie najskôr"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Autor"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Autor"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Vydané pred "
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Vydané pred "
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Triediť podľa dátumu knihy, najnovšie najskôr"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "Triediť podľa dátumu knihy, najstaršie najskôr"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "Poslať na e-mail čítačky"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "Poslať do čítačky"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Zobraziť knihy"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Verejná polica"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr ""
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "Importovať LDAP používateľov"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Nastavenia poštového servera"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "SMTP hostiteľ"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "SMTP port"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "SMTP prihlásenie"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Z poštovej adresy"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr "Poštová služba"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "GMail skrz OAuthľ"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Adresár databázy Calibre"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Úroveň denníka"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Externý port"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Kníh na stránku"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Nahrávania"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Anonymné prezeranie"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Verejná registrácia"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Vzdialené prihlásenie Magic Link"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Prihlásenie na reverznú proxy"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Meno hlavičky pre reverznú proxy"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Upraviť základnú konfiguráciu"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Upraviť konfiguráciu používateľského rozhrania"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Upraviť configuráciu databázy Calibre"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "Naplánované úlohy"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "Začiatok"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "Maximálne trvanie"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "Generovať náhľady obálok pre série"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Znovu naviazať spojenie s Calibre databázou"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr "Vygenerovať záložné súbory pre metadáta"
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "Obnoviť vyrovnávaciu pamäť pre náhľady"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Setup KOReader Sync"
 msgstr "čítačka epub"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr ""
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Správa"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Stiahnuť ladiaci balík"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Zobraziť denníky"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Reštart"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Vypnúť"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "Informácia o verzii"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Verzia"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Detaily"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "Aktualizácia zlyhala:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Aktualizovať kanál"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Aktuálna verzia"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Kontrola aktualizácie"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Vykonať aktualizáciu"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Skutočne chcete reštartovať?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "V poriadku"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Skutočne chcete vypnúťť?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Aktualizuje sa, neskúšajte znovu načítať stránku"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7080,614 +6952,591 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Knihy v tejto knižnici"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Nahráva sa..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "Aktualizácia zlyhala:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Chyba spojenia"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Série: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "cez"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "V knižnici"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "znížiť"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Viac od"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Zmazať knihu"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Zmazať formáty:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Previesť knihu s formátom:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Previesť z:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr "vybrať možnosť"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Previesť do:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Previesť knihu"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Chyba"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Formát nahrávania"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "ID série"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Dátum vydania"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Typ identifikátora"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Hodnota identifikátora"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Odstrániť"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Pridať identifikátor"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr "Načítať obálku z URL (JPEG-obrázok sa stiahne a uloží v databáze)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Nahrať obálku knihy z miestneho disku"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "Povoliť synchronizáciu Kobo"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Zobraziť knihu pri ukladaní"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Načítať metadáta"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Kľúčové slovo"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "Vyhľadať kľúčové slovo"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Načítava sa..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Chyba pri vyhľadávaní!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "Nič sa nenaslo! Skúste, prosím iné kľúčové slovo."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "Toto pole je povinné"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 #, fuzzy
 msgid " Exchange author & title"
 msgstr "Vymeniť autora a názov"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "Vytvoriť policu"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr ""
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Update Title Sort automatically  "
 msgstr "Automaticky aktualizovať triedenie podľa názvu"
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Automaticky aktualizovať triedeni podľa autora"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Zadajte názov"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Zadajte triedenie podľa názvu knihy"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Triedenie podľa názvu knihy"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Zadajte triedenie podľa autora knihy"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Triedenie podľa autora knihy"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Zadajte autorov"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Zadajte kategórie"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Zadajte série"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Zadajte jazyky"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Dátum vydania"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Zadajte vydavateľov"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Zadajte komentáre"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Comments"
 msgstr "Komentáre"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Archived?"
 msgstr "Archivovaný"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Read?"
 msgstr "Čítať"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "Zadať "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Naozaj to chcete?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "Kniha z názvom bude zlúčená s:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "Na knihu s názvom:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr ""
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr ""
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr ""
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr ""
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr ""
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Upraviť metadáta"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "Vytvoriť policu"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr ""
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Pridať"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr "Poštový server nie je nastavený, kontaktujte prosím správcu."
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 #, fuzzy
 msgid "Message"
 msgstr "Zlúčiť"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Na vašu e-mailovú adresu bolo odoslané nové heslo"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Poslať do čítačky"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Naspäť"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Umiestnenie databázy Calibre"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7703,13 +7552,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7720,7 +7569,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7731,43 +7580,43 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr ""
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
 "can be wherever you desire"
 msgstr ""
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Používať Google Drive?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Autentifikovať Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Calibre zložka na Google Drive"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "ID kanála na sledovanie metadát"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Zrušiť"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Znovu naviazať spojenie s Calibre databázou"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7777,133 +7626,133 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "Skutočne chcete vypnúťť?"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Znovu naviazať spojenie s Calibre databázou"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr "Nové umiestnenie databáze nie je platné, zadajte prosím správnu cestu"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Použiť štandardnú autentifikáciu"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Použiť LDAP autentifikáciu"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Použiť OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Konfigurácia servera"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Port servera"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Umiestnenie SSL certifikačného súboru (ponechať prázdne pre nie-SSL servery)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "Umiestnenie SSL súboru s kľúčom (ponechať prázdne pre nie-SSL servery)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Aktualizovať kanál"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Stabilný"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Nočný"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "Hostitelia s dôverou (oddelené čiarkou)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Konfigurácia súboru denníka"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr ""
 "Umiestnenie a meno denníkového súboru pre prístup (access.log keď nezadané)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Povoliť denník pristupu"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr ""
 "Umiestnenie a meno denníkového súboru pre prístup (access.log keď nezadané)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "Konfigurácia servera"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 "Previesť neanglické znaky v názve a mene autora počas ukladania na disk"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Povoliť nahrávanie"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr "(Zaistite, prosím, že používateľ má tiež právo nahrávať)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Povolené formáty pre nahrávanie"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Povoliť anonymné prechádzanie"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Povoliť verejnú registráciu"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "Použiť e-mailovú adresu ako meno používateľa"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Povoliť vzdialené prihlasovanie Magic Link"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7911,154 +7760,154 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Proxy neznáme žiadosti na obchod Kobo"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Externý port servera (pre portovo preposielané API volania)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Použiť Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Goodreads API kľúč"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Hardcover Sync"
 msgstr "Povoliť synchronizáciu Kobo"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "Žetón expiroval"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Goodreads API kľúč"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8066,421 +7915,421 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Povoliť reverznú proxy autentifikáciu"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Typ prihlásenia"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "Hostiteľské meno alebo IP adresa LDAP servera"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "Port LDAP servera"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "LDAP šifrovanie"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Cesta k LDAP CA-certifikátu (potrebná iba pre autentifikáciu certifikátom "
 "klienta)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Cesta k LDAP certifikátu (potrebná iba pre autentifikáciu certifikátom "
 "klienta)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Cesta k LDAP súboru kľúča (potrebná iba pre autentifikáciu certifikátom "
 "klienta)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "LDAP autentifikácia"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Jednoduchý"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "Meno používateľa pre LDAP správcu"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "Heslo pre LDAP správcu"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "LDAP rozlišovacie meno (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "Filter pre LDAP objekt používateľa"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "LDAP server je OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr "Pre import používateľa sú potrebné nasledovné nastavenia"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "Filter pre LDAP objekt skupiny"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "Meno LDAP skupiny"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "Pole členov LDAP skupiny"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "Detekcia filtra pre LDAP členstvo používateľa"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "Automatická detekcia"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "Filter používateľa"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "Filter pre LDAP členstvo požívateľa"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "Načítať metadáta"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
 msgstr ""
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "Upraviť konfiguráciu používateľského rozhrania"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "Žetón sa nenašiel"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "Chyba spojenia"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "Nastavenia OAuth"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Id"
 msgstr "%(provider)s OAuth klientské ID"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Secret"
 msgstr "%(provider)s OAuth klientské tajomstvo"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "Zobraziť konfiguráciu"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "Meno používateľa"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr ""
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "Poštová služba"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr ""
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "Meno LDAP skupiny"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr ""
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Predvolené nastavenia pre nových používateľov"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Povoliť sťahovanie"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Povoliť zobrazovač e-knihy"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Povoliť nahrávanie"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Povoliť úpravu"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Povoliť mazanie kníh"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Povoliť zmenu hesla"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Povoliť úpravu verejných políc"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr ""
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Získať OAuth prístupové údaje pre %(provider)s"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "%(provider)s OAuth klientské ID"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "%(provider)s OAuth klientské tajomstvo"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Externé binárky"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Path to Calibre Binaries"
 msgstr "Cesta k Calibre prevádzaču e-kníh"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Calibre E-Book Converter Settings"
 msgstr "Nastavenie Calibre prevádzača e-kníh"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Cesta Kepubify prevádzaču e-kníh"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "Binárny súbor pre UnRar sa nenašiel"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 msgid "Security Settings"
 msgstr "Bezpečnostné nastavenia"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8488,338 +8337,333 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr "Obmedziť neúspešné pokusy o prihlásenie"
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr ""
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr ""
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Session protection"
 msgstr "Ochrana sedenia"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr "Základná"
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr "Silná"
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 msgid "User Password policy"
 msgstr "Zásady pre používateľské heslá"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr "Minimálna dĺžka hesla"
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr "Vyžadovať číslo"
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr "Vyžadovať malé písmená"
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr "Vyžadovať veľké písmená"
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr "Vyžadovať špeciálne znaky"
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Zobraziť konfiguráciu"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Počet kníh na náhodné zobrazenie"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr "Počet autorov na zobrazenie pred ukrytím (0=Zakázať ukrývanie)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "Zmazať"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "tmavá téma caliBlur!"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Regulárny výraz pre ignorované stĺpce"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Prepojiť stav Prečítané/Neprečítané do Calibre stĺpca"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "Prepojiť stav Prečítané/Neprečítané do Calibre stĺpca"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Zobraziť obmedzenia založené na Calibre stĺpcoch"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Regulárny výraz pre triedenie podľa názvu knihy"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Zobraziť konfiguráciu"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Custom CSS"
 msgstr "Filter používateľa"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Predvolené nastavenia pre nových používateľov"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "Verzia"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Používateľ Správca"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "Zobrazenie na jednej stránke"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "Predvolený jazyk"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "Predvolené nastavenia pre nových používateľov"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "Predvolené viditeľné jazyky pre knihy"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "Predvolené viditeľnosti pre nových používateľov"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Predvolené viditeľnosti pre nových používateľov"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Ukázať náhodné knihy v detailnom zobrazení"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Pridať Povolené/Zakázané značky"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Pridať Povolené/Zakázané používateľom definované hodnoty stĺpca"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Nahrať"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "Archivovaný"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "Stiahnuť"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Začať"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8828,14 +8672,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8843,96 +8687,95 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "Zlúčiť vybrané knihy"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "Zmazaných {} používateľov"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "Chyba pri mazaní police"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "Nič sa nenašlo"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "Upraviť meno používateľa"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "Prehľadávať knižnicu"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "Vytvoriť policu"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "Zlúčiť vybrané knihy"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "Chyba pri mazaní police"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Calibre-Web denník: "
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8940,11 +8783,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -8955,11 +8798,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -8969,162 +8812,162 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "Archivované knihy"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9132,11 +8975,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9144,110 +8987,108 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "Metadáta boli úspešne aktualizované"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identifikátory"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "Obálka knihy"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
 "investigation."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9255,157 +9096,157 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Nastavenia OAuth"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "Nastavenia"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "Nastavenia OAuth"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9413,103 +9254,102 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Synchronizovať vybrané police s Kobo"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Nastavenia OAuth"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9517,44 +9357,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Previesť knihu s formátom:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9562,871 +9402,859 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Povoliť verejnú registráciu"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Nastavenia OAuth"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Povoliť verejnú registráciu"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Povoliť verejnú registráciu"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Zmazať formáty:"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Načítať metadáta"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Hodnotenie"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Ďalší"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Označiť ako neprečítané"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Označiť ako prečítané"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "Označiť ako neprečítané"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "Označiť ako neprečítané"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Pridať do archívu"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Obnoviť z archívu"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Obnoviť z archívu"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Pridať do archívu"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "Obnoviť z archívu"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "Prehľadávať knižnicu"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "Nastavenia databáze boli aktualizované"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "Hodnotenie lepšie ako"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "Kniha %(index)s z %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 #, fuzzy
 msgid "File sizes"
 msgstr "Veľkosť písma"
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Popis:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "Poslať na e-mail čítačky"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "Poslať na e-mail čítačky"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "Vytvoriť policu"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "Zmazať formáty:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "Vytváranie cesty k obálke knihy zlyhalo"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "Vytváranie cesty k obálke knihy zlyhalo"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr ""
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Zmazať knihu"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "Zobraziť najlepšie hodnotené knihy"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "Vybrať"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "Zlúčiť vybrané knihy"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Zmazať knihu"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "Predchádzajúci"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "Zlúčiť vybrané knihy"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "Detailu o knihe"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "upraviť metadáta"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "Zlúčiť vybrané knihy"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "Nič sa nenašlo"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr ""
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Zmazať formáty:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be permanently deleted:"
 msgstr "Táto kniha bude navždy vymazaná z databázy"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "Neprečítané knihy"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "Táto kniha bude navždy vymazaná z databázy"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "Táto kniha bude navždy vymazaná z databázy"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr ""
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr ""
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr ""
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "Typ e-mailového účtu"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr "Štandardný e-mailový účet"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr "Gmail účet"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr "Nastaviť Gmail účet"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Zrušiť Gmail účet"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "SMTP heslo"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Limit pre veľkosť prílohy"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 msgid "Save and Send Test Email"
 msgstr "Uložiť a poslať testovací e-mail"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Povolené domény (Biely zoznam)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Pridať doménu"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Zadajte doménové meno"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Zakázané domény (Čierny zoznam)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10434,162 +10262,153 @@ msgstr ""
 "Otvoriť súbor .kobo/Kobo/Kobo eReader.conf v textovom editore a pridať "
 "(alebo upraviť):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Kobo žetón:"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "Zoznam"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "Vytvoriť policu"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "Vyhľadať výraz:"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "Zobraziť knihu pri ukladaní"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "Vytvoriť policu"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "Načítava sa..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
 msgstr "Naozaj chcete zmeniť vybrané role pre vybraných používateľov?"
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "Vytváranie cesty k obálke knihy zlyhalo"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr "Naozaj chcete zmeniť vybrané role pre vybraných používateľov?"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "Vytvoriť policu"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "Vytváranie cesty k obálke knihy zlyhalo"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
@@ -10597,422 +10416,421 @@ msgid ""
 msgstr ""
 "Inštancia Calibre-Web nie je nastavené, kontaktujte prosím vašeho správcu"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Vytvoriť hlásenie problému"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Návrat domov"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "Odhlásiť používateľa"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "Upraviť policu"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show this shelf in your sidebar"
 msgstr "Synchronizovať túto policu so zariadením Kobo"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "Zobraziť všetko"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "Verejná polica"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Pridať do police"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Domov"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Prepnúť navigáciu"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Prehľadávať knižnicu"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Katalóg e-kníh Calibre-Web"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Odhlásiť sa"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "Nastavenia"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "Prehľadávať knižnicu"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Nie je dostupná informácia o vydaní"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Katalóg e-kníh Calibre-Web"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Zmazať knihu"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Prosím, neskúšajte znovu načítať stránku"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Vytvoriť policu"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Predchádzajúci"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Detailu o knihe"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Skutočne chcete vypnúťť?"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Zlúčiť vybrané knihy"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Formát nahrávania"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Zmazať formáty:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Zmazať knihu"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nič sa nenašlo"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Zmeniť mierku na najlepšie"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "Do:"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfigurácia"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Pridať do police"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Zlúčiť vybrané knihy"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Označiť ako neprečítané"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Zmazať knihu"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Zmazať knihu"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Vytvoriť policu"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Chyba spojenia"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr ""
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "Mriežka"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "SMTP heslo"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Zapamätať si ma"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Zabudli ste heslo?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Prihlásiť sa cez Magic Link"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 #, fuzzy
 msgid "Log in with SSO"
 msgstr "Prihlásiť sa cez Magic Link"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Ukázať Calibre-Web denník "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Calibre-Web Log: "
 msgstr "Ukázať Calibre-Web denník "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Prúdový výstup, nedá sa zobraziť"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Ukázať denník prístupu: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Stiahnuť Calibre-Web denník"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "Stiahnuť denník prístupu"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "Zdieľať s kýmkoľvek"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Vybrať Povolené/Zakázané značky"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Vybrať Povolené/Zakázané používateľom definované hodnoty stĺpca"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Vybrať Povolené/Zakázané značky pre používateľa"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr ""
 "Vybrať Povolené/Zakázané používateľom definované hodnoty stĺpca pre "
 "používateľa"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Zadať štítok"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Pridať obmedzenie zobrazenia"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "Tento formát knihy bude navždy vymazaný z databázy"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Táto kniha bude navždy vymazaná z databázy"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "a pevný disk"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Dôležitá poznámka pre Kobo: zmazané knihy zostanú na každom spárovanom Kobo "
 "zariadení."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11020,574 +10838,570 @@ msgstr ""
 "Kniha musí byť najskôr archivovaná a zariadenie synchronizované pred tým než "
 "môže byť kniha bezpečne zmazaná."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Vyberte umiestnenie súboru"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "typ"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "meno"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "veľkosť"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "Rodičovský adresár"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "Ok"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Katalóg e-kníh Calibre-Web"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "čítačka epub"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "Akcie"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "Čierne"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "Veľkosť písma"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Nasledujúca stránka"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr ""
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 #, fuzzy
 msgid "Default"
 msgstr "Zmazať"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr ""
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr ""
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 #, fuzzy
 msgid "KaiTi"
 msgstr "Čakajúca"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 #, fuzzy
 msgid "Arial"
 msgstr "Vertikálne"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 #, fuzzy
 msgid "Spread"
 msgstr "Čítať"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 #, fuzzy
 msgid "Two columns"
 msgstr "Neplatný stĺpec na čítanie"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 #, fuzzy
 msgid "One column"
 msgstr "Neplatný stĺpec na čítanie"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Preformátovať text keď sú otvorené bočné panely."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Čítačka komiksov"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Klávesové skratky"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Predchádzajúca stránka"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Nasledujúca stránka"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 msgid "Single Page Display"
 msgstr "Zobrazenie na jednej stránke"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr "Zobrazenie dlhý pás"
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Zmeniť mierku na najlepšie"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Zmeniť mierku na šírku"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Zmeniť mierku na výšku"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Zmeniť mierku na prirodzenú"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Otočiť doprava"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Otočiť doľava"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Prevrátiť obrázok"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "Zobraziť"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 msgid "Single Page"
 msgstr "Jedna stránka"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr "Dlhý pás"
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Mierka"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Najlepšie"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Na výšku"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Na šírku"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Prirodzené"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Otočiť"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Prevrátiť"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Horizontálne"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Vertikálne"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Direction"
 msgstr "Popis"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Zľava doprava"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Sprava doľava"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr "Resetovať na vrch"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 msgid "Remember Position"
 msgstr "Zapamätať si pozíciu"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "Posúvatko"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "Ukázať"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "DJVU čítačka"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "PDF čítačka"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "textová čítačka"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Registrovať nový účet"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Vyberte si meno používateľa"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Váš e-mail"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Magic Link - Autorizovať nové zariadenie"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "Na inom zariadení, prihlásiť sa a navštíviť:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "Po verifikácii budete automaticky prihlásený na tomto zariadení."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Toto verifikačné prepojenie expiruje za 10 minút."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "Vygenerovať náhľady obálok kníh pre série"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Nič sa nenašlo"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Vyhľadať výraz:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Výsledky pre:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Dátum vydania od"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Dátum vydania do"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr ""
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Vylúčiť značky"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Vylúčiť série"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "Vylúčiť police"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Vylúčiť jazyky"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Rozšírenia"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Vylúčiť rozšírenia"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Hodnotenie lepšie ako"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Hodnotenie horšie ako"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "Od:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "Do:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Zmazať túto poličku"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "Upraviť vlastnosti police"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Skryté chyby"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "Usporiadať knihy manuálne"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "Znemožniť zmenu poradia"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "Povoloť zmenu poradia"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Zlúčiť vybrané knihy"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Účet"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Žetón sa nenašiel"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Zmazať túto poličku"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Pridať do police"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Prehľadávať knižnicu"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Prehľadávať knižnicu"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Zdieľať s kýmkoľvek"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "Synchronizovať túto policu so zariadením Kobo"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Používateľ sa nenašiel"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Skryté chyby"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Štatistiky police"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Knihy v tejto knižnici"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Autori v tejto knižnici"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Kategórie v tejto knižnici"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Série v tejto knižnici"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Systémove štatistiky"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "Program"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Nainštalovaná verzia"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Čas spustenia"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Actions"
 msgstr "Akcie"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "Otočiť"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 "Táto úloha bude zrušená. Akýkoľvek pokrok vykonaný v tejto úlohe bude "
 "uložený."
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
@@ -11595,395 +11409,395 @@ msgstr ""
 "Ak je toto naplánovaná úloha, bude znovu spustená v najbližšom naplánovanom "
 "čase."
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "Zmazaných {} používateľov"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Katalóg e-kníh Calibre-Web"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "Váš e-mail"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "Nastavenia"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Resetovať heslo používateľa"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "Konfigurácia servera"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "Poslať na e-mail čítačky"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "Zadajte jazyky"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Jazyk kníh"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "Nebolo poskytnuté platné jazykové nastavenie pre knihu"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "Nastavenia OAuth"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Pripojiť"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Odpojiť"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Synchronizačný žetón Kobo"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Vytvoriť/Zobraziť"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "Vynútiť úplnú synchronizáciu Kobo"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "Synchronizovať s Kobo iba knihy vo vybraných policiach"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "Synchronizovať s Kobo iba knihy vo vybraných policiach"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "Bezpečnostné nastavenia"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Pridať povolené/zakázané užívateľom definovaných hodnôt stĺpca"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Magic Shelves Order"
 msgstr "Synchronizovať vybrané police s Kobo"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "Naposledy pridané knihy"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "Upraviť verejné police"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Zmazať používateľa"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -11991,155 +11805,155 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Zmeniť heslo"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Zmeniť heslo"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Vytvoriť/Zobraziť"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Vygenerovať autentifikačné URL pre Kobo"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Vybrať..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Odstrániť výbery"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "Upraviť používateľa"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "Upraviť meno používateľa"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 msgid "Enter Email"
 msgstr "Zadať e-mail"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "Enter eReader Email"
 msgstr "Zadať e-mail pre čítačku"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "eReader Email"
 msgstr "e-mail pre čítačku"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "Zadať e-mail pre čítačku"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "e-mail pre čítačku"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Nastavenie jazyka"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "Viditeľné jazyky kníh"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "Upraviť povolené znaťky"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Povolené značky"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Upraviť zakázané značky"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Zakázané značky"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "Upraviť povolené hodnoty stĺpca"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "Povolené hodnoty stĺpca"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "Upraviť zakázané hodnoty stĺpca"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "Zakázané hodnoty stĺpca"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "Zmeniť heslo"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "Upraviť verejné police"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "Synchronizovať vybrané police s Kobo"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "Synchronizovať vybrané police s Kobo"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 msgid "Show Read/Unread Section"
 msgstr "Zobraziť sekciu Prečítané/Neprečítané"
 

--- a/cps/translations/sl/LC_MESSAGES/messages.po
+++ b/cps/translations/sl/LC_MESSAGES/messages.po
@@ -23,45 +23,45 @@ msgstr ""
 "X-Loco-Parser: loco_parse_po\n"
 "X-Loco-Source-Locale: sl_SI\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Statistika"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 "Zbirka podatkov Calibre ni na voljo. Ponovno konfigurirajte pot do knjižnice."
 
-#: cps/admin.py:208
+#: cps/admin.py
 msgid "Server restarted, please reload page."
 msgstr "Strežnik se je znova zagnal, prosimo, ponovno naložite stran."
 
-#: cps/admin.py:210
+#: cps/admin.py
 msgid "Performing Server shutdown, please close window."
 msgstr "Izvajanje zaustavitve strežnika, prosim zaprite okno."
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "Podatkovna baza je uspešno ponovno povezana"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Neznan ukaz"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 "Uspeh! Knjige so v čakalni vrsti za varnostno kopiranje metapodatkov, za "
 "rezultat preverite opravila"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
@@ -69,48 +69,48 @@ msgstr ""
 "Napaka: Žeton Hardcover ni na voljo. Nastavite okoljsko spremenljivko "
 "HARDCOVER_TOKEN ali jo konfigurirajte v Osnovnih nastavitvah."
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 "Uspeh! Opravilo samodejnega pridobivanja Hardcover se je začelo. Napredek "
 "preverite na plošči Opravila."
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 "Napaka pri zagonu opravila samodejnega pridobivanja Hardcover: %(error)s"
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr "Preglejte ujemajoče Hardcover zadetke"
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr "Napaka pri nalaganju čakalne vrste za pregled: %(error)s"
 
-#: cps/admin.py:414
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover ID applied successfully"
 msgstr "{} uporabnikov uspešno izbrisanih"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr "Ujemanje %(action)s"
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr "Ni ujemanj na čakanju za zavrnitev"
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr "Zavrnjenih %(count)s ujemanj"
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
@@ -118,168 +118,166 @@ msgstr ""
 "Osveževanje predpomnilnika sličic se je začelo za {} knjig. To lahko traja "
 "nekaj minut."
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr "Ni bilo najdenih knjig z ovitki za obdelavo."
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr "Napaka pri zagonu osveževanja sličic: {}"
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Administrativna stran"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "Hardcover API žeton"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Osnovne nastavitve"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Nastavitve uporabniškega vmesnika"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr "Stolpec po meri št. %(column)d ne obstaja v zbirki podatkov Calibre"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Urejanje uporabnikov"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Vse"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Ne najdem uporabnika"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} uporabnikov uspešno izbrisanih"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Pokaži vse"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Napačno oblikovana zahteva"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "Imena gosta ni mogoče spremeniti"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "Gost ne more imeti te vloge"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr "Ni več nobenega admin uporabnika, ne morem odstraniti vloge admin"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "Vrednost mora biti true ali false"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Neveljavna vloga"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "Gost ne more imeti tega pogleda"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "Nepravilen pogled"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr "Lokalni jezik gosta se določi samodejno in ga ni mogoče nastaviti."
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Ni navedenega veljavnega lokalnega jezika"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Ni navedenega veljavnega jezika knjige"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Parameter ni najden"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "DB nastavitev ni mogoče zapisati"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Nepravilen stolpec za branje"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Neveljavni stolpec za omejitev"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Ali res želite izbrisati žeton Kobo?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "Ali res želite izbrisati to domeno?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "Ali res želite izbrisati tega uporabnika?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Ste prepričani, da želite izbrisati to polico?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr ""
 "Ali ste prepričani, da želite spremeniti lokalne jezike izbranih uporabnikov?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "Ste prepričani, da želite spremeniti vidne jezike knjig za izbrane "
 "uporabnike?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 "Ali ste prepričani, da želite spremeniti izbrano vlogo za izbranega(-e) "
 "uporabnika(-e)?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
@@ -287,7 +285,7 @@ msgstr ""
 "Ali ste prepričani, da želite spremeniti izbrane omejitve za izbranega(-e) "
 "uporabnika(-e)?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -295,14 +293,14 @@ msgstr ""
 "Ali ste prepričani, da želite spremeniti izbrane omejitve vidljivosti za "
 "izbranega(-e) uporabnika(-e)?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "Ali ste prepričani, da želite spremeniti obnašanje sinhronizacije police za "
 "izbranega(-e) uporabnika(-e)?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
@@ -310,122 +308,117 @@ msgstr ""
 "Ali ste prepričani, da želite spremeniti obnašanje sinhronizacije police za "
 "izbranega(-e) uporabnika(-e)?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Ste prepričani, da želite spremeniti lokacijo knjižnice Calibre?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Onemogoči"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Omogoči"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "{} izbrisanih vnosov za sinhronizacijo"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "ne najdem žetona"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Oznaka ni bila najdena"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Neveljavno dejanje"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "Client_secrets.json ni nastavljen za spletno aplikacijo"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "Lokacija dnevniške datoteke ni veljavna, vnesite pravilno pot"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "Lokacija dnevniške datoteke dostopa ni veljavna, vnesite pravilno pot"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr "Vnesite ponudnika LDAP, vrata, DN in identifikator objekta uporabnika"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Vnesite račun in geslo storitve LDAP"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "Vnesite račun storitve LDAP"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Filter predmetov skupine LDAP mora imeti en identifikator oblike \"%s\""
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "Filter predmeta skupine LDAP ima neusklajene oklepaje"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Filter uporabniškega objekta LDAP mora imeti en identifikator oblike \"%s\""
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "Filter objekta uporabnika LDAP ima neusklajene oklepaje"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Filter za uporabnike članov LDAP mora imeti en identifikator oblike \"%s\""
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "Filter uporabnika člana LDAP ima neusklajene oklepaje"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -433,29 +426,24 @@ msgstr ""
 "LDAP CACcertifikat, lokacija certifikata ali ključa ni veljavna, vnesite "
 "pravilno pot"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Dodajanje novega uporabnika"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Urejanje nastavitev e-poštnega strežnika"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "Uspeh! Račun Gmail je potrjen."
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Ups! Napaka podatkovne baze: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -463,54 +451,54 @@ msgstr ""
 "Testno e-poštno sporočilo je v čakalni vrsti za pošiljanje na %(email)s "
 "naslovov, za rezultat preverite opravila"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr ""
 "Pri pošiljanju testnega e-poštnega sporočila je prišlo do napake: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Najprej nastavite vaš e-poštni naslov..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Posodobljene nastavitve e-poštnega strežnika"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "Urejanje uporabnikov"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Najprej nastavite nastavitve pošte SMTP..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "Najprej nastavite vaš e-poštni naslov..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "Novo geslo je bilo poslano na vaš e-poštni naslov"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -518,7 +506,7 @@ msgstr ""
 "Testno e-poštno sporočilo je v čakalni vrsti za pošiljanje na %(email)s "
 "naslovov, za rezultat preverite opravila"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -527,159 +515,157 @@ msgstr ""
 "Testno e-poštno sporočilo je v čakalni vrsti za pošiljanje na %(email)s "
 "naslovov, za rezultat preverite opravila"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "Urejanje nastavitev načrtovanih opravil"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "Nepravilen začetni čas za določeno nalogo"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "Nepravilno trajanje za določeno nalogo"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "Posodobljene nastavitve načrtovanih opravil"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Ups! Zgodila se je neznana napaka. Prosimo, poskusite znova pozneje."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "Naslov"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Urejanje uporabnika %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Uspeh! Ponastavitev gesla za uporabnika %(user)s"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Ups! Nastavite nastavitve pošte SMTP."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Pregledovalnik dnevniške datoteke"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Zahteva za paket posodobitev"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Prenos paketa posodobitev"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Razpakiranje paketa posodobitev"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Zamenjava datotek"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Povezave do zbirke podatkov so zaprte"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Ustavitev strežnika"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Posodobitev je končana, pritisnite OK in ponovno naložite stran"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Posodobitev ni uspela:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "Napaka HTTP"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Napaka povezave"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Potek časa pri vzpostavljanju povezave"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Splošna napaka"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr "Datoteke posodobitve ni bilo mogoče shraniti v začasno mapo"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "Datotek med posodabljanjem ni bilo mogoče zamenjati"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "Nisem uspel izpisati vsaj enega uporabnika LDAP"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Nisem uspel ustvariti vsaj enega uporabnika LDAP"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Napaka: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Napaka: V odzivu strežnika LDAP ni vrnjenega nobenega uporabnika"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "V podatkovni zbirki ni najden vsaj en uporabnik LDAP"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} Uporabnik je bil uspešno uvožen"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr "Pot do knjig ni veljavna"
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "Lokacija do DB ni veljavna, vnesite pravilno pot"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "V DB ni mogoče zapisati"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "Lokacija datoteka Keyfile ni veljavna, vnesite pravilno pot"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr "Lokacija datoteke Certfile ni veljavna, vnesite pravilno pot"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
@@ -687,13 +673,13 @@ msgstr ""
 "Samodejnega ustvarjanja uporabnikov ni mogoče omogočiti brez omogočene "
 "avtentikacije preko povratnega proksija"
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 "Samodejno ustvarjanje uporabnikov zahteva veljavno ime glave povratnega "
 "proksija"
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
@@ -701,7 +687,7 @@ msgstr ""
 "Neveljavna oblika gostitelja za preusmeritev OAuth. Vključite celoten URL s "
 "protokolom (npr. https://vasa-domena.si)"
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
@@ -709,75 +695,75 @@ msgstr ""
 "Gostitelj preusmeritve OAuth ne sme vsebovati poti. Uporabite le osnovni URL "
 "(npr. https://vasa-domena.si)"
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr "Dolžina gesla mora biti med 1 in 40"
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "Posodobljene nastavitve zbirke podatkov"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "Nastavitev zbirke podatkov"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Ups! Izpolnite vsa polja."
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "E-pošta ni iz veljavne domene"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Dodajanje novega uporabnika"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Ustvarjen uporabnik '%(user)s'"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "Ups! Za to e-pošto že obstaja račun ali ime."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Uporabnik '%(nick)s' je izbrisan"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "Ne morem izbrisati uporabnika gosta"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr ""
 "Ni preostalega uporabnika administratorja, uporabnika ni mogoče izbrisati"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "E-pošta ne sme biti prazna in mora biti veljavna."
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Uporabnik '%(nick)s' je posodobljen"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr "Povezava uspešna! OIDC odkritna točka je dostopna. %(endpoints)s"
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
@@ -785,12 +771,12 @@ msgstr ""
 "Povezava ni uspela: OIDC odkritna točka ni bila najdena (404). Preverite, "
 "ali je osnovni URL pravilen."
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr "Povezava ni uspela: Strežnik je vrnil kodo stanja %(code)s"
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
@@ -798,14 +784,14 @@ msgstr ""
 "Povezava ni uspela: Ni se bilo mogoče povezati s strežnikom. Preverite URL "
 "in omrežno povezavo."
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 "Povezava ni uspela: Zahteva je potekla. Strežnik je morda počasen ali "
 "nedosegljiv."
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
@@ -813,12 +799,12 @@ msgstr ""
 "Povezava ni uspela: Strežnik je vrnil neveljaven JSON. To morda ni končna "
 "točka OIDC."
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Napaka povezave"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
@@ -827,26 +813,26 @@ msgstr ""
 "V metapodatkih manjkajo zahtevana polja OIDC: %(fields)s. To morda ni "
 "veljavna končna točka metapodatkov OIDC."
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr "URL metapodatkov je veljaven! Najdenih %(count)s OAuth končnih točk."
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "Informacije o izdaji niso na voljo"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr "URL metapodatkov ni bil najden (404). Preverite, ali je URL pravilen."
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
@@ -854,50 +840,50 @@ msgstr ""
 "Povezava ni uspela: Ni se bilo mogoče povezati z URL-jem metapodatkov. "
 "Preverite URL in omrežno povezavo."
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr "Povezava ni uspela: Čas za zahtevo se je iztekel."
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr "Povezava ni uspela: Neveljaven JSON v odgovoru."
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "Zgodila se je neznana napaka. Prosimo, poskusite znova pozneje."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "Napaka povezave"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr "Obnova ni uspela: Pot do knjižnice Calibre ni nastavljena."
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr "Obnova ni uspela: metadata.db ni bil najden na %(path)s"
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr "Obnova ni uspela: app.db ni bil najden na %(path)s"
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Napaka povezave"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 "Obnova končana, vendar čiščenje app.db ni uspelo. Za podrobnosti glejte "
 "dnevnike."
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
@@ -906,204 +892,203 @@ msgstr ""
 "Obnova končana. Varnostne kopije in dnevnik obnove so shranjeni v %(dir)s. "
 "Vsi podatki, povezani s knjigami, so bili ponastavljeni."
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "Prenesena datoteka %(file)s"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr "Češčina"
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr "Neščina"
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr "Grščina"
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr "Španščina"
 
-#: cps/constants.py:265
+#: cps/constants.py
 #, fuzzy
 msgid "Finnish"
 msgstr "Končano"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr "Francoščina"
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr "Galščina"
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr "Madžarščina"
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr "Indonezijščina"
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr "Italijanščina"
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr "Japonščina"
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr "Kmerščina"
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr "Korejščina"
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr "Nizozemščina"
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr "Norveščina"
 
-#: cps/constants.py:276
+#: cps/constants.py
 #, fuzzy
 msgid "Polish"
 msgstr "Založnik"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr "Portugalščina"
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr "Portugalščina (Brazilija)"
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr "Ruščina"
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr "Sloveščina"
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr "Slovenščina"
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr "Švedščina"
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr "Turščina"
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr "Ukrajinščina"
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr "Vietnamščina"
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr "Kitajščina (poenostavljena, Kitajska)"
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr "kitajščina (tradicionalna, Tajvan)"
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "ni nameščen"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Manjkajo dovoljenja za izvajanje"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, fuzzy, python-format
 msgid "Change cover — %(title)s"
 msgstr "Zamenjava avtorja in naslova"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Zgodila se je neznana napaka. Prosimo, poskusite znova pozneje."
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Could not render the e-reader preview."
 msgstr "Ni bilo mogoče najti določenega imenika"
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr "Preklapljanje tem je začasno onemogočeno do različice 5.0.0"
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
@@ -1111,370 +1096,358 @@ msgstr ""
 "Osvežitev knjižnice 🔄 Preverjamo morebitne spregledane knjige, prosimo, "
 "počakajte ..."
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 "Neveljaven cron izraz za iskanje dvojnikov. Spremembe niso bile shranjene."
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr "Časovni žig"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Book ID"
 msgstr "Knjige"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Naslov knjige"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "Avtor"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr "Vrsta sprožilca"
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "Vrste datotek"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filename"
 msgstr "ime"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr "Ročno?"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr "Brez sprememb"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr "Izvirnik varnostno kopiran?"
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr "Uporabljeni popravki"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr "Izvirna oblika"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "Nalaganje vrsta"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "Neznano"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr "✅ Vse nadzorne storitve delujejo po načrtih! 👍"
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr "🔴 Storitev vnosa se izvaja, detektor sprememb metapodatkov pa ne."
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr "🔴 Detektor sprememb metapodatkov deluje, storitev vnosa pa ne."
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 "⛔ Niti storitev vnosa niti detektor sprememb metapodatkov se ne izvajata"
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr "Prišlo je do napake"
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 "Popravljalnik EPUB za posamezno knjigo ni podprt v knjižnicah Google Drive."
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "Neveljavna vloga"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "Združevanje izbranih knjig"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "%(format)s vrsta ni najdena na disku"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB Fixer started for selected book."
 msgstr "Združevanje izbranih knjig"
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr "Napaka pri zagonu popravljalnika EPUB za izbrano knjigo."
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr "Za dostop do te strani morate biti skrbnik."
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr "Zahtevani so tako uporabniško ime kot podatki o sliki."
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr "Neveljavna oblika slikovnih podatkov. Izbrati morate veljavno sliko."
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr "Nepodprta vrsta slike. Dovoljena sta le PNG in JPEG."
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr "Slika je prevelika. Prosimo, uporabite sliko, manjšo od 500 KB."
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr "Neveljavni Base64 podatki o sliki."
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid image data format."
 msgstr "Nepravilna oblike e-poštnega naslova"
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr "Napaka pri preverjanju podatkov slike."
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Profile picture updated successfully."
 msgstr "{} uporabnikov uspešno izbrisanih"
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Nobeno"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "Izbriši knjigo"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr "Skupina dvojnikov je že bila opuščena"
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "Izbriši knjigo"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "Izbriši knjigo"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr "Skupina dvojnikov ni bila opuščena"
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "Ni bilo najdenih rezultatov"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr "Iskanje dvojnikov končano (rezervni način)"
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 #, fuzzy
 msgid "Invalid resolution strategy"
 msgstr "Neveljavna vloga"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 "Mapa za uvoz ni zapisljiva. Preverite dovoljenja za nosilec /cwa-book-ingest."
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr "Manjkajoč ali neveljaven ID knjige za nalaganje formata"
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr "Formata ni mogoče naložiti: Knjiga ne obstaja več v knjižnici"
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Prenos opravljen, obdelujem, prosim počakajte..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 #, fuzzy
 msgid "Failed to queue upload for processing"
 msgstr "Nisem uspel ustvariti poti za naslovnice"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Manjka izvorni ali ciljni format za pretvorbo"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr ""
 "Knjiga je uspešno dodana v čakalno vrsto za pretvorbo v %(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Pri pretvorbi te knjige je prišlo do napake: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "Vrsta datoteke ni dovoljena za nalaganje v ta strežnik"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr "Datoteke s končnico '%(ext)s' ni dovoljeno naložiti na ta strežnik"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "Datoteka, ki jo želite naložiti, mora imeti končnico"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr "Ups! Izbrana knjiga ni na voljo. Datoteka ne obstaja ali ni dostopna"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "Uporabnik nima pravice do nalaganja naslovnice"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 "Identifikatorji niso občutljivi na velikost črk, prepisovanje starega "
 "identifikatorja"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "'%(langname)s' ni veljaven jezik"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Metapodatki so bili uspešno posodobljeni"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "Napaka pri urejanju knjige: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Neznano"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1482,96 +1455,96 @@ msgstr ""
 "Naložena knjiga verjetno obstaja v knjižnici, preden naložite novo, "
 "razmislite o spremembi:"
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "Datoteke %(filename)s ni bilo mogoče shraniti v začasno mapo"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Nisem uspel premakniti naslovne datoteke %(file)s: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Uspešno izbrisana vrsta knjige"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Knjiga je bila uspešno izbrisana"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "Manjkajo vam dovoljenja za brisanje knjig"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "urejanje metapodatkov"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "Številka serije: %(seriesindex)s ni veljavno število, preskočim"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr "Uporabnik nima pravic za nalaganje dodatnih formatov datotek"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Nisem uspel ustvariti poti %(path)s (zavrnjeno dovoljenje)."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Nisem uspel shraniti datoteke %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Oblina datotek %(ext)s je dodan v %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "ne najdem žetona"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "%(format)s vrsta ni najdena na disku"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1579,7 +1552,7 @@ msgstr ""
 "Nastavitev Google Drive ni dokončana, poskusite deaktivirati in znova "
 "aktivirati Google Drive"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1587,87 +1560,86 @@ msgstr ""
 "Povratna domena ni preverjena, sledite korakom za preverjanje domene v "
 "konzoli za razvijalce Google"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "Vrsta %(format)s ni najdena za id knjige: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(format)s ni bil najden v storitvi Google Drive: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s ni najden: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "Pošlji v e-bralnik"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "Vrsta %(format)s ni najdena za id knjige: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "Vrsta %(format)s ni najdena za id knjige: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 msgid "Test Email"
 msgstr "Testna e-pošta"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Registracijski e-poštni naslov za uporabnika: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Pretvarjanje %(orig)s v %(format)s in pošiljanje v e-bralnik"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Pošlji %(format)s v e-bralnik"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s pošljite v e-bralnik"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "Zahtevane datoteke ni bilo mogoče prebrati. Morda napačna dovoljenja?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "Stanja branja ni bilo mogoče nastaviti: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
@@ -1675,12 +1647,12 @@ msgstr ""
 "Brisanje knjižne mape za knjigo %(id)s ni bilo uspešno, pot ima podmape: "
 "%(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "Brisanje knjige %(id)s ni bilo uspešno: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
@@ -1689,7 +1661,7 @@ msgstr ""
 "Brisanje knjige %(id)s samo iz zbirke podatkov, pot do knjige v zbirki "
 "podatkov ni veljavna: %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
@@ -1697,66 +1669,66 @@ msgstr ""
 "Preimenovanje avtorja iz: '%(src)s' v '%(dest)s' ni bilo uspešno z napako: "
 "%(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Datoteke %(file)s ni mogoče najti v storitvi Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Preimenovanje naslova iz: '%(src)s' v '%(dest)s' ni bilo uspešno z napako: "
 "%(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Pot do knjige %(path)s ni bila najdena v storitvi Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr "Najden obstoječi račun za ta e-poštni naslov"
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "To uporabniško ime je že zasedeno"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr "Nepravilna oblike e-poštnega naslova"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr "Geslo ni v skladu s pravili za preverjanje gesla"
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 "Modul Python 'advocate' ni nameščen, vendar je potreben za nalaganje "
 "naslovnic"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Napaka pri nalaganju naslovnice"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr ""
 "Datoteka naslovnice ni veljavna slikovna datoteka ali je ni bilo mogoče "
 "shraniti"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Napaka vrste naslovnice"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
@@ -1764,107 +1736,107 @@ msgstr ""
 "Dostop do lokalnega gostitelja ali lokalnega omrežja za prenos naslovnice ni "
 "dovoljen."
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Nisem uspel ustvariti poti za naslovnice"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "Za datoteke naslovnic so podprte samo datoteke jpg/jpeg/png/webp/bmp"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "Nepravilna vsebina datoteke z naslovnico"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Samo datoteke jpg/jpeg so podprte kot datoteke naslovnic"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr "Naslovnica"
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "Binarna datoteka UnRar ni bila najdena"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr "Napaka pri izvajanju UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr "Ni bilo mogoče najti določenega imenika"
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr "Navedite imenik in ne datoteke"
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr "Binarne datoteke Calibre niso izvedljive"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr "Manjkajoče binarne datoteke Calibre: %(missing)s"
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Manjkajoča dovoljenja za izvršilni program: %(missing)s"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr "Napaka pri izvajanju programa Calibre"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr "Vse knjige v vrsti za varnostno kopiranje metapodatkov"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Nastavitev za Kobo"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Registracija pri %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
@@ -1874,13 +1846,13 @@ msgstr ""
 "napačne konfiguracije obsega (scope). Preverite nastavitve OAuth ali se "
 "obrnite na skrbnika."
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 "Prijava ni uspela: Žeton OAuth je potekel. Prosimo, poskusite se ponovno "
 "prijaviti."
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
@@ -1888,14 +1860,14 @@ msgstr ""
 "Prijava ni uspela: Ni se bilo mogoče povezati s končno točko ponudnika "
 "OAuth. Poskusite znova ali se obrnite na skrbnika."
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "Ups! E-poštni strežnik ni nastavljen, obrnite se na skrbnika."
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1905,37 +1877,37 @@ msgstr ""
 "Prijava ni uspela: Odgovor ponudnika OAuth ne vsebuje zahtevanih polj: "
 "%(fields)s. Preverite nastavitve OAuth ali se obrnite na skrbnika."
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr "Povezovanje računa OAuth ni uspelo. Prosimo, poskusite znova."
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 "Napaka OAuth: Ponudnik je vrnil neveljavne podatke o uporabniku. Prosimo, "
 "poskusite znova."
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "Uspeh! Prijavljeni ste kot: %(nickname)s"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Povezava do %(oauth)s je bila uspešna"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1946,58 +1918,58 @@ msgstr ""
 "%(provider)s. Obrnite se na skrbnika, da vam ustvari račun ali poveže "
 "obstoječega."
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 "Avtentikacija OAuth ni uspela. Poskusite znova ali se obrnite na skrbnika."
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr "Ups! E-poštni strežnik ni nastavljen, obrnite se na skrbnika."
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "Odklop povezave z %(oauth)s je bil uspešen"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Odklop povezave z %(oauth)s ni bil uspešen"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "Ni povezano z %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Neuspešna prijava v GitHub."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Neuspešna pridobitev informacij o uporabniku iz storitve GitHub."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Neuspešna prijava v Google."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Neuspešna ridobititev informacij o uporabniku iz Googla."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "Failed to log in with Generic OAuth."
 msgstr "Neuspešna prijava v GitHub."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 "Avtentikacija OAuth ni uspela: Napaka pri validaciji žetona. Poskusite znova."
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
@@ -2005,7 +1977,7 @@ msgstr ""
 "Avtentikacija OAuth ni uspela zaradi nepričakovane napake. Obrnite se na "
 "skrbnika."
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
@@ -2015,4074 +1987,4006 @@ msgstr ""
 "konfigurirajte nastavitev 'OAuth Redirect Host' v Skrbnik > Osnovne "
 "nastavitve > OAuth."
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "Napaka GitHub Oauth, prosimo, poskusite pozneje."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "Napaka GitHub Oauth: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Napaka Google Oauth, poskusite pozneje."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Napaka Google Oauth: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, fuzzy, python-brace-format
 msgid "OAuth error: {}"
 msgstr "Napaka GitHub Oauth: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "Abecedno razvrščene knjige"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "Knjige razvrščene po abecedi"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Najbolj vroče knjige"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "Priljubljene publikacije iz tega kataloga na podlagi prenosov."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Najbolje ocenjene knjige"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Priljubljene publikacije iz tega kataloga na podlagi ocene."
 
-#: cps/opds.py:182
+#: cps/opds.py
 msgid "Recently added Books"
 msgstr "Nedavno dodane knjige"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Najnovejše knjige"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Naključne knjige"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Prikaži naključne knjige"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Prebrane knjige"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Trenutna različica"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Neprebrane knjige"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Avtorji"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Knjige, razvrščene po avtorju"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Založniki"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Knjige, razvrščene po založniku"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Kategorije"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Knjige, razvrščene po kategorijah"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Serije"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Knjige, razvrščene po serijah"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Jeziki"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Knjige, razvrščene po jezikih"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Ocene"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Knjige, razvrščene po oceni"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Vrste datotek"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Knjige, razvrščene po vrstah datotek"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Police"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "Knjige, urejene po policah"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Čarobne police ✨"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Knjige, urejene po policah"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "Opis"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} zvezdic"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Iskanje"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Prijava"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "ne najdem žetona"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Veljavnost žetona je potekla"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Uspeh! Vrnite se v svojo napravo"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Knjige"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Prikaži nedavne knjige"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Prikaži vroče knjige"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Prenesene knjige"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Prikaži prenesene knjige"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Prikaži najbolje ocenjene knjige"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 msgid "Show Read and Unread"
 msgstr "Prikaži prebrano in neprebrano"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Prikaži neprebrane"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Odkrivanje"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Category Section"
 msgstr "Prikaži oddelek kategorije"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Series Section"
 msgstr "Prikaži razdelek serij"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Author Section"
 msgstr "Prikaži razdelek avtorjev"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Publisher Section"
 msgstr "Prikaži razdelek založnikov"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Language Section"
 msgstr "Prikaži razdelek jezikov"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Ratings Section"
 msgstr "Prikaži razdelek ocen"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show File Formats Section"
 msgstr "Prikaži razdelek vrste datotek"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Arhivirane knjige"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Archived Books"
 msgstr "Prikaži arhivirane knjige"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Seznam knjig"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Prikaži seznam knjig"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr "Dvojniki"
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Prikaži najbolje ocenjene knjige"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Objavljeno po"
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Objavljeno pred"
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Ocena <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Ocena >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Prebrani status = '%(status)s'"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr "Napaka pri iskanju stolpcev po meri, ponovno zaženite Calibre-Web"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Napredno iskanje"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Navedena nepravilna polica"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "Žal vam ni dovoljeno dodati knjige na to polico."
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "Knjiga je že del police: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 "%(book_id)s je neveljaven ID knjige. Ni ga bilo mogoče dodati na polico"
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "Knjiga je bila dodana na polico: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "Knjige ne smete dodati na polico"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Knjige so že del police: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "Knjige so bile dodane na polico: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Ni bilo mogoče dodati knjig na polico: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "Navedena nepravilna polica"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Ni bilo mogoče dodati knjig na polico: %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Knjige so že del police: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "Knjige so bile dodane na polico: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "Knjiga je bila odstranjena s police: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "Žal vam ni dovoljeno odstraniti knjige s te police"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Ustvari polico"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Žal vam ni dovoljeno urejati te police"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Urejanje police"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "Napaka pri brisanju police"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "Polica je bila uspešno izbrisana"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Spremeni vrstni red police: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "Žal vam ni dovoljeno ustvariti javne police"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Ustvarjena polica %(title)s"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Polica %(title)s je spremenjena"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Prišlo je do napake"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "Javna polica z imenom '%(title)s' že obstaja."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "Zasebna polica z imenom '%(title)s' že obstaja."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Polica: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Napaka pri odpiranju police. Polica ne obstaja ali ni dostopna"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Izključi police"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Anonimno"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Neavtentificirano"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr "Dodaj oznako"
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Da"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Ne"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Stanje branje"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Tema"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Svetlo"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Temno"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "Sepia"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Dodaj na polico"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Avtor"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Brskaj"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Zapri"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Izbriši"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Združitev"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Založnik"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Prebrano"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Naslov"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Naloži"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Račun"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Administator"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Objavljeno"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Vir:"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "O programu"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr "Vse"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr "Arhiv"
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Arhivirano"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Prekliči"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "Pretvori"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr "Datum dodajanja"
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Opis"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr "Opusti"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Prenesi"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Uredi"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "E-pošta"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Omogoči sinhronizacijo s Kobo"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Šifriranje"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "Skrij"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Identifikatorji"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Jezik"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr "Zadnjič spremenjeno"
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Geslo"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Vrata"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Napredek"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Ocena"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Shrani"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "Izberi"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr "Pošlji"
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Status"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Oznake"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Opravilo"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Opravila"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Uporabnik"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Uporabniško ime"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Oglejte si"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Na čakanju"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Neuspešno"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Začeto"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Končano"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "Končano"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "Preklicano"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Neznani status"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Nepričakovani podatki med branjem informacij o posodobitvi"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr "Posodobitev ni na voljo. Najnovejšo različico že imate nameščeno"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6090,15 +5994,15 @@ msgstr ""
 "Na voljo je nova posodobitev. Klikni spodnji gumb za posodobitev na "
 "najnovejšo različico."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Ni bilo mogoče pridobiti informacij o posodobitvi"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr "Klikni spodnji gumb za posodobitev na najnovejšo stabilno različico."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6107,164 +6011,164 @@ msgstr ""
 "Na voljo je nova posodobitev. Klikni spodnji gumb za posodobitev na "
 "različico: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Informacije o izdaji niso na voljo"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Odkrivanje (naključne knjige)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Vroče knjige (največkrat prenesene)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "Prenesene knjige od %(user)s"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Avtor: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Založnik: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Serija: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "Ocena: brez"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Ocena: %(rating)s zvezdic"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Vrsta datoteke: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Kategorija: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Jezik: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Najbolj vroče knjige"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Skrita knjiga"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "Napaka pri brisanju police"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr "Čarobna polica&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr "Pravila niso navedena"
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "Nepravilna oblike e-poštnega naslova"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr "Napaka pri obdelavi pravil"
 
-#: cps/web.py:1426
+#: cps/web.py
 #, fuzzy
 msgid "Invalid request"
 msgstr "Neveljavna vloga"
 
-#: cps/web.py:1470
+#: cps/web.py
 #, fuzzy
 msgid "Name and rules are required"
 msgstr "Zahtevani so tako uporabniško ime kot podatki o sliki."
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr "Ime police je predolgo (največ 100 znakov)"
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 #, fuzzy
 msgid "Error creating shelf"
 msgstr "Napaka pri brisanju police"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Ustvari polico"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr "Dovoljenje za spreminjanje javnega statusa je zavrnjeno"
 
-#: cps/web.py:1587
+#: cps/web.py
 #, fuzzy
 msgid "Shelf name is required"
 msgstr "To polje je obvezno"
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "Napaka pri brisanju police"
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "Urejanje police"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "Ne najdem uporabnika"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr "Dostop zavrnjen"
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "{} uporabnikov uspešno izbrisanih"
 
-#: cps/web.py:1710
+#: cps/web.py
 #, fuzzy
 msgid "Error duplicating shelf"
 msgstr "Napaka pri brisanju police"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
@@ -6272,154 +6176,152 @@ msgstr ""
 "Sistemskih polic ni mogoče izbrisati. Lahko jih skrijete v nastavitvah "
 "uporabniškega profila."
 
-#: cps/web.py:1755
+#: cps/web.py
 #, fuzzy
 msgid "Error deleting shelf"
 msgstr "Napaka pri brisanju police"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 "Svojih lastnih polic ne morete skriti. Če jih ne želite, jih raje izbrišite."
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr "Polica je že skrita"
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "Napaka pri brisanju police"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr "Polica ni bila skrita"
 
-#: cps/web.py:1818
+#: cps/web.py
 #, fuzzy
 msgid "Error unhiding shelf"
 msgstr "Napaka pri brisanju police"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Prenosi"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Seznam vrste datotek"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Najprej nastavite nastavitve pošte SMTP..."
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr "Ups! Posodobite svoj profil z veljavnim e-poštnim naslovom eReaderja."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "Uspeh! Knjiga je v vrsti za pošiljanje v %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Ups! Pri pošiljanju knjige je prišlo do napake: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr "Noben e-poštni naslov ni bil izbran"
 
-#: cps/web.py:2473
+#: cps/web.py
 #, fuzzy
 msgid "Additional email addresses are disabled for your account."
 msgstr "Vnesite dodatne e-poštne naslove (ločene z vejico):"
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "Uspeh! Knjiga je v vrsti za pošiljanje v %(eReadermail)s"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr "Počakajte eno minuto za registracijo naslednjega uporabnika"
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Registriraj"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr ""
 "Napaka pri povezavi z zalednim strežnikom limiterja, obrnite se na skrbnika"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr "Ups! E-poštni strežnik ni nastavljen, obrnite se na skrbnika."
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "Ups! Vaša e-pošta ni dovoljena."
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "Uspeh! Potrditveno e-poštno sporočilo je bilo poslano."
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
 msgstr "Instanca Calibre-Web ni nastavljena, obrni se na skrbnika"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "Ups! E-poštni strežnik ni nastavljen, obrnite se na skrbnika."
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr "Ni mogoče aktivirati avtentikacije LDAP"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr "Standardna prijava je onemogočena."
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr "Pred naslednjo prijavo počakajte eno minuto"
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr "Uporabniško ime ne more biti prazno"
 
-#: cps/web.py:2756
+#: cps/web.py
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "prijavljeni ste kot: '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "Uspeh! Prijavljeni ste kot: %(nickname)s"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
 msgstr "Instanca Calibre-Web ni nastavljena, obrni se na skrbnika"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
@@ -6427,7 +6329,7 @@ msgstr ""
 "Prijava uspešna, vendar lokalni račun ni bil najden. Obrnite se na skrbnika "
 "za ustvarjanje računa."
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
@@ -6436,710 +6338,680 @@ msgstr ""
 "Rezervna prijava kot: %(nickname)s, strežnik LDAP ni dosegljiv ali uporabnik "
 "ni znan"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr "Ni se mogel prijaviti: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 msgid "Wrong Username or Password"
 msgstr "Napačno uporabniško ime ali geslo"
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr "Novo geslo je bilo poslano na vaš e-poštni naslov"
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr "Zgodila se je neznana napaka. Prosimo, poskusite znova pozneje."
 
-#: cps/web.py:2838
+#: cps/web.py
 msgid "Please enter valid username to reset password"
 msgstr "Za ponastavitev gesla vnesite veljavno uporabniško ime"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "Prijavljeni ste kot: '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 msgid "Success! Profile Updated"
 msgstr "Uspeh! Profil posodobljen"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "Ups! Račun za to e-pošto že obstaja."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 #, fuzzy
 msgid "Invalid book ID."
 msgstr "Neveljavna vloga"
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr "Vtičnik za sinhronizacijo KOReader"
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "Nisem našel veljavne datoteke gmail.json z informacijami OAuth"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr "Samodejno pridobivanje Hardcover ID-jev"
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "%(book)s pošljite v e-bralnik"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr "Preverjanje razpoložljivih formatov..."
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "Pošlji v e-bralnik"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-send completed successfully"
 msgstr "{} uporabnikov uspešno izbrisanih"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr "Samodejno pošiljanje"
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr "Izbriši vsebino začasne mape"
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s pošlji v e-bralnik"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Calibre ebook-convert %(tool)s ni najden"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "%(format)s vrsta ni najdena na disku"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "Pretvornik e-knjig ni uspel z neznano napako"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Kepubify-converter ni uspel: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 "Pretvorjena datoteka ni bila najdena ali je v mapi %(folder)s več kot ena "
 "datoteka"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre ni uspel z napako: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "Ebook-converter ni uspel: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Ponovno se povezuejm na podatkovno zbirko Calibre"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr "Čiščenje referenc arhiviranih knjig"
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "Izbriši knjigo"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan skipped: import in progress"
 msgstr "Iskanje dvojnikov končano: %(count)s novih skupin"
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Opusti to skupino dvojnikov"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Razpakiranje paketa posodobitev"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Ni bilo najdenih rezultatov"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr "Iskanje dvojnikov končano: %(count)s skupin"
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr "Iskanje dvojnikov končano: %(count)s novih skupin"
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr "Iskanje dvojnikov končano: %(count)s skupin samodejno razrešenih"
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Omogoči sinhronizacijo s Kobo"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "E-naslov"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr "Varnostno kopiranje metapodatkov"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr "Pretvori knjižnico – celoten zagon"
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "V knjižnici"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr "Popravljalnik EPUB – celoten zagon"
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr "Popravljalnik EPUB"
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "Ustvarjene sličice naslovnic %(count)s"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "Sličicah naslovnice"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "Ustvarjene sličice serije {0}"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "Čiščenje predpomnilnika sličic naslovnice"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "Knjige, urejene po policah"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Sprememba gesla"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Ustvari polico"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "Varnostne nastavitve"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Nastavitve"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "izberi možnost"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "Dodaj na polico"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Javno)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 msgid "Downloads, fewest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Prenesi"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "Razvrstite glede na datum knjige, najprej najnovejši"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "Razvrsti po datumu knjige, najprej najstarejši"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Avtor"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Avtor"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Objavljeno pred"
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Objavljeno pred"
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr ""
 "Razvrsti glede na knjigo, ki je bila dodana na polico, najprej najnovejša."
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr ""
 "Razvrsti glede na knjigo, ki je bila dodana na polico, najprej najstarejša."
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr "Uporabniki&nbsp;&nbsp;👤"
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "Pošlji v e-pošto e-bralnika"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "Pošlji v e-bralnik"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Oglejte si knjige"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Javna polica"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr "Upravljanje profilnih slik"
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "Uvoz uporabnikov LDAP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Nastavitve e-poštnega strežnika"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "Ime gostitelja SMTP"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "Vrata SMTP"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "Prijava v SMTP"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Iz e-poštnega naslova"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr "Storitev e-pošte"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail prek Oauth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr "Nastavitve⚙️"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Imenik zbirk podatkov Calibre"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Raven dnevnika"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Zunanja vrata"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Število knjig na stran"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Nalaganje"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Anonimno brskanje"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Javna registracija"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Prijava v oddaljeno prijavo Magic Link"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Prijava za povratni posredniški strežnik"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Ime glave povratnega posredniškega strežnika"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Urejanje osnovnih nastavitev"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Urejanje nastavitev uporabniškega vmesnika"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Urejanje nastavitev podatkovne zbirke Calibre"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "Načrtovana opravila"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "Čas začetka"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "Najdaljše trajanje"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr "Načrtovano osveževanje sličic"
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "Ustvarjanje sličic naslovnic serij"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "Ponovna povezava podatkovne zbirke Calibre"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr "Ustvarjanje varnostnih datotek metapodatkov"
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "Osvežitev predpomnilnika sličic"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Setup KOReader Sync"
 msgstr "epub bralnik"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Run Hardcover Auto-Fetch"
 msgstr "Hardcover API žeton"
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Administracija"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Prenos paketa za odpravljanje napak"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Prikaži dnevnike"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Ponovni zagon"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Izklop"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "Informacije o različici"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Različica"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Podrobnosti"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "Posodobitev ni uspela:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Kanal za posodobitve"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Trenutna različica"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Preveri za posodobitev"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Izvedite posodobitev"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Ali ste prepričani, da želite znova zagnati računalnik?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "V redu"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Ste prepričani, da želite izklopiti?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Posodabljanje, prosimo, ne nalagajte te strani znova"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7147,429 +7019,407 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import"
 msgstr "Pomembno:"
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Knjig v tej knjižnici"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Nalaganje..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "Posodobitev ni uspela:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Napaka povezave"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr "Opomba:"
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Serija: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "preko"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "V knjižnici"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "zmanjšaj"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Več po"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Izbriši knjigo"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Brisanje vrste:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Pretvori vrsto knjige:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Pretvori iz:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr "izberi možnost"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Pretvori v:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Pretvori knjigo"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Napaka"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Nalaganje vrsta"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "Številka serije"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Datum objave"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Vrsta identifikatorja"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Vrednost identifikatorja"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Odstrani"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Dodaj identifikator"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Prenesi naslovnico iz naslova URL (JPEG - slika se prenese in shrani v "
 "zbirko podatkov)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Prenesi naslovnico iz lokalnega diska"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "Omogoči sinhronizacijo s Kobo"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr "Onemogoči sinhronizacijo opomb v Hardcover"
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr "Onemogoči sinhronizacijo napredka branja v Hardcover"
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Oglej si knjigo po shranjevanju"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Pridobivanje metapodatkov"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Ključna beseda"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "Ključna beseda za iskanje"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr "Izbrana polja metapodatkov so bila uporabljena v obrazcu za urejanje."
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Nalaganje..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Napaka pri iskanju!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "Ni najden noben rezultat! Poskusite z drugo ključno besedo."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "To polje je obvezno"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 #, fuzzy
 msgid " Exchange author & title"
 msgstr "Zamenjava avtorja in naslova"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "Ustvari polico"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr "Počisti vse"
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Update Title Sort automatically  "
 msgstr "Samodejna posodobitev razvrščanja po naslovu"
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Samodejna posodobitev razvrščanja po avtorju"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Vnesi naslov"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Vnesi razvrščanje naslovov"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Razvrščanje naslovov"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Vnesi razvrščanje avtorjev"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Razvrščanje avtorjev"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Vnesi avtorja"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Vnesi kategorijo"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Vnesi serijo"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Vnesi jezike"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Datum objave"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Vnesi založnike"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Vnesi komentarje"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Comments"
 msgstr "Komentarji"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Archived?"
 msgstr "Arhivirano"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Read?"
 msgstr "Preberi"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "Vnesi "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Ste res prepričani?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "Knjige z naslovom bodo združene iz:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "V knjigo z naslovom:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr "Naslednje knjige bodo izbrisane:"
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr "Naslednje knjige bodo arhivirane:"
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr "Naslednje knjige bodo odstranjene iz arhiva:"
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr "Naslednje knjige bodo označene kot prebrane:"
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr "Naslednje knjige bodo označene kot neprebrane:"
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Urejanje metapodatkov"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr "Uredite polja, ki jih želite spremeniti. Prazna polja bodo prezrta:"
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
@@ -7577,188 +7427,187 @@ msgstr ""
 "Za avtorje, oznake/kategorije, jezike in založnike je podprtih več "
 "vrednosti. Uporabite vrednosti, ločene z vejico (npr. \"Ime1, Ime2\")."
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "Ustvari polico"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr "Izberite polico, na katero želite dodati izbrane knjige:"
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr "-- Izberite polico --"
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Dodaj"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr "Ups! E-poštni strežnik ni nastavljen, obrnite se na skrbnika."
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr "Sporočilo"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Novo geslo je bilo poslano na vaš e-poštni naslov"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Pošlji v e-bralnik"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Nazaj"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Lokacija podatkovne zbirke Calibre"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7774,13 +7623,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7791,7 +7640,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7802,11 +7651,11 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr "Funkcionalnost razdeljene knjižnice"
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
@@ -7816,32 +7665,32 @@ msgstr ""
 "code> naj ostane v <code>/calibre-library</code>, vendar so lahko datoteke "
 "vaše knjižnice kjer koli želite"
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Uporabljaš Google Drive?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Preverjanje pristnosti storitve Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Mapa Calibre v Google Drive"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "Metapodatki Watch ID kanala"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Preklic"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Ponovna povezava podatkovne zbirke Calibre"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7858,97 +7707,97 @@ msgstr ""
 "varnostno kopirani v /config/backup pred kakršnim koli uničujočim dejanjem.</"
 "b> Dnevnik obnove bo shranjen poleg varnostnih kopij."
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "Ste prepričani, da želite izklopiti?"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Ponovna povezava podatkovne zbirke Calibre"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr "Nova lokacija db je neveljavna, vnesite veljavno pot"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Uporaba standardnega preverjanja pristnosti"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Uporaba overjanja LDAP"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Uporaba protokola OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Nastavitve strežnika"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Vrata strežnika"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Lokacija datoteke SSL potrdila (za strežnike, ki ne uporabljajo SSL pustite "
 "prazno)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Lokacija datoteke s ključi SSL (za strežnike, ki ne uporabljajo SSL pustite "
 "prazno)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Kanal za posodobitve"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Stabilen"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Nočen"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "Zaupanja vredni gostitelji (ločeni z vejico)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Nastavitev dnevniške datoteke"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "Lokacija in ime dnevniške datoteke dostopa (access.log, če ni vneseno)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Omogoči dnevnik dostopa"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "Lokacija in ime dnevniške datoteke dostopa (access.log, če ni vneseno)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "Nastavitve strežnika"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 "Pretvarjanje neangleških znakov v naslovu in avtorju med shranjevanjem na "
 "disk"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
@@ -7956,39 +7805,39 @@ msgstr ""
 "Vstavljanje metapodatkov v datoteko e-knjige ob prenosu/pretvorbi/"
 "elektronski pošti (potrebujete binarne datoteke Calibre/Kepubify)"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Omogoči nalaganje"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr "(prepričaj se, da imajo uporabniki tudi dovoljenja za nalaganje)"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Dovoljene vrste datotek za nalaganje"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Omogočanje anonimnega brskanja"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Omogočanje javne registracije"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "Uporabi e-pošto kot uporabniško ime"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Omogoči oddaljeno prijavo prek povezave Magic Link"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7996,157 +7845,157 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Posredovanje neznanih zahtev do trgovine Kobo"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Zunanja vrata strežnika (za posredovane klice API)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 "Sinhronizacija napredka branja Kobo s knjigo (zahteva ključ API za "
 "uporabnika)"
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Uporabi Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Ključ API Goodreads"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Hardcover Sync"
 msgstr "Omogoči sinhronizacijo s Kobo"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr "Hardcover API ključ"
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "Veljavnost žetona je potekla"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Ključ API Goodreads"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8154,11 +8003,11 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Omogočanje avtentikacije povratnega posrednika"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
@@ -8167,11 +8016,11 @@ msgstr ""
 "Zaupa glavi \"Remote-User\" iz povratnega proksija za avtentikacijo. To je "
 "metoda prijave, ki se razlikuje od spodnje varnostne nastavitve HTTPS."
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr "Uporaba preko HTTPS"
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
@@ -8179,11 +8028,11 @@ msgstr ""
 "Omogoči nastavitve varnih piškotkov (Secure, SameSite=Lax). To omogočite LE, "
 "če do strežnika dostopate preko HTTPS, sicer vam bo dostop onemogočen."
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr "Samodejno ustvari uporabnike iz povratnega proksija"
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
@@ -8193,79 +8042,79 @@ msgstr ""
 "povratnega proksija. Omogočite le, če je vaša avtentikacija povratnega "
 "proksija pravilno zavarovana."
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Vrsta prijave"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr "Uporabi OAuth (zahteva HTTPS)"
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "Gostiteljsko ime ali naslov IP strežnika LDAP"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "Vrata strežnika LDAP"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "Šifriranje LDAP"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Pot do CACcertifikata LDAP (potrebna samo za preverjanje pristnosti "
 "odjemalčevega certifikata)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Pot potrdila LDAP (potrebna samo za preverjanje pristnosti potrdila "
 "odjemalca)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "Pot do datoteke ključa LDAP (potrebna samo za preverjanje pristnosti "
 "odjemalčevega potrdila)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "Preverjanje pristnosti LDAP"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Enostavno"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "Uporabniško ime skrbnika LDAP"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "Geslo skrbnika LDAP"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "Razpoznavno ime (DN) LDAP"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "Filtriranje predmeta uporabnika LDAP"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "Strežnik LDAP je OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr "Samodejno ustvari uporabnike iz LDAP"
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
@@ -8273,43 +8122,43 @@ msgstr ""
 "Samodejno ustvari uporabniške račune, ko je avtentikacija LDAP za nove "
 "uporabnike uspešna. Priporočljivo za podjetniška okolja."
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr "Za uvoz uporabnika so potrebne naslednje nastavitve"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "Filter objektov skupine LDAP"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "Ime skupine LDAP"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "Polje člani skupine LDAP"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "Zaznavanje filtrov za uporabnike članov LDAP"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "Samodejno zaznavanje"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "Filter po meri"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "Filtriranje uporabnikov članov LDAP"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr "Pomembno:"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
@@ -8317,28 +8166,28 @@ msgstr ""
 "Avtentikacija OAuth zahteva dostop do strežnika preko HTTPS. Če uporabljate "
 "HTTP, prijava ne bo uspela."
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr "Splošni ponudnik OAuth"
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr "URL metapodatkov OAuth (za samodejno odkrivanje)"
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "Pridobivanje metapodatkov"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr "Pustite prazno za ročno konfiguracijo spodaj"
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr "Uporabi ročne URL-je končnih točk (povozi samodejno odkrivanje)"
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
@@ -8346,47 +8195,47 @@ msgstr ""
 "Označite to za ročno nastavitev posameznih končnih točk OAuth namesto "
 "uporabe samodejnega odkrivanja"
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "Urejanje nastavitev uporabniškega vmesnika"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr "Osnovni URL OAuth"
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr "Končna točka za avtorizacijo"
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "ne najdem žetona"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr "Končna točka UserInfo"
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "Napaka povezave"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "Nastavitve OAuth"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr "Seznam obsegov (scopes) OAuth, ločenih s presledkom"
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr "Gostitelj za preusmeritev OAuth"
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
@@ -8396,7 +8245,7 @@ msgstr ""
 "napake \"neveljaven preusmeritveni URI\". Vključite protokol (https://). "
 "Pustite prazno za samodejno zaznavanje."
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
@@ -8404,75 +8253,75 @@ msgstr ""
 "Zahtevano, če: dostopate preko več imen gostiteljev, ste za povratnim "
 "proksijem ali prejemate napake \"neveljaven preusmeritveni URI\"."
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Id"
 msgstr "%(provider)s Id odjemalca OAuth"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Secret"
 msgstr "%(provider)s skrivnost odjemalca OAuth"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "Prikaži nastavitve"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "Uporabniško ime"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr "Polje JWT za pridobitev uporabniškega imena"
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "Storitev e-pošte"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr "Polje JWT za pridobitev e-pošte"
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "OAuth skupina za skrbnika"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr "OAuth skupina za skrbnika"
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
@@ -8482,102 +8331,102 @@ msgstr ""
 "onemogočanje upravljanja skrbnikov na podlagi skupin ali uporabite splošno "
 "nastavitev v Varnostnih nastavitvah za večji nadzor."
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Privzete nastavitve za nove uporabnike"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Dovoli prenose"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Dovoli pregledovalnik e-knjig"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Dovoli nalaganje"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Omogoči urejanje"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Dovoli izbris knjig"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Dovoli spreminjanje gesla"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Omogoči urejanje javnih polic"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr "Besedilo gumba za prijavo"
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Pridobitev %(provider)s poverilnice OAuth"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "%(provider)s Id odjemalca OAuth"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "%(provider)s skrivnost odjemalca OAuth"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Zunanje binarne datoteke"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr "Pot do binarnih datotek Calibre"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Calibre E-Book Converter Settings"
 msgstr "Nastavitve pretvornika e-knjig Calibre"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Pot do Kepubify pretvornika e-knjig"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 msgid "Location of Unrar binary"
 msgstr "Lokacija binarnega programa Unrar"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 msgid "Security Settings"
 msgstr "Varnostne nastavitve"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr "Onemogoči standardno prijavo (uporabniško ime/geslo)"
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
@@ -8586,11 +8435,11 @@ msgstr ""
 "OAuth ali LDAP. Preden to omogočite, se prepričajte, da imate delujoč "
 "alternativni način prijave."
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr "Omogoči upravljanje skrbniških vlog na podlagi skupin OAuth"
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8602,90 +8451,90 @@ msgstr ""
 "skrbniških vlog na plošči za upravljanje uporabnikov, s čimer preprečite, da "
 "bi prijave preko OAuth povozile lokalne dodelitve vlog."
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr "Omejitev neuspelih poskusov prijave"
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr "Nastavitev zalednega sistema za omejitve"
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr "Možnosti za omejitev zalednega sistema"
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 "Preveri ali se končnice datotek ujemajo z vsebino datoteke pri nalaganju"
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Session protection"
 msgstr "Zaščita seje"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr "Osnovna"
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr "Močna"
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 msgid "User Password policy"
 msgstr "Pravilnik o geslih uporabnikov"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr "Najmanjša dolžina gesla"
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr "Obvezna uporaba številk"
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr "Obvezna uporaba malih črk"
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr "Obvezna uporaba velikih črk"
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr "Obvezna uporaba znakov (potrebno za kitajske/japonske/korejske znake)"
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr "Obvezna uporaba posebnih znakov"
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Prikaži nastavitve"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr "Naslov, prikazan v zavihku brskalnika in navigacijski vrstici."
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr "Število knjig za prikaz na stran v seznamu (1-200)."
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Število naključnih knjig za prikaz"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr "Število naključnih knjig na začetni strani (1-30)."
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr ""
 "Število avtorjev, ki se prikažejo pred skrivanjem (0 = onemogoči skrivanje)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
@@ -8693,16 +8542,16 @@ msgstr ""
 "Največje število avtorjev v podrobnostih knjige pred skrajšanjem. Nastavite "
 "na 0 za onemogočanje."
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "Privzeto"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "caliBlur! temna tema"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
@@ -8710,244 +8559,239 @@ msgstr ""
 "Privzeta tema za nove uporabnike in anonimno brskanje. Uporabniki lahko "
 "izberejo svojo želeno temo v svojem profilu."
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Regularni izraz za ignoriranje stolpcev"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 "Regex vzorec za prikritje po meri nastavljenih stolpcev v uporabniškem "
 "vmesniku."
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Poveži stanje prebrano/neprebrano s stolpcem Calibre"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "Poveži stanje prebrano/neprebrano s stolpcem Calibre"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Prikaz omejitev na podlagi stolpca Calibre"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 "Omejitev vidnosti knjig na podlagi vrednosti v Calibre tekstovnem stolpcu po "
 "meri."
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Regularni izraz za razvrščanje naslovov"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Prikaži nastavitve"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Custom CSS"
 msgstr "Filter po meri"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Privzete nastavitve za nove uporabnike"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 "Te nastavitve bodo uporabljene za vse na novo ustvarjene uporabniške račune."
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "Različica"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Administratorski uporabnik"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "Prikaz ene strani"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "Privzeti jezik"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "Privzete nastavitve za nove uporabnike"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "Privzet vidni jezik knjig"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "Privzete vidnosti za nove uporabnike"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Privzete vidnosti za nove uporabnike"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 "Izberite, kateri razdelki stranske vrstice so privzeto vidni za nove "
 "uporabnike."
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Prikaži naključne knjige v podrobnem pogledu"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Dodajanje oznak dovoljeno/zavrnjeno"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Dodajanje vrednosti stolpca dovoljeno/zavrnjeno po meri"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Naloži"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Candidates"
 msgstr "Možna ujemanja"
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "Arhiv"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "Prenesi"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Začetek"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr "Urnik 5 min"
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr "Urnik 15 min"
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr "Pretvorba knjižnice je bila uspešno načrtovana"
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr "Napaka pri načrtovanju pretvorbe knjižnice"
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8956,14 +8800,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8971,96 +8815,95 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr "Zaženi na posamezni knjigi"
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr "Iskanje po naslovu/avtorju"
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "Združevanje izbranih knjig"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "{} uporabnikov uspešno izbrisanih"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "Napaka pri brisanju police"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "Ni bilo najdenih rezultatov"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "Vnesi uporabniško ime"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "Iskanje po knjižnici"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "Ustvari polico"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "Združevanje izbranih knjig"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "Napaka pri brisanju police"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Nastavitve pretvornika e-knjig Calibre"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -9068,11 +8911,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -9083,11 +8926,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -9097,39 +8940,39 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
-"To orodje je bilo prilagojeno po orodju <a href=\"https://kindle-epub-fix."
-"netlify.app/\">kindle-epub-fix.netlify.app</a>, ki ga je izdelal <a "
+"To orodje je bilo prilagojeno po orodju <a href=\"https://kindle-epub-"
+"fix.netlify.app/\">kindle-epub-fix.netlify.app</a>, ki ga je izdelal <a "
 "href=\"https://github.com/innocenat\">innocenat</a>."
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr "Omogoči agresivni način popravljanja EPUB (tvegano)"
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
@@ -9138,12 +8981,12 @@ msgstr ""
 "kodiranja z nižjo stopnjo zaupanja. Za večino knjižnic je priporočljiv varni "
 "način."
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "Arhivirane knjige"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
@@ -9152,116 +8995,116 @@ msgstr ""
 "obstaja več v knjižnici Calibre. Pomaga ohranjati natančno število "
 "arhiviranih elementov."
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr "Urnik čiščenja:"
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr "Pogosti intervali"
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr "Vsakih 15 minut"
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr "Vsakih 30 minut"
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr "Vsako uro"
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr "Vsaki 2 uri"
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr "Vsake 4 ure"
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr "Vsakih 6 ur"
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr "Vsakih 12 ur"
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr "Dnevno/Tedensko/Mesečno"
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr "Dnevno ob določenem času"
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr "Tedensko na določen dan"
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr "Mesečno na določen dan"
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr "Privzeto: dnevno ob 03:00"
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr "Dan v tednu:"
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr "Ponedeljek"
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr "Torek"
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr "Sreda"
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr "Četrtek"
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr "Petek"
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr "Sobota"
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr "Nedelja"
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr "Dan v mesecu:"
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr "(1-28)"
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr "Čas dneva:"
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr "(Časovni pas strežnika: %(tz)s)"
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr "Omogoči samodejno pridobivanje metapodatkov za nove knjige"
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9269,11 +9112,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr "Omogoči pametno uveljavljanje metapodatkov"
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9284,12 +9127,12 @@ msgstr ""
 "boljše kakovosti (npr. daljši opisi, višja ločljivost ovitkov). Ko je "
 "onemogočeno, bodo podatki zamenjani neposredno od ponudnika."
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "Metapodatki so bili uspešno posodobljeni"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
@@ -9298,27 +9141,25 @@ msgstr ""
 "Izberite, katera polja metapodatkov naj se posodobijo pri samodejnem "
 "pridobivanju. Neoznačena polja ne bodo nikoli spremenjena."
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr "Oznake/Žanri"
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identifikatorji"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "Naslovnica"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr "Nasvet"
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
@@ -9327,25 +9168,25 @@ msgstr ""
 "Te izbire polj veljajo tako za pametni kot neposredni način zamenjave. "
 "Pametni način bo dodatno uporabil kriterije kakovosti."
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr "Časovna omejitev obdelave uvoza"
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
@@ -9354,19 +9195,19 @@ msgstr ""
 "Najdaljši čas (v minutah) za obdelavo posamezne knjige. Datoteke, ki "
 "prekoračijo ta čas, so premaknjene v mapo za spodletele poskuse."
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr "Časovna omejitev (minute):"
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr "Razpon: 5-120 minut (privzeto: 15)"
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr "Čiščenje zastarelih začasnih datotek"
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
@@ -9375,27 +9216,27 @@ msgstr ""
 "Prezrte začasne datoteke prenosov (.uploading, .part itd.) se lahko očistijo "
 "po določenem času. Nastavitev na 0 onemogoči čiščenje."
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr "Starost zastarelih datotek (minute):"
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr "Razpon: 0-10080 minut (privzeto: 120)"
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr "Interval čiščenja zastarelih datotek (sekunde):"
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr "Razpon: 0-86400 sekund (privzeto: 600)"
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr "Zakasnitev samodejnega pošiljanja za nove knjige"
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9407,19 +9248,19 @@ msgstr ""
 "pred pošiljanjem. Velja le za uporabnike, ki so v svojem profilu omogočili "
 "samodejno pošiljanje."
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr "Zakasnitev (minute):"
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr "Razpon: 1-60 minut (privzeto: 5)"
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr "Hierarhija ponudnikov za samodejno pridobivanje metapodatkov"
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
@@ -9429,26 +9270,26 @@ msgstr ""
 "pridobivanju za nove knjige. Povlecite in spustite za spremembo vrstnega "
 "reda. Uporabljeni bodo le omogočeni ponudniki."
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 "Ponudniki so preizkušeni po vrstnem redu od zgoraj navzdol. Povlecite za "
 "spremembo vrstnega reda."
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr "Omogočeni ponudniki metapodatkov"
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr "Neoznačeni ponudniki so onemogočeni na ravni celotnega sistema."
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Hardcover API žeton"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
@@ -9458,12 +9299,12 @@ msgstr ""
 "Hardcover omogočajo sinhronizacijo napredka branja in opomb z aplikacijo "
 "Hardcover.app pri uporabi združljivih e-bralnikov."
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Token Required"
 msgstr "Hardcover API žeton"
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
@@ -9474,18 +9315,18 @@ msgstr ""
 "nastaviti splošni žeton v Osnovnih nastavitvah. Brez veljavnega žetona bo ta "
 "funkcija ostala onemogočena."
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
@@ -9495,24 +9336,24 @@ msgstr ""
 "visoko stopnjo zaupanja se uveljavijo samodejno; ujemanja z nizko stopnjo "
 "zaupanja se uvrstijo v čakalno vrsto za ročni pregled."
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr "Urnik zagona:"
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 "Kako pogosto naj se samodejno zažene opravilo pridobivanja Hardcover ID-jev"
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr "Prag minimalnega zaupanja:"
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr "Razpon: 0.50-1.00 (privzeto: 0.85)"
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
@@ -9522,15 +9363,15 @@ msgstr ""
 "ocene se uvrstijo v vrsto za ročni pregled. Višje vrednosti = manj "
 "samodejnih ujemanj, a večja natančnost."
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr "Velikost serije:"
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr "Razpon: 10-200 knjig na zagon (privzeto: 50)"
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
@@ -9538,15 +9379,15 @@ msgstr ""
 "Število knjig, obdelanih v vsakem načrtovanem zagonu. Manjše serije "
 "zmanjšajo obremenitev API-ja; večje serije hitreje obdelajo vašo knjižnico."
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr "Zakasnitev zaradi omejitve števila zahtev (sekunde):"
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr "Razpon: 0-60 sekund (privzeto: 5.0)"
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
@@ -9554,34 +9395,34 @@ msgstr ""
 "Zakasnitev med API zahtevami na Hardcover. Preprečuje omejevanje zahtev in "
 "ščiti vaš API ključ. Ob napakah uporablja eksponentno podaljševanje časa."
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "Nastavitve"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "Nastavitve OAuth"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9589,36 +9430,35 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr "Omogoči obvestila za prispevanje prevodov"
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -9627,12 +9467,12 @@ msgstr ""
 "Ko je onemogočeno, ne boste več prejemali obvestil v spletnem vmesniku, če "
 "uporabljate jezik, ki ni angleščina, in prevodi za ta jezik niso popolni."
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Usklajevanje izbrane police s Kobo"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
@@ -9640,11 +9480,11 @@ msgstr ""
 "Ko je aktivno, bodo vaše Čarobne police sinhronizirane z vašo napravo Kobo "
 "kot zbirke. Opomba: Omogočiti morate tudi Kobo Sync v Osnovnih nastavitvah."
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Omogoči zamegljena ozadja na mobilnih napravah (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -9652,16 +9492,16 @@ msgstr ""
 "Ko je aktivno, se učinek zamegljenega ozadja ovitka izriše tudi na majhnih "
 "zaslonih. Onemogočite, če opazite upočasnitev pri pomikanju ali animacijah."
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Nastavitve OAuth"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -9669,11 +9509,11 @@ msgstr ""
 "Ko je aktivno, bo kopija vseh uvoženih datotek shranjena v <i>/config/"
 "processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -9681,21 +9521,21 @@ msgstr ""
 "Ko je aktivno, bodo originali uvoženih datotek, ki so bile pretvorjene, "
 "shranjeni v /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9707,11 +9547,11 @@ msgstr ""
 "spodletelih datotek tistega dne. To pomaga ohranjati red v podimenikih /"
 "config/processed_books in zmanjšuje porabo prostora na disku."
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -9721,33 +9561,33 @@ msgstr ""
 "samodejno pretvorjene v tukaj izbran format (razen formatov na spodnjem "
 "seznamu prezrtih)"
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Pretvori vrsto knjige:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9755,19 +9595,19 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr "Calibre lahko ob uvozu zazna podvojene naslove knjig in glede na"
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr "samodejno združevanje"
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -9775,34 +9615,34 @@ msgstr ""
 "nastavitev. Nastavi se lahko tako, da izbriše eno od obeh različic podvojene "
 "knjige ali pa ohrani obe (privzeto)."
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Zavrže podvojen uvoz, ohrani kopijo v knjižnici"
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr "Prepiše kopijo v knjižnici z novo uvoženo datoteko"
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Ustvari podvojen zapis in ohrani obe kopiji"
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
@@ -9810,32 +9650,32 @@ msgstr ""
 "Omogočite ali onemogočite sistem za zaznavanje dvojnikov. Ko je onemogočeno, "
 "se iskanje dvojnikov ne bo izvajalo in obvestila ne bodo prikazana."
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Omogočanje javne registracije"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr "Metoda zaznavanja dvojnikov"
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr "Hibridno (SQL predfilter + Python validacija)"
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr "Samo Python (najpočasneje, najzanesljivejše)"
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr "Samo zastarel SQL (eksperimentalno)"
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
@@ -9843,12 +9683,12 @@ msgstr ""
 "Hibridni način uporablja hiter SQL predfilter za zožitev kandidatov, nato pa "
 "uporabi zanesljivo Python logiko za končne rezultate."
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Nastavitve OAuth"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
@@ -9856,42 +9696,42 @@ msgstr ""
 "Nastavite iskanje dvojnikov v ozadju. Ta se izvajajo samodejno brez "
 "blokiranja uporabniškega vmesnika."
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr "Omogoči samodejno iskanje dvojnikov"
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr "Iskanje po uvozu"
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr "Zaženi po vsakem uvozu (z omejitvijo pogostosti)"
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Manual only"
 msgstr "Ročno?"
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr "Čas čakanja po uvozu (sekunde)"
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr "Počakaj toliko sekund po zadnjem uvozu pred začetkom iskanja v ozadju."
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr "Načrtovana iskanja (cron izraz)"
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr "Pustite prazno za onemogočanje načrtovanih iskanj. Primer:"
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
@@ -9900,15 +9740,15 @@ msgstr ""
 "iskanje (cron). Uporabite „Samo ročno“, da onemogočite iskanja po uvozu, a "
 "ohranite urnike cron."
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr "Naslednje načrtovano iskanje:"
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
@@ -9917,31 +9757,31 @@ msgstr ""
 "Nastavite, katera polja metapodatkov se uporabijo za določanje dvojnikov. "
 "Knjige se morajo ujemati v VSEH izbranih kriterijih, da štejejo za dvojnike."
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr "Upoštevaj naslove knjig pri zaznavanju dvojnikov"
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr "Upoštevaj avtorje knjig pri zaznavanju dvojnikov"
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr "Upoštevaj jezik knjig pri zaznavanju dvojnikov"
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr "Upoštevaj zbirke (serije) knjig pri zaznavanju dvojnikov"
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr "Upoštevaj založnika knjig pri zaznavanju dvojnikov"
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr "Upoštevaj format datoteke pri zaznavanju dvojnikov"
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
@@ -9949,11 +9789,11 @@ msgstr ""
 "Izbran mora biti vsaj en kriterij. Kot osnovna kriterija sta priporočena "
 "naslov in avtor."
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr "Vrstni red prioritete formatov dvojnikov"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
@@ -9963,11 +9803,11 @@ msgstr ""
 "razrešitve „Format najvišje kakovosti“. Povlecite in spustite za razvrščanje "
 "formatov po prioriteti (višje = bolje)."
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr "Nasvet:"
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
@@ -9977,11 +9817,11 @@ msgstr ""
 "knjige z višje uvrščenimi formati ohranjene, tiste z nižjo prioriteto pa "
 "izbrisane."
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr "Obvestila o dvojnikih in samodejna razrešitev"
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
@@ -9989,12 +9829,12 @@ msgstr ""
 "Nastavite način obveščanja o podvojenih knjigah in po želji omogočite "
 "samodejno razreševanje."
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Omogočanje javne registracije"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
@@ -10004,16 +9844,16 @@ msgstr ""
 "uporabniki s pravico urejanja bodo ob prijavi videli značko na gumbu "
 "Dvojniki v stranski vrstici in pojavno obvestilo."
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Omogočanje javne registracije"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr "Opozorilo:"
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
@@ -10021,77 +9861,77 @@ msgstr ""
 "To bo samodejno izbrisalo knjige na podlagi spodnje strategije. Izvirne "
 "datoteke bodo varnostno kopirane v"
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr "Strategija samodejne razrešitve"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr "Ohrani najnovejšo"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr "Izbriši starejše kopije, ohrani nazadnje dodano knjigo"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr "Ohrani najstarejšo"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr "Izbriši novejše kopije, ohrani prvo dodano"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Izvirna oblika"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr "Združi formate v najnovejšo knjigo, ostale izbriši"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr "Ohrani format najvišje kakovosti"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 "Prednost daj formatom na podlagi vašega vrstnega reda prioritete formatov"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Pridobivanje metapodatkov"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr "Ohrani knjigo z najbolj popolnimi informacijami"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr "Ohrani največjo datoteko"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr "Ohrani knjigo z največjo skupno velikostjo datotek"
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 "Izberite, katero knjigo želite obdržati pri samodejnem razreševanju "
 "dvojnikov."
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Ocena"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr "Obdobje mirovanja (minute)"
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
@@ -10099,7 +9939,7 @@ msgstr ""
 "Najkrajši čas med samodejnimi razrešitvami (0 za onemogočanje). Preprečuje "
 "zaporedne izbrise med množičnim uvozom."
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -10107,288 +9947,276 @@ msgstr ""
 "Samodejna razrešitev se zažene, ko iskanje dvojnikov zazna nove dvojnike. "
 "Opuščene skupine dvojnikov se nikoli ne razrešijo samodejno."
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr "Pregled %(count)s ujemanj na čakanju"
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr "Kliknite za ogled več"
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Naslednji"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Označi kot neprebrano"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Označi kot prebrano"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "Označi kot neprebrano"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "Označi kot neprebrano"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Dodaj v arhiv"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Obnovi iz arhiva"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Obnovi iz arhiva"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Dodaj v arhiv"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "Obnovi iz arhiva"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Reloaded metadata from disk"
 msgstr "Omogočeni ponudniki metapodatkov"
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Unhide from your library"
 msgstr "Skrij to polico iz stranske vrstice"
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "Skrij to polico iz stranske vrstice"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "Posodobljene nastavitve zbirke podatkov"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "Zgornja ocena"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "Knjiga %(index)s v %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr "ID"
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr "UUID"
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr "UUID kopiran v odložišče"
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr "UUID-ja ni bilo mogoče kopirati"
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr "Kopiraj UUID"
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 #, fuzzy
 msgid "File sizes"
 msgstr "Velikosti pisave"
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Opis:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "Pošlji v e-pošto e-bralnika"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "Pošlji v e-pošto e-bralnika"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "Ustvari polico"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr "Dodatni e-poštni naslovi:"
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr "Vnesite dodatne e-poštne naslove (ločene z vejico):"
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr "primer@domena.si, drug@domena.si"
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr "Vnesite enega ali več e-poštnih naslovov, ločenih z vejico"
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "Brisanje vrste:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "Nisem uspel ustvariti poti za naslovnice"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "Nisem uspel ustvariti poti za naslovnice"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
@@ -10396,66 +10224,66 @@ msgstr ""
 "Knjige z ujemajočimi naslovi, avtorji in jeziki. Knjige v različnih jezikih "
 "se ne štejejo za dvojnike."
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Izbriši knjigo"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "Prikaži najbolje ocenjene knjige"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr "Izberi dvojnike"
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "Izberi"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "Združevanje izbranih knjig"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Izbriši knjigo"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View Background Tasks"
 msgstr "Pregled nalog v ozadju"
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr "Samodejno razreši dvojnike"
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
@@ -10463,23 +10291,23 @@ msgstr ""
 "Samodejno razreši vse skupine dvojnikov tako, da ohrani eno knjigo in "
 "izbriše ostale na podlagi strategije."
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr "Strategija:"
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr "Ohrani najnovejšo - Izbriši starejše kopije, ohrani nazadnje dodano"
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr "Ohrani najstarejšo - Izbriši novejše kopije, ohrani prvo dodano"
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr "Združi formate - Združi formate v najnovejšo knjigo, ostale izbriši"
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
@@ -10487,65 +10315,65 @@ msgstr ""
 "Ohrani format najvišje kakovosti - Prednost daj formatom glede na vašo "
 "prioriteto formatov"
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 "Ohrani največ metapodatkov - Ohrani knjigo z najbolj popolnimi informacijami"
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 "Ohrani največjo datoteko - Ohrani knjigo z največjo skupno velikostjo datotek"
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "Prejšnji"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr "Izvedi razrešitev"
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 "To bo trajno izbrisalo knjige. Izvirne datoteke bodo varnostno kopirane v"
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "Združevanje izbranih knjig"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr "Opusti to skupino dvojnikov"
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "Podrobnosti o knjigi"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "urejanje metapodatkov"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "Združevanje izbranih knjig"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "Ni bilo najdenih rezultatov"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 "V vaši knjižnici ni knjig s podvojenimi kombinacijami naslova in avtorja."
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
@@ -10553,125 +10381,125 @@ msgstr ""
 "To iskanje išče knjige z identičnimi naslovi IN avtorji, da prepreči napačne "
 "rezultate."
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Execute Auto-Resolution"
 msgstr "Izvedi razrešitev"
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Brisanje vrste:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr "Tega dejanja ni mogoče razveljaviti!"
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be permanently deleted:"
 msgstr "Naslednje knjige bodo izbrisane:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "Neprebrane knjige"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "Naslednje knjige bodo izbrisane:"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "Naslednje knjige bodo izbrisane:"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr "Opomba: Formati datotek iz izvornih knjig bodo dodani ciljni knjigi."
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr "Predogled razrešitve"
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr "Uspeh"
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr "Izbrani dvojniki knjig so bili uspešno izbrisani!"
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr "Pri obdelavi vaše zahteve je prišlo do napake."
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "Vrsta e-poštnega računa"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr "Standardni e-poštni račun"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr "Račun Gmail"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr "Nastavitev računa Gmail"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Preklic dostopov do Gmail"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "Geslo za SMTP"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Omejitev velikosti priloge"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 msgid "Save and Send Test Email"
 msgstr "Shrani in pošlji testno e-pošto"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Dovoljene domene (bel seznam)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Dodajanje domene"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Vnesi ime domene"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Zavrnjene domene (črni seznam)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr "(Čarobno)"
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10679,23 +10507,23 @@ msgstr ""
 "V urejevalniku besedila odprite datoteko .kobo/Kobo/Kobo eReader.conf in "
 "dodajte (ali uredite):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Kobo žeton:"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "Seznam"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr "Pregled ujemanj Hardcover 🔖"
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr "Vse je urejeno!"
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
@@ -10703,26 +10531,26 @@ msgstr ""
 "Ni ujemanj Hardcover, ki bi zahtevala pregled. Nova ujemanja se bodo "
 "pojavila tukaj, ko se zažene opravilo samodejnega pridobivanja."
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr "Nazaj na skrbniško ploščo"
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr "Potreben pregled"
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr "Ujemanja na čakanju"
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
@@ -10732,71 +10560,65 @@ msgstr ""
 "Ujemanja z visoko stopnjo zaupanja se uveljavijo samodejno; ta pa zahtevajo "
 "ročno potrditev."
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "Ustvari polico"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "Iskalni izraz:"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr "Možna ujemanja"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr "Najboljših %(count)s"
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr "Zaupanje"
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr "Razlog ujemanja"
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "Oglej si knjigo po shranjevanju"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr "Izberi to ujemanje"
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "Ustvari polico"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr "Preskoči za zdaj"
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "Nalaganje..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr "✓ Izberi to ujemanje"
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr "Napaka pri uveljavljanju ujemanja"
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
@@ -10805,17 +10627,16 @@ msgstr ""
 "Ali ste prepričani, da želite spremeniti izbrano vlogo za izbranega(-e) "
 "uporabnika(-e)?"
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr "✗ Zavrni vsa ujemanja"
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "Nisem uspel ustvariti poti za naslovnice"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
@@ -10823,307 +10644,304 @@ msgstr ""
 "Ali ste prepričani, da želite spremeniti izbrano vlogo za izbranega(-e) "
 "uporabnika(-e)?"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "Ustvari polico"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "Nisem uspel ustvariti poti za naslovnice"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr "→ Preskoči za zdaj"
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr "Napaka pri preskoku ujemanja"
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "Instanca Calibre-Web ni nastavljena, obrni se na skrbnika"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Ustvarjanje poročila o težavi"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Vrnitev domov"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "Odjava uporabnika"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr "Obvestilo za mobilne naprave"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 "Urejanje čarobnih polic najbolje deluje na namiznih ali tabličnih "
 "računalnikih."
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr "Osveži polico za posodobitev z najnovejšimi spremembami"
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "Urejanje police"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr "Skrij to polico iz stranske vrstice"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show this shelf in your sidebar"
 msgstr "Sinhronizacija te police z napravo Kobo"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "Pokaži vse"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "Javna polica"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Dodaj na polico"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 #, fuzzy
 msgid "KOReader Sync is disabled."
 msgstr "Standardna prijava je onemogočena."
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Domov"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Preklopi navigacijo"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Iskanje po knjižnici"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Katalog e-knjig Calibre-Web"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Odjava"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "Nastavitve"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "Iskanje po knjižnici"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Informacije o izdaji niso na voljo"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Katalog e-knjig Calibre-Web"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr "Poglej dnevnik sprememb"
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Dvojniki"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr "Prispevajte tukaj!"
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Ne osvežuj strani"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Ustvari polico"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr "Čarobne police ✨"
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Prejšnji"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Podrobnosti o knjigi"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Tega dejanja ni mogoče razveljaviti!"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Združevanje izbranih knjig"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Nalaganje vrsta"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Brisanje vrste:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Izbriši knjigo"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr "V vaši knjižnici so nerazrešeni dvojniki knjig"
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Ni bilo najdenih rezultatov"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr "Opomni me pozneje"
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr "Ogled in razreševanje dvojnikov"
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Povečaj na najboljše"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "Nasvet"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 msgid "Confirm"
 msgstr ""
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Dodaj na polico"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Združevanje izbranih knjig"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Označi kot neprebrano"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Izbriši knjigo"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Izbriši knjigo"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -11131,96 +10949,96 @@ msgid ""
 msgstr ""
 "To bo trajno izbrisalo knjige. Izvirne datoteke bodo varnostno kopirane v"
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Ustvari polico"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Napaka povezave"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr "Filtriraj po začetnici"
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "Mreža"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "Geslo za SMTP"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Zapomni si me"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Ste pozabili geslo?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Prijavi se s povezavo Magic Link"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 #, fuzzy
 msgid "Log in with SSO"
 msgstr "Prijavi se s povezavo Magic Link"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 "Standardna prijava je onemogočena. Prosimo, uporabite eno od alternativnih "
 "metod prijave."
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Prikaži dnevnik Calibre-Web:"
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Calibre-Web Log: "
 msgstr "Prikaži dnevnik Calibre-Web:"
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Izhodni tok, ki ga ni mogoče prikazati"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Prikaži dnevnik dostopa: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Prenos Calibre-Web Log"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "Prenos dnevnika dostopa"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr "Sistemska predloga"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 "To je vnaprej konfigurirana predloga police. Lahko jo poljubno urejate."
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "Deli z vsemi"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
@@ -11228,50 +11046,50 @@ msgstr ""
 "Drugi uporabniki si lahko ogledajo to polico. Uporabniki z dovoljenjem "
 "„Urejanje javnih polic“ jo lahko urejajo ali izbrišejo."
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Izberite dovoljene/zavrnjene oznake"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Izberite dovoljene/zavrnjene vrednosti stolpcev po meri"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Izberite dovoljene/zavrnjene oznake uporabnika"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr "Izberite dovoljene/zavrnjene vrednosti stolpcev po meri uporabnika"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Vnesite oznako"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Dodajanje omejitve prikaza"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "Ta vrsta knjige bo trajno izbrisana iz podatkovne baze"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Ta knjiga bo trajno izbrisana iz baze podatkov"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "in iz trdega diska"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Pomembno opozorilo Kobo: izbrisane knjige bodo ostale v vsaki povezani "
 "napravi Kobo."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11279,284 +11097,284 @@ msgstr ""
 "Preden lahko knjigo varno izbrišete, jo morate najprej arhivirati in "
 "sinhronizirati napravo."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Izberi lokacijo datoteke"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "vrsta"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "ime"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "velikost"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "Nadrejeni imenik"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "V redu"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Katalog e-knjig Calibre-Web"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "epub bralnik"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "Dejanja"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "Črno"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "Velikosti pisave"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Naslednja stran"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr "Pisava"
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 msgid "Default"
 msgstr "Privzeto"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr "Yahei"
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr "SimSun"
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 msgid "KaiTi"
 msgstr "KaiTi"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 msgid "Arial"
 msgstr "Arial"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 msgid "Spread"
 msgstr "Razprši"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr "Dva stolpca"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr "En stolpec"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Preusmerjanje besedila, ko so odprte stranske vrstice."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 #, fuzzy
 msgid "Note"
 msgstr "Opomba:"
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Bralnik stripov"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Bližnjice na tipkovnici"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Prejšnja stran"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Naslednja stran"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 msgid "Single Page Display"
 msgstr "Prikaz ene strani"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr "Prikaz dolgega traku"
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Povečaj na najboljše"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Povečaj na širino"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Povečaj na višino"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Povečaj na privzeto"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Obračanje v desno"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Obračanje v levo"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Obrni sliko"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "Prikaz"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 msgid "Single Page"
 msgstr "Ena stran"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr "Dolgi trak"
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Povečava"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Najboljša"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Širina"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Višina"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Privzeto"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Zavrti"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Obrni"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Vodoravno"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Navpično"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Direction"
 msgstr "Opis"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Od leve proti desni"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Od desne proti levi"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr "Ponastavitev na vrh"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 msgid "Remember Position"
 msgstr "Zapomni si položaj"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "Drsni trak"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "Prikaži"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "Bralnik DJVU"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "Bralnik PDF"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "txt bralnik"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Registracija novega računa"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Izberite uporabniško ime"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Vaš e-poštni naslov"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Magic Link - avtorizacija nove naprave"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "V drugi napravi se prijavite in obiščite:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "Po preverjanju boste samodejno prijavljeni v to napravo."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Ta povezava za preverjanje poteče čez 10 minut."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
@@ -11564,260 +11382,256 @@ msgstr ""
 "Samodejno osveži vse sličice med načrtovanim vzdrževanjem. Sličice se vedno "
 "generirajo na zahtevo, ne glede na to nastavitev."
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "Ustvarjanje sličic naslovnic serij"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Ni bilo najdenih rezultatov"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Iskalni izraz:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Rezultati za:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Datum objave od"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Datum objave do"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr "Prazen"
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Izključi oznake"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Izključi serijo"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "Izključi police"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Izključi jezike"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Razširitve"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Izključitev razširitev"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Zgornja ocena"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Spodnja ocena"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "Od:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "Za:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Brisanje te police"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "Urejanje lastnosti police"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Skrita knjiga"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "Ročno urejanje knjig"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "Onemogoči spremembo vrstnega reda"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "Omogoči spremembo vrstnega reda"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Združevanje izbranih knjig"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Najboljših %(count)s"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "ne najdem žetona"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Brisanje te police"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Could not add the books. Please try again."
 msgstr "Povezovanje računa OAuth ni uspelo. Prosimo, poskusite znova."
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Dodaj na polico"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Iskanje po knjižnici"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Iskanje po knjižnici"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Deli z vsemi"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "Sinhronizacija te police z napravo Kobo"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Ne najdem uporabnika"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Skrita knjiga"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Statistika knjižnice"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Knjig v tej knjižnici"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Avtorjev v tej knjižnici"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Kategorij v tej knjižnici"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Serij v tej knjižnici"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Sistemske statistike"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "Program"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Nameščena različica"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr "Pregled nalog v ozadju"
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Čas delovanja"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Actions"
 msgstr "Dejanja"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr "Prihajajoča načrtovana pošiljanja"
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr "Načrtovan čas"
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "Zavrti"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
@@ -11825,15 +11639,15 @@ msgstr ""
 "Prihajajoča pošiljanja so shranjena in se bodo uvrstila med naloge ob "
 "načrtovanem času. Čakajoče pošiljanje lahko prekličete, preden se izvede."
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr "Prihajajoče načrtovane operacije"
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr "Vrsta"
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
@@ -11842,14 +11656,14 @@ msgstr ""
 "ohranjeni tudi po ponovnem zagonu. Prekličite jih, če ne želite, da se "
 "sprožijo."
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 "To opravilo bo preklicano. Vsak napredek, dosežen pri tem opravilu, bo "
 "shranjen."
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
@@ -11857,169 +11671,169 @@ msgstr ""
 "Če je to načrtovano opravilo, se bo ponovno izvedlo ob naslednjem "
 "načrtovanem času."
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "{} uporabnikov uspešno izbrisanih"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr "Napaka pri preklicu načrtovanega elementa"
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Katalog e-knjig Calibre-Web"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Portainer:"
 msgstr "Pomembno:"
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Set up automatic updates"
 msgstr "Omogoči samodejno iskanje dvojnikov"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "Vaš e-poštni naslov"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "Nastavitve"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr "Podatki o računu"
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 "Če želite spremeniti svoj e-poštni naslov ali geslo, lahko to storite tukaj."
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Ponastavitev uporabniškega gesla"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "Nastavitve strežnika"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "Pošlji v e-pošto e-bralnika"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr "Uporabite vejico za ločevanje več naslovov"
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr "E-poštni naslovi za vaše e-bralnike. Več naslovov ločite z vejicami."
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
@@ -12028,11 +11842,11 @@ msgstr ""
 "Ko je omogočeno, bodo na novo uvožene knjige samodejno poslane na vse zgoraj "
 "nastavljene e-poštne naslove e-bralnikov."
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr "Samodejno pošlji nove knjige v moje e-bralnike"
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
@@ -12040,111 +11854,111 @@ msgstr ""
 "Ko je omogočeno, bodo na novo uvožene knjige samodejno poslane na vse zgoraj "
 "nastavljene e-poštne naslove e-bralnikov."
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr "Nastavitve jezika in teme"
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "Vnesi jezike"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Jezik knjig"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr "Filtriraj knjižnico, da bodo prikazane le knjige v določenem jeziku."
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "Ni navedenega veljavnega jezika knjige"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr "OAuth in API integracije"
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "Nastavitve OAuth"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Povezava"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Odklop povezave"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Hardcover API Token"
 msgstr "Hardcover API žeton"
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr "API žeton za integracijo ponudnika metapodatkov Hardcover."
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Žeton za sinhronizacijo Kobo"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Ustvari/pogled"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "Vsili popolno sinhronizacijo s Kobo"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "Sinhroniziranje samo knjig na izbranih policah s Kobo"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "Sinhroniziranje samo knjig na izbranih policah s Kobo"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "Varnostne nastavitve"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 "Izberite, kateri razdelki naj bodo prikazani v navigaciji stranske vrstice."
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Dodajanje dovoljenih/zavrnjenih vrednosti stolpcev po meri"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr "Vrstni red OPDS kataloga"
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
@@ -12152,7 +11966,7 @@ msgstr ""
 "Prerazvrstite korenski katalog OPDS tako, da navedete ID-je vnosov v želenem "
 "vrstnem redu. Neznani ID-ji so prezrti, manjkajoči vnosi pa dodani samodejno."
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
@@ -12160,74 +11974,74 @@ msgstr ""
 "Povlecite za prerazvrstitev korenskih vnosov OPDS. Manjkajoči vnosi bodo "
 "dodani samodejno."
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr "Uporabniška dovoljenja"
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr "Nastavite, katera dejanja sme izvajati ta uporabnik."
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Magic Shelves Order"
 msgstr "Čarobne police ✨"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "Zadnjič spremenjeno"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Least recently modified"
 msgstr "Zadnjič spremenjeno"
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr "Vidnost čarobnih polic"
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
@@ -12236,34 +12050,34 @@ msgstr ""
 "ni mogoče izbrisati, le skriti. Skrijete lahko tudi javne police drugih "
 "uporabnikov."
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr "Privzete sistemske police:"
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "Urejanje javnih polic"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr "%(visible)s od %(total)s privzetih polic je vidnih"
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr "%(visible)s od %(total)s javnih polic je vidnih"
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Izbriši uporabnika"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12271,156 +12085,156 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Sprememba gesla"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Sprememba gesla"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Ustvari/pogled"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Last used"
 msgstr "Zadnjič spremenjeno"
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Ustvarite URL avtentikacije Kobo"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr "Vidno"
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Izberi..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Odstranjevanje izbire"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "Uredi uporabnika"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "Vnesi uporabniško ime"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 msgid "Enter Email"
 msgstr "Vnesi e-pošto"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "Enter eReader Email"
 msgstr "Vnesi e-pošto e-bralnika"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "eReader Email"
 msgstr "E-pošta za e-bralnik"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "Vnesi e-pošto e-bralnika"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "E-pošta za e-bralnik"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Lokacija"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "Jeziki vidnih knjig"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "Uredi dovoljene oznake"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Dovoljene oznake"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Uredi zavrnjene oznake"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Zavrnjene oznake"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "Urejanje dovoljenih vrednosti stolpcev"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "Dovoljene vrednosti stolpcev"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "Urejanje vrednosti zavrnjenega stolpca"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "Zavrnjene vrednosti stolpcev"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "Sprememba gesla"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "Urejanje javnih polic"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "Usklajevanje izbrane police s Kobo"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "Usklajevanje izbrane police s Kobo"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 msgid "Show Read/Unread Section"
 msgstr "Prikaži razdelek Prebrano/neprebrano"
 

--- a/cps/translations/sv/LC_MESSAGES/messages.po
+++ b/cps/translations/sv/LC_MESSAGES/messages.po
@@ -19,33 +19,33 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Statistik"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 #, fuzzy
 msgid "Server restarted, please reload page."
 msgstr "Server startas om, vänligen uppdatera sidan"
 
-#: cps/admin.py:210
+#: cps/admin.py
 #, fuzzy
 msgid "Performing Server shutdown, please close window."
 msgstr "Stänger servern, vänligen stäng fönstret"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr ""
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Okänt kommando"
 
-#: cps/admin.py:232
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
@@ -53,222 +53,220 @@ msgstr ""
 "Testa e-post i kö för att skicka till %(email)s, vänligen kontrollera "
 "Uppgifter för resultat"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr ""
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 
-#: cps/admin.py:414
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover ID applied successfully"
 msgstr "{} användare har tagits bort"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr ""
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr ""
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr ""
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr ""
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr ""
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Administrationssida"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "OAuth-inställningar"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Grundläggande konfiguration"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Användargränssnitt konfiguration"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, fuzzy, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr "Anpassad kolumn n.%(column)d finns inte i calibre-databasen"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Redigera användare"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Alla"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Användaren hittades inte"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} användare har tagits bort"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Visa alla"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Felaktig begäran"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "Gästnamn kan inte ändras"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "Gäst kan inte ha den här rollen"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr ""
 "Ingen administratörsanvändare kvar, kan inte ta bort administratörsrollen"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "Värdet måste vara sant eller falskt"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Ogiltig roll"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "Gästen kan inte ha den här vyn"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "Ogiltig vy"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr "Gästens språk bestäms automatiskt och kan inte ställas in"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Inget giltigt språk anges"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Inget giltigt bokspråk anges"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Parameter hittades inte"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr ""
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 #, fuzzy
 msgid "Invalid Read Column"
 msgstr "Ogiltig roll"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr ""
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Vill du verkligen ta bort Kobo-token?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "Vill du verkligen ta bort den här domänen?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "Vill du verkligen ta bort den här användaren?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Är du säker på att du vill ta bort hyllan?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr "Är du säker på att du vill ändra språk för valda användare?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr "Är du säker på att du vill ändra synliga bokspråk för valda användare?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 "Är du säker på att du vill ändra den valda rollen för de valda användarna?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
@@ -276,7 +274,7 @@ msgstr ""
 "Är du säker på att du vill ändra de valda begränsningarna för de valda "
 "användarna?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -284,137 +282,132 @@ msgstr ""
 "Är du säker på att du vill ändra de valda synlighetsbegränsningarna för de "
 "valda användarna?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "Är du säker på att du vill ändra den valda rollen för de valda användarna?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
 msgstr ""
 "Är du säker på att du vill ändra den valda rollen för de valda användarna?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 #, fuzzy
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Är du säker på att du vill stoppa Calibre-Web?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Förneka"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Tillåt"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr ""
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Token hittades inte"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Taggen hittades inte"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Ogiltig åtgärd"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json är inte konfigurerad för webbapplikation"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "Loggfilens plats är inte giltig, vänligen ange rätt sökväg"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "Åtkomstloggplatsens plats är inte giltig, vänligen ange rätt sökväg"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 "Vänligen ange en LDAP-leverantör, port, DN och användarobjektidentifierare"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 #, fuzzy
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Ange giltigt användarnamn för att återställa lösenordet"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr ""
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP-gruppobjektfilter måste ha en \"%s\"-formatidentifierare"
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "LDAP-gruppobjektfilter har omatchande parentes"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP-användarobjektfilter måste ha en \"%s\"-formatidentifierare"
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "LDAP-användarobjektfilter har omatchad parentes"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Användarfilter för LDAP-medlemmar måste ha en \"%s\"-formatidentifierare"
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "Användarfilter för LDAP-medlemmar har omatchad parentes"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -422,29 +415,24 @@ msgstr ""
 "LDAP-certifikat, certifikat eller nyckelplats är inte giltigt, vänligen ange "
 "rätt sökväg"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Lägg till ny användare"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Ändra SMTP-inställningar"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr ""
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Databasfel: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
@@ -452,53 +440,53 @@ msgstr ""
 "Testa e-post i kö för att skicka till %(email)s, vänligen kontrollera "
 "Uppgifter för resultat"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Det gick inte att skicka Testmeddelandet: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Vänligen konfigurera din e-postadress först..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "E-postserverinställningar uppdaterade"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "Redigera användare"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Konfigurera SMTP-postinställningarna först..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "Vänligen konfigurera din e-postadress först..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "Nytt lösenord skickades till din e-postadress"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
@@ -506,7 +494,7 @@ msgstr ""
 "Testa e-post i kö för att skicka till %(email)s, vänligen kontrollera "
 "Uppgifter för resultat"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
@@ -515,928 +503,913 @@ msgstr ""
 "Testa e-post i kö för att skicka till %(email)s, vänligen kontrollera "
 "Uppgifter för resultat"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr ""
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr ""
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr ""
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr ""
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Ett okänt fel uppstod. Försök igen senare."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "Titel"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Redigera användaren %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Lösenord för användaren %(user)s återställd"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Konfigurera SMTP-postinställningarna först..."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Visaren för loggfil"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Begär uppdateringspaketet"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Hämtar uppdateringspaketet"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Packar upp uppdateringspaketet"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Ersätta filer"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Databasanslutningarna är stängda"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Stoppar server"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Uppdatering klar, tryck på okej och uppdatera sidan"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Uppdateringen misslyckades:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "HTTP-fel"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Anslutningsfel"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Tiden ute när du etablerade anslutning"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Allmänt fel"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 #, fuzzy
 msgid "Update file could not be saved in temp dir"
 msgstr "Uppdateringsfilen kunde inte sparas i Temp Dir"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr ""
 
-#: cps/admin.py:2419
+#: cps/admin.py
 #, fuzzy
 msgid "Failed to extract at least One LDAP User"
 msgstr "Det gick inte att skapa minst en LDAP-användare"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Det gick inte att skapa minst en LDAP-användare"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Fel: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Fel: Ingen användare återges som svar på LDAP-servern"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "Minst en LDAP-användare hittades inte i databasen"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} användare har importerats"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr ""
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "DB-plats är inte giltig, vänligen ange rätt sökväg"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "DB är inte skrivbar"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "Keyfile-platsen är inte giltig, vänligen ange rätt sökväg"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr "Certfile-platsen är inte giltig, vänligen ange rätt sökväg"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr ""
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 #, fuzzy
 msgid "Database Settings updated"
 msgstr "E-postserverinställningar uppdaterade"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 #, fuzzy
 msgid "Database Configuration"
 msgstr "Funktion konfiguration"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Fyll i alla fält!"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "E-posten är inte från giltig domän"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Lägg till ny användare"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Användaren '%(user)s' skapad"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "Hittade ett befintligt konto för den här e-postadressen eller namnet."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Användaren '%(nick)s' borttagen"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "Det går inte att ta bort gästanvändaren"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "Ingen adminstratörsanvändare kvar, kan inte ta bort användaren"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr ""
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Användaren '%(nick)s' uppdaterad"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr ""
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr ""
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Anslutningsfel"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr ""
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "Ingen versionsinformation tillgänglig"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr ""
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr ""
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr ""
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "Ett okänt fel uppstod. Försök igen senare."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "Anslutningsfel"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Anslutningsfel"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "Filen %(file)s uppladdad"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr ""
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr ""
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr ""
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr ""
 
-#: cps/constants.py:265
+#: cps/constants.py
 #, fuzzy
 msgid "Finnish"
 msgstr "Klar"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr ""
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr ""
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr ""
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr ""
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr ""
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr ""
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr ""
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr ""
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr ""
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr ""
 
-#: cps/constants.py:276
+#: cps/constants.py
 #, fuzzy
 msgid "Polish"
 msgstr "Förlag"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr ""
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr ""
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr ""
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr ""
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr ""
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr ""
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr ""
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr ""
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr ""
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr ""
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "inte installerad"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Körningstillstånd saknas"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, python-format
 msgid "Change cover — %(title)s"
 msgstr ""
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Anslutningsfel"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr ""
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Book ID"
 msgstr "Böcker"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Boktitel"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "Författare"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr ""
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "Filformat"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filename"
 msgstr "namn"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr ""
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr ""
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "Ladda upp format"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "Okänd"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr ""
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "Ogiltig roll"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "Slå ihop utvalda böcker"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "%(format)s-format hittades inte på disken"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB Fixer started for selected book."
 msgstr "Slå ihop utvalda böcker"
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr ""
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr ""
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid image data format."
 msgstr "Ogiltigt e-postadressformat"
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Profile picture updated successfully."
 msgstr "{} användare har tagits bort"
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Ingen"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "Ta bort boken"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "Ta bort boken"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "Ta bort boken"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "Inga resultat hittades"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 #, fuzzy
 msgid "Invalid resolution strategy"
 msgstr "Ogiltig roll"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Uppladdning klar, bearbetning, vänligen vänta ..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 #, fuzzy
 msgid "Failed to queue upload for processing"
 msgstr "Det gick inte att skapa sökväg för omslag"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Källa eller målformat för konvertering saknas"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "Boken är i kö för konvertering till %(book_format)s"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Det gick inte att konvertera den här boken: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 #, fuzzy
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "Filändelsen '%(ext)s' får inte laddas upp till den här servern"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr "Filändelsen '%(ext)s' får inte laddas upp till den här servern"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "Filen som ska laddas upp måste ha en ändelse"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 "Hoppsan! Vald boktitel är inte tillgänglig. Filen finns inte eller är inte "
 "tillgänglig"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr ""
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 "Identifierare är inte skiftlägeskänsliga, skriver över gammal identifierare"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "%(langname)s är inte ett giltigt språk"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Metadata uppdaterades"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr ""
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Okänd"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1444,96 +1417,96 @@ msgstr ""
 "Uppladdad bok finns förmodligen i biblioteket, överväg att ändra innan du "
 "laddar upp nya: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "Filen %(filename)s kunde inte sparas i temp dir"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "Det gick inte att flytta omslagsfil %(file)s: %(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "Bokformat har tagits bort"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "Boken har tagits bort"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr ""
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "redigera metadata"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr ""
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr ""
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "Det gick inte att skapa sökväg %(path)s (behörighet nekad)."
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Det gick inte att lagra filen %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Filformatet %(ext)s lades till %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Token hittades inte"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "%(format)s-format hittades inte på disken"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1541,7 +1514,7 @@ msgstr ""
 "Installationen av Google Drive är inte klar, försök att inaktivera och "
 "aktivera Google Drive igen"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1549,89 +1522,88 @@ msgstr ""
 "Återuppringningsdomänen är inte verifierad, följ stegen för att verifiera "
 "domänen i Google utvecklarkonsol"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "%(format)s formatet hittades inte för bok-id: %(book)d"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(format)s hittades inte på Google Drive: %(fn)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s hittades inte: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 #, fuzzy
 msgid "Send to eReader"
 msgstr "Skicka till Kindle"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "%(format)s formatet hittades inte för bok-id: %(book)d"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "%(format)s formatet hittades inte för bok-id: %(book)d"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 #, fuzzy
 msgid "Test Email"
 msgstr "Test e-post"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Registrera e-post för användare: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Konvertera %(orig)s till %(format)s och skicka till Kindle"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Skicka %(format)s till Kindle"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "%(book)s send to eReader"
 msgstr "Skicka till Kindle"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "Den begärda filen kunde inte läsas. Kanske fel behörigheter?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr ""
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
@@ -1639,19 +1611,19 @@ msgstr ""
 "Borttagning av bokmapp för boken %(id)s misslyckades, sökvägen har "
 "undermappar: %(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "Borttagning av boken %(id)s misslyckades: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, fuzzy, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
 "%(path)s"
 msgstr "Borttagning av boken %(id)s, boksökväg inte giltig: %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, fuzzy, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
@@ -1659,196 +1631,196 @@ msgstr ""
 "Byt namn på titel från: \"%(src)s\" till \"%(dest)s\" misslyckades med fel: "
 "%(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Filen %(file)s hittades inte på Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Byt namn på titel från: \"%(src)s\" till \"%(dest)s\" misslyckades med fel: "
 "%(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Boksökvägen %(path)s hittades inte på Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr ""
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Detta användarnamn är redan taget"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 #, fuzzy
 msgid "Invalid Email address format"
 msgstr "Ogiltigt e-postadressformat"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr ""
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Fel vid hämtning av omslaget"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr "Omslagsfilen är inte en giltig bildfil eller kunde inte lagras"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Fel på omslagsformat"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
 msgstr ""
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Det gick inte att skapa sökväg för omslag"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "Endast jpg/jpeg/png/webp/bmp-filer stöds som omslagsfil"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr ""
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "Endast jpg/jpeg-filer stöds som omslagsfil"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr ""
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "UnRar binär fil hittades inte"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing UnRar"
 msgstr "Fel vid körning av UnRar"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr ""
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr ""
 
-#: cps/helper.py:2125
+#: cps/helper.py
 #, fuzzy
 msgid "Calibre binaries not viable"
 msgstr "DB är inte skrivbar"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "Körningstillstånd saknas"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing Calibre"
 msgstr "Fel vid körning av UnRar"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr ""
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Kobo-installation"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "Registrera dig med %(provider)s"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "E-postservern är inte konfigurerad, kontakta din administratör!"
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1856,35 +1828,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "du är nu inloggad som: \"%(nickname)s\""
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "Länk till %(oauth)s lyckades"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1892,4150 +1864,4082 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr "E-postservern är inte konfigurerad, kontakta din administratör!"
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "Sluta länka till %(oauth)s lyckades"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "Sluta länka till %(oauth)s misslyckades"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "Inte länkad till %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Det gick inte att logga in med GitHub."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Det gick inte att hämta användarinformation från GitHub."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Det gick inte att logga in med Google."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Det gick inte att hämta användarinformation från Google."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "Failed to log in with Generic OAuth."
 msgstr "Det gick inte att logga in med GitHub."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "GitHub Oauth-fel, försök igen senare."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "GitHub Oauth-fel: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Google Oauth-fel, försök igen senare."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Google Oauth-fel: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, fuzzy, python-brace-format
 msgid "OAuth error: {}"
 msgstr "GitHub Oauth-fel: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "Alfabetiska böcker"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "Böcker sorterade alfabetiskt"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Heta böcker"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "Populära publikationer från den här katalogen baserad på hämtningar."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Bäst rankade böcker"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Populära publikationer från den här katalogen baserad på betyg."
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "Hämtade böcker"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "De senaste böckerna"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Slumpmässiga böcker"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Visa slumpmässiga böcker"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Lästa böcker"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Aktuell version"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Olästa böcker"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Författare"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Böcker ordnade efter författare"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Förlag"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Böcker ordnade efter förlag"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Kategorier"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Böcker ordnade efter kategori"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Serier"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Böcker ordnade efter serier"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Språk"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Böcker ordnade efter språk"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Betyg"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Böcker sorterade efter Betyg"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Filformat"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Böcker ordnade av filformat"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Hyllor"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "Böcker organiserade i hyllor"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Redigera publika hyllor"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Böcker organiserade i hyllor"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "Beskrivning"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} stjärnor"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Sök"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Logga in"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Token hittades inte"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Token har löpt ut"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Lyckades! Vänligen återvänd till din enhet"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Böcker"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Visa senaste böcker"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Visa heta böcker"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Hämtade böcker"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Visa hämtade böcker"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Visa böcker med bästa betyg"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Read and Unread"
 msgstr "Visa lästa och olästa"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Visa olästa"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Upptäck"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Category Section"
 msgstr "Visa kategorival"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Series Section"
 msgstr "Visa serieval"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Author Section"
 msgstr "Visa författarval"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Publisher Section"
 msgstr "Visa urval av förlag"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Language Section"
 msgstr "Visa språkval"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Ratings Section"
 msgstr "Visa val av betyg"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show File Formats Section"
 msgstr "Visa val av filformat"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Arkiverade böcker"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Archived Books"
 msgstr "Visa arkiverade böcker"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Boklista"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Visa boklista"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr ""
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Visa böcker med bästa betyg"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Publicerad efter "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Publicerad före "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Betyg <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Betyg >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, fuzzy, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Lässtatus = %(status)s"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Avancerad sökning"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Ogiltig hylla specificerad"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 #, fuzzy
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "Tyvärr får du inte lägga till en bok på hyllan: %(shelfname)s"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "Boken är redan en del av hyllan: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "Boken har lagts till i hyllan: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr ""
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "Böcker är redan en del av hyllan: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "Böcker har lagts till hyllan: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "Kunde inte lägga till böcker till hyllan: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "Ogiltig hylla specificerad"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "Kunde inte lägga till böcker till hyllan: %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Böcker är redan en del av hyllan: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "Böcker har lagts till hyllan: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "Boken har tagits bort från hyllan: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr ""
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Skapa en hylla"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 #, fuzzy
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr ""
 "Tyvärr har du inte rätt att ta bort en bok från den här hyllan: %(sname)s"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Redigera en hylla"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr ""
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 #, fuzzy
 msgid "Shelf successfully deleted"
 msgstr "Boken har tagits bort"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Ändra ordning på hyllan: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr ""
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Hyllan %(title)s skapad"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Hyllan %(title)s ändrad"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Det fanns ett fel"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "En offentlig hylla med namnet \"%(title)s\" finns redan."
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "En privat hylla med namnet \"%(title)s\" finns redan."
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Hylla: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Fel vid öppning av hyllan. Hylla finns inte eller är inte tillgänglig"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Uteslut hyllor"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Anonym"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "Oautentiserad"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Ja"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Nej"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Lässtatus"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Tema"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Ljust"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Mörkt"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr ""
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Lägg till hyllan"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Författare"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Bläddra"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Stäng"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Ta bort"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Slå samman"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Förlag"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Läst"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Titel"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Ladda upp"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Konto"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Administratör"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Publicerad"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Källa"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "Om"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Arkiverad"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Beskrivning"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Hämta"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Redigera"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "E-post"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "Aktivera Kobo sync"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Identifierare"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Språk"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Lösenord"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Förlopp"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Betyg"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Spara"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "Välj"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Status"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Taggar"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Uppgift"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Uppgifter"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Användare"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Smeknamn"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Visa"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Väntar"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Misslyckades"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Startad"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Klar"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr ""
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr ""
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Okänd status"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Oväntade data vid läsning av uppdateringsinformation"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr ""
 "Ingen uppdatering tillgänglig. Du har redan den senaste versionen installerad"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6043,16 +5947,16 @@ msgstr ""
 "En ny uppdatering är tillgänglig. Klicka på knappen nedan för att uppdatera "
 "till den senaste versionen."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Kunde inte hämta uppdateringsinformation"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr ""
 "Klicka på knappen nedan för att uppdatera till den senaste stabila versionen."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6061,1039 +5965,1007 @@ msgstr ""
 "En ny uppdatering är tillgänglig. Klicka på knappen nedan för att uppdatera "
 "till version: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Ingen versionsinformation tillgänglig"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Upptäck (slumpmässiga böcker)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Heta böcker (mest hämtade)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "Hämtade böcker av %(user)s"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Författare: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Förlag: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Serier: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr ""
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Betyg: %(rating)s stars"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Filformat: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Kategori: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Språk: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Heta böcker"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Dold bok"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "Fel vid hämtning av omslaget"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "Ogiltigt e-postadressformat"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 #, fuzzy
 msgid "Invalid request"
 msgstr "Ogiltig roll"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr ""
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 #, fuzzy
 msgid "Error creating shelf"
 msgstr "Fel vid hämtning av omslaget"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Skapa en hylla"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 #, fuzzy
 msgid "Shelf name is required"
 msgstr "Detta fält är obligatoriskt"
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "Fel vid hämtning av omslaget"
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "Redigera en hylla"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "Användaren hittades inte"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "{} användare har tagits bort"
 
-#: cps/web.py:1710
+#: cps/web.py
 #, fuzzy
 msgid "Error duplicating shelf"
 msgstr "Fel vid hämtning av omslaget"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 #, fuzzy
 msgid "Error deleting shelf"
 msgstr "Fel vid hämtning av omslaget"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "Fel vid hämtning av omslaget"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 #, fuzzy
 msgid "Error unhiding shelf"
 msgstr "Fel vid hämtning av omslaget"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Hämtningar"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Lista över filformat"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 #, fuzzy
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Konfigurera SMTP-postinställningarna först..."
 
-#: cps/web.py:2400
+#: cps/web.py
 #, fuzzy
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr "Konfigurera din kindle-e-postadress först..."
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "Boken är i kö för att skicka till %(eReadermail)s"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Det gick inte att skicka den här boken: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "Boken är i kö för att skicka till %(eReadermail)s"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Registrera"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 #, fuzzy
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr "E-postservern är inte konfigurerad, kontakta din administratör!"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr "E-postservern är inte konfigurerad, kontakta din administratör!"
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "Din e-post är inte tillåten att registrera"
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "Bekräftelsemail skickades till ditt e-postkonto."
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
 msgstr "E-postservern är inte konfigurerad, kontakta din administratör!"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "E-postservern är inte konfigurerad, kontakta din administratör!"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 #, fuzzy
 msgid "Cannot activate LDAP authentication"
 msgstr "Det går inte att aktivera LDAP-autentisering"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr ""
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, fuzzy, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "du är nu inloggad som: \"%(nickname)s\""
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "du är nu inloggad som: \"%(nickname)s\""
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
 msgstr "E-postservern är inte konfigurerad, kontakta din administratör!"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
 "known"
 msgstr ""
 
-#: cps/web.py:2801
+#: cps/web.py
 #, fuzzy, python-format
 msgid "Could not login: %(message)s"
 msgstr "Det gick inte att logga in: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 #, fuzzy
 msgid "Wrong Username or Password"
 msgstr "Fel användarnamn eller lösenord"
 
-#: cps/web.py:2832
+#: cps/web.py
 #, fuzzy
 msgid "New Password was sent to your email address"
 msgstr "Nytt lösenord skickades till din e-postadress"
 
-#: cps/web.py:2836
+#: cps/web.py
 #, fuzzy
 msgid "An unknown error occurred. Please try again later."
 msgstr "Ett okänt fel uppstod. Försök igen senare."
 
-#: cps/web.py:2838
+#: cps/web.py
 #, fuzzy
 msgid "Please enter valid username to reset password"
 msgstr "Ange giltigt användarnamn för att återställa lösenordet"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, fuzzy, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "du är nu inloggad som: \"%(nickname)s\""
 
-#: cps/web.py:3158
+#: cps/web.py
 #, fuzzy
 msgid "Success! Profile Updated"
 msgstr "Profilen uppdaterad"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "Hittade ett befintligt konto för den här e-postadressen"
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 #, fuzzy
 msgid "Invalid book ID."
 msgstr "Ogiltig roll"
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr ""
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "Hittade ingen giltig gmail.json-fil med OAuth-information"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "Skicka till Kindle"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "Skicka till Kindle"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-send completed successfully"
 msgstr "{} användare har tagits bort"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr ""
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr ""
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, fuzzy, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "Skicka till Kindle"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "calibre e-bokkonverterings %(tool)s hittades inte"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "%(format)s-format hittades inte på disken"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "E-bokkonverteraren misslyckades med okänt fel"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Kepubify-konverteraren misslyckades: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr "Konverterad fil hittades inte eller mer än en fil i mappen %(folder)s"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "calibre misslyckades med fel: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "E-bokkonverteraren misslyckades: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 #, fuzzy
 msgid "Reconnecting Calibre database"
 msgstr "Plats för Calibre-databasen"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "Ta bort boken"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Ta bort boken"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Packar upp uppdateringspaketet"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Inga resultat hittades"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Aktivera Kobo sync"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 #, fuzzy
 msgid "E-mail"
 msgstr "E-post"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 #, fuzzy
 msgid "Backing up Metadata"
 msgstr "redigera metadata"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "I biblioteket"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "Böcker organiserade i hyllor"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Ändra lösenord"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Skapa en hylla"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "OAuth-inställningar"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Inställningar"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "välj ett alternativ"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "Lägg till hyllan"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Publik)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "Hämtningar"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Hämtningar"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "Sortera efter bokdatum, nyast först"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "Sortera efter bokdatum, äldsta först"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Författare"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Författare"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Publicerad före "
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Publicerad före "
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Sortera efter bokdatum, nyast först"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "Sortera efter bokdatum, äldsta först"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Send to eReader Email"
 msgstr "Kindle"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "Skicka till Kindle"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Visa e-böcker"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Publik hylla"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr ""
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "Importera LDAP-användare"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Inställningar för SMTP-e-postserver"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "SMTP-värdnamn"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "SMTP-port"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "SMTP-inloggning"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Från meddelande"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Service"
 msgstr "E-posttjänst"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail via Oauth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Calibre DB dir"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Loggnivå"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Extern port"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Böcker per sida"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Laddar upp"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Anonym surfning"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Publik registrering"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Fjärrinloggning"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "Omvänd proxy inloggning"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Omvänt proxy rubriknamn"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Redigera grundläggande konfiguration"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Redigera UI-konfiguration"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Edit Calibre Database Configuration"
 msgstr "Redigera grundläggande konfiguration"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr ""
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Start Time"
 msgstr "Startad"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr ""
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr ""
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 #, fuzzy
 msgid "Reconnect Calibre Database"
 msgstr "Plats för Calibre-databasen"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr ""
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr ""
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Setup KOReader Sync"
 msgstr "PDF-läsare"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr ""
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Administration"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Hämta felsökningspaketet"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Visa loggfiler"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Starta om Calibre-Web"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Stoppa Calibre-Web"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr ""
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Version"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Detaljer"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "Uppdateringen misslyckades:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Uppdatera kanal"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Aktuell version"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Sök efter uppdatering"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Utför uppdatering"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Är du säker på att du vill starta om Calibre-Web?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Är du säker på att du vill stoppa Calibre-Web?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Uppdaterar, vänligen uppdatera inte sidan"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7101,619 +6973,596 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Böcker i det här biblioteket"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Laddar upp..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "Uppdateringen misslyckades:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Anslutningsfel"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Serier: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "via"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "I biblioteket"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "minska"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Mer av"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Ta bort boken"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Ta bort format:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Konvertera bokformat:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Konvertera från:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "select an option"
 msgstr "välj ett alternativ"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Konvertera till:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Konvertera boken"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Fel"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Ladda upp format"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "Serie-ID"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Publiceringsdatum"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Identifierartyp"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Identifierarvärde"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Ta bort"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Lägg till identifierare"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Omslagswebbadress (jpg, omslag hämtas och lagras i databasen, fältet är "
 "efteråt tomt igen)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Ladda upp omslag från lokal enhet"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "Aktivera Kobo sync"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Visa bok vid Spara"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Hämta metadata"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Sökord"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Search keyword"
 msgstr " Sök sökord "
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Läser in..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Sökningsfel!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "Inga resultat hittades! Försök med ett annat sökord."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "Detta fält är obligatoriskt"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr ""
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "Skapa en hylla"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr ""
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Update Title Sort automatically  "
 msgstr "Uppdatera titelsortering automatiskt"
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Uppdatera författarsortering automatiskt"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Ange titel"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Ange titelsortering"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Titelsortering"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Ange författarsortering"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Författarsortering"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Ange författare"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Ange kategorier"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Ange serier"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Ange språk"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Publiceringsdatum"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Ange utgivare"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter comments"
 msgstr "Ange domännamn"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Comments"
 msgstr "Ange domännamn"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Archived?"
 msgstr "Arkiverad"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Read?"
 msgstr "Läst"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter "
 msgstr "Identifierare"
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Är du verkligen säker?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "Böcker med titel slås samman från:"
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "I bok med titel:"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr ""
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr ""
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr ""
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr ""
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr ""
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Redigera metadata"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "Skapa en hylla"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr ""
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Lägg till"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr "E-postservern är inte konfigurerad, kontakta din administratör!"
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 #, fuzzy
 msgid "Message"
 msgstr "Slå samman"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Nytt lösenord skickades till din e-postadress"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Skicka till Kindle"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Tillbaka"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Plats för Calibre-databasen"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7729,13 +7578,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7746,7 +7595,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7757,43 +7606,43 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr ""
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
 "can be wherever you desire"
 msgstr ""
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Använda Google Drive?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Autentisera Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Google Drive Calibre-mapp"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "Metadata Titta på kanal ID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Återkalla"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Plats för Calibre-databasen"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7803,130 +7652,130 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "Är du säker på att du vill stoppa Calibre-Web?"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Plats för Calibre-databasen"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "New db location is invalid, please enter valid path"
 msgstr "DB-plats är inte giltig, vänligen ange rätt sökväg"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "Använd standardautentisering"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "Använd LDAP-autentisering"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "Använd OAuth"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Serverkonfiguration"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Serverport"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL certfile plats (lämna den tom för icke-SSL-servrar)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL Keyfile plats (lämna den tom för icke-SSL-servrar)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Uppdatera kanal"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Stabil"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Ostabil"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr ""
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Loggfil konfiguration"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "Plats och namn på åtkomstloggfil (access.log för ingen post)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Aktivera åtkomstlogg"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "Plats och namn på åtkomstloggfil (access.log för ingen post)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "Serverkonfiguration"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Aktivera uppladdning"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr ""
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "Tillåtna filformat för uppladdning"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Aktivera anonym surfning"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Aktivera offentlig registrering"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "Använd e-post som användarnamn"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Aktivera fjärrinloggning (\"magisk länk\")"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7934,154 +7783,154 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "Proxy okänd begäran till Kobo Store"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "Extern port för server (för port vidarebefordrade API-anrop)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Använd Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Goodreads API-nyckel"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Hardcover Sync"
 msgstr "Aktivera Kobo sync"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "Token har löpt ut"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Goodreads API-nyckel"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8089,420 +7938,420 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Tillåt omvänd proxyautentisering"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Inloggningstyp"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "LDAP-serverns värdnamn eller IP-adress"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "LDAP-serverport"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "LDAP-kryptering"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "LDAP CACertificate-sökväg (behövs endast för autentisering av "
 "klientcertifikat)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "LDAP-certifikatsökväg (behövs endast för autentisering av klientcertifikat)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 "LDAP-nyckelfilsökväg (behövs endast för autentisering av klientcertifikat)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "LDAP-autentisering"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "Enkel"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "LDAP-adminstratörsanvändarnamn"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "LDAP-adminstratörslösenord"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "LDAP Distinguished Name (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "LDAP-användarobjektfilter"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "LDAP-server är OpenLDAP?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr "Följande inställningar behövs för användarimport"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "LDAP-gruppobjektfilter"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "LDAP-gruppnamn"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "Fält för LDAP-gruppmedlemmar"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "LDAP-användarfilterdetektering för medlemmar"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "Upptäck automatiskt"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "Anpassat filter"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "LDAP-användarfilter för medlemmar"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "Hämta metadata"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
 msgstr ""
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "Redigera UI-konfiguration"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "Token hittades inte"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "Anslutningsfel"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "OAuth-inställningar"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Id"
 msgstr "%(provider)s OAuth-klient-id"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Secret"
 msgstr "%(provider)s OAuth-klient-hemlighet"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "Visa konfiguration"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "Smeknamn"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr ""
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "E-posttjänst"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr ""
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "LDAP-gruppnamn"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr ""
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Standardinställningar för nya användare"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Tillåt Hämtningar"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Tillåt bokvisare"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Tillåt Uppladdningar"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Tillåt Redigera"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Tillåt borttagning av böcker"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Tillåt Ändra lösenord"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Tillåt Redigering av offentliga hyllor"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr ""
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "Skaffa %(provider)s OAuth-certifikat"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "%(provider)s OAuth-klient-id"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "%(provider)s OAuth-klient-hemlighet"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Externa binärer"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Path to Calibre Binaries"
 msgstr "Sökväg till calibre e-bokkonverterare"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Calibre E-Book Converter Settings"
 msgstr "Inställningar för calibre e-bokkonverterare"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Sökväg till Kepubify calibre e-bokkonverterare"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "Plats för UnRar-binär"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Security Settings"
 msgstr "OAuth-inställningar"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8510,341 +8359,336 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr ""
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr ""
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr ""
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Session protection"
 msgstr "välj ett alternativ"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr ""
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr ""
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "User Password policy"
 msgstr "Återställ användarlösenordet"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr ""
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr ""
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Visa konfiguration"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Antal slumpmässiga böcker att visa"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr "Antal författare att visa innan de döljs (0 = inaktivera dölja)"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "Ta bort"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "caliBlur! Mörkt tema"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Reguljärt uttryck för att ignorera kolumner"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "Länka läst/oläst-status till Calibre-kolumn"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "Länka läst/oläst-status till Calibre-kolumn"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "Visa begränsningar baserade på calibre-kolumnen"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Reguljärt uttryck för titelsortering"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Visa konfiguration"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Custom CSS"
 msgstr "Anpassat filter"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Standardinställningar för nya användare"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "Version"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Adminstratör användare"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "Administrationssida"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Language"
 msgstr "Uteslut språk"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "Standardinställningar för nya användare"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Visible Language of Books"
 msgstr "Visa böcker med språk"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "Standardvisibiliteter för nya användare"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Standardvisibiliteter för nya användare"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Visa slumpmässiga böcker i detaljvyn"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "Lägg till tillåtna/avvisade taggar"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Lägg till tillåtna/avvisade anpassade kolumnvärden"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Ladda upp"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "Arkiverad"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "Hämta"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Starta"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8853,14 +8697,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8868,96 +8712,95 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "Slå ihop utvalda böcker"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "{} användare har tagits bort"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "Fel vid hämtning av omslaget"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "Inga resultat hittades"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "Ange användarnamn"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "Sök i bibliotek"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "Skapa en hylla"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "Slå ihop utvalda böcker"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "Fel vid hämtning av omslaget"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Visa åtkomstlogg: "
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8965,11 +8808,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -8980,11 +8823,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -8994,162 +8837,162 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "Arkiverade böcker"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9157,11 +9000,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9169,110 +9012,108 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "Metadata uppdaterades"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identifierare"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "Upptäck"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
 "investigation."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9280,157 +9121,157 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "OAuth-inställningar"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "Inställningar"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "OAuth-inställningar"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9438,102 +9279,101 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "OAuth-inställningar"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9541,44 +9381,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Konvertera bokformat:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9586,874 +9426,862 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Aktivera offentlig registrering"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "OAuth-inställningar"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Aktivera offentlig registrering"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Aktivera offentlig registrering"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Ta bort format:"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Hämta metadata"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Betyg"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Nästa"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Markera som oläst"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Markera som läst"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "Markera som oläst"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "Markera som oläst"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Lägg till i arkivet"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Återställ från arkivet"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Återställ från arkivet"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Lägg till i arkivet"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "Återställ från arkivet"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "Sök i bibliotek"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "E-postserverinställningar uppdaterade"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "Betyg större än"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr ""
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr ""
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Beskrivning:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "Kindle"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "Kindle"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "Skapa en hylla"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "Ta bort format:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "Det gick inte att skapa sökväg för omslag"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "Det gick inte att skapa sökväg för omslag"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr ""
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Ta bort boken"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "Visa böcker med bästa betyg"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "Välj"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "Slå ihop utvalda böcker"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Ta bort boken"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "Föregående"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "Slå ihop utvalda böcker"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "Bokdetaljer"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "redigera metadata"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "Slå ihop utvalda böcker"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "Inga resultat hittades"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr ""
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Ta bort format:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be permanently deleted:"
 msgstr "Boken kommer att tas bort från Calibre-databasen"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "Olästa böcker"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "Boken kommer att tas bort från Calibre-databasen"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "Boken kommer att tas bort från Calibre-databasen"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr ""
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr ""
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr ""
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "Välj servertyp"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Standard Email Account"
 msgstr "Använd standard e-postkonto"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Gmail Account"
 msgstr "Välj servertyp"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Setup Gmail Account"
 msgstr "Välj servertyp"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Återkalla Gmail-åtkomst"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "SMTP-lösenord"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Gräns för bilagestorlek"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Save and Send Test Email"
 msgstr "Spara inställningarna och skicka test-e-post"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Tillåtna domäner för registrering"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Lägg till domän"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Ange domännamn"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Avvisade domäner för registrering"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
@@ -10461,120 +10289,114 @@ msgstr ""
 "Öppna filen .kobo/Kobo/Kobo eReader.conf i en textredigerare och lägg till "
 "(eller redigera):"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 #, fuzzy
 msgid "Kobo Token:"
 msgstr "Kobo Sync Token"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "Skapa en hylla"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "Sökterm:"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "Visa bok vid Spara"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "Skapa en hylla"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "Läser in..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
@@ -10582,463 +10404,459 @@ msgid ""
 msgstr ""
 "Är du säker på att du vill ändra den valda rollen för de valda användarna?"
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "Det gick inte att skapa sökväg för omslag"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr ""
 "Är du säker på att du vill ändra den valda rollen för de valda användarna?"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "Skapa en hylla"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "Det gick inte att skapa sökväg för omslag"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "E-postservern är inte konfigurerad, kontakta din administratör!"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "Skapa ärende"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Tillbaka till hemmet"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 #, fuzzy
 msgid "Logout User"
 msgstr "Logga ut"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "Redigera en hylla"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Show this shelf in your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "Visa alla"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "Publik hylla"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Lägg till hyllan"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Hem"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Växla navigering"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Sök i bibliotek"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Calibre-Web e-bokkatalog"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Logga ut"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "Inställningar"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "Sök i bibliotek"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Ingen versionsinformation tillgänglig"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Calibre-Web e-bokkatalog"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Ta bort boken"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Vänligen uppdatera inte sidan"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Skapa en hylla"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Föregående"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Bokdetaljer"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Är du säker på att du vill stoppa Calibre-Web?"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Slå ihop utvalda böcker"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Ladda upp format"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Ta bort format:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Ta bort boken"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Inga resultat hittades"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Skala till bäst"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfiguration"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Lägg till hyllan"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Slå ihop utvalda böcker"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Markera som oläst"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Ta bort boken"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Ta bort boken"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Skapa en hylla"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Anslutningsfel"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr ""
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr ""
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "SMTP-lösenord"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Kom ihåg mig"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Glömt lösenord?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Logga in med magisk länk"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 #, fuzzy
 msgid "Log in with SSO"
 msgstr "Logga in med magisk länk"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Visa Calibre-Web-logg: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Calibre-Web Log: "
 msgstr "Visa Calibre-Web-logg: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Strömutmatning kan inte visas"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Visa åtkomstlogg: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Hämta logg för calibre-web"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "Hämta åtkomstlogg"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "Dela med alla"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "Välj tillåtna/avvisade taggar"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Välj tillåtna/avvisade anpassade kolumnvärden"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "Välj tillåtna/avvisade användarens taggar"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr "Välj tillåtna/avvisade anpassade kolumnvärden för användaren"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Ange tagg"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "Lägg till visningsbegränsning"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "Detta bokformat tas bort permanent från databasen"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Boken kommer att tas bort från Calibre-databasen"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "och från hårddisken"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 "Viktigt Kobo-notering: borttagna böcker kommer att finnas kvar på alla "
 "kopplade Kobo-enheter."
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
@@ -11046,974 +10864,970 @@ msgstr ""
 "Böcker måste först arkiveras och enheten synkroniseras innan en bok säkert "
 "kan tas bort."
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Välj filplats"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "typ"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "namn"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "storlek"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "Föräldramapp"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "Ok"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Calibre-Web e-bokkatalog"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 #, fuzzy
 msgid "epub Reader"
 msgstr "PDF-läsare"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 msgid "Annotations"
 msgstr ""
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 #, fuzzy
 msgid "Black"
 msgstr "Tillbaka"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr ""
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Nästa sida"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr ""
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 #, fuzzy
 msgid "Default"
 msgstr "Ta bort"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr ""
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr ""
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 #, fuzzy
 msgid "KaiTi"
 msgstr "Väntar"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 #, fuzzy
 msgid "Arial"
 msgstr "Vertikal"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 #, fuzzy
 msgid "Spread"
 msgstr "Läst"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 #, fuzzy
 msgid "Two columns"
 msgstr "Ogiltig roll"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 #, fuzzy
 msgid "One column"
 msgstr "Ogiltig roll"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Fyll i texten igen när sidofält är öppna."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Comic Reader"
 msgstr "PDF-läsare"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Kortkommandon"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Föregående sida"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Nästa sida"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page Display"
 msgstr "Administrationssida"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "Skala till bäst"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Skala till bredd"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Skala till höjd"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Skala till ursprunglig"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Rotera åt höger"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Rotera åt vänster"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Vänd bilden"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page"
 msgstr "Administrationssida"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr ""
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Skala"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Bäst"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Bredd"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Höjd"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Ursprunglig"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Rotera"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Vänd"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Horisontell"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Vertikal"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Direction"
 msgstr "Beskrivning"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Vänster till höger"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Höger till vänster"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Reset to Top"
 msgstr "Tillbaka till hemmet"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Remember Position"
 msgstr "Kom ihåg mig"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr ""
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Show"
 msgstr "Visa alla"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 #, fuzzy
 msgid "DJVU Reader"
 msgstr "PDF-läsare"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 #, fuzzy
 msgid "PDF Reader"
 msgstr "PDF-läsare"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 #, fuzzy
 msgid "txt Reader"
 msgstr "PDF-läsare"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Registrera ett nytt konto"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Välj ett användarnamn"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Din e-postadress"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Magic Link - Auktorisera ny enhet"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "På en annan enhet, logga in och besök:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "När du gör det kommer du automatiskt att logga in på den här enheten."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Länken går ut efter 10 minuter."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr ""
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Inga resultat hittades"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Sökterm:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Resultat för:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Publiceringsdatum från"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Publiceringsdatum till"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr ""
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Uteslut taggar"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Uteslut serier"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "Uteslut hyllor"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Uteslut språk"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Tillägg"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Uteslut tillägg"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Betyg större än"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Betyg mindre än"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr ""
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr ""
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Ta bort den här hyllan"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "Redigera hyllegenskaper"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Dold bok"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "Ordna böcker manuellt"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "Inaktivera ändring av ordning"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "Aktivera ändring av ordning"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Slå ihop utvalda böcker"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Konto"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Token hittades inte"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Ta bort den här hyllan"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Lägg till hyllan"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Sök i bibliotek"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Sök i bibliotek"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Dela med alla"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr ""
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Användaren hittades inte"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Dold bok"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Calibre-biblioteksstatistik"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Böcker i det här biblioteket"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Författare i det här biblioteket"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Kategorier i det här biblioteket"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Serier i detta bibliotek"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Systemstatistik"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 #, fuzzy
 msgid "Program"
 msgstr "Förlopp"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Installerad version"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Drifttid"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr ""
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "Rotera"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
 msgstr ""
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "{} användare har tagits bort"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Calibre-Web e-bokkatalog"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "Din e-postadress"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "Inställningar"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Återställ användarlösenordet"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "Serverkonfiguration"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "Kindle"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "Ange språk"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Visa böcker med språk"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "Inget giltigt bokspråk anges"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "OAuth-inställningar"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Koppla"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Koppla bort"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Kobo Sync Token"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Skapa/Visa"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 msgid "Expose only books in selected shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "OAuth-inställningar"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Lägg till tillåtna/avvisade anpassade kolumnvärden"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "Senaste tillagda böcker"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "Redigera publika hyllor"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Ta bort den här användaren"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12021,159 +11835,159 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Ändra lösenord"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Ändra lösenord"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Skapa/Visa"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "Skapa Kobo Auth URL"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Välj..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Ta bort markeringar"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "Redigera användare"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "Ange användarnamn"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Email"
 msgstr "Test e-post"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email"
 msgstr "Kindle"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email"
 msgstr "Test e-post"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "Kindle"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "Test e-post"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Språk"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "Synliga bokspråk"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "Redigera tillåtna taggar"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Tillåtna taggar"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Redigera avvisade taggar"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Avvisade taggar"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "Redigera tillåtna kolumnvärden"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "Tillåtna kolumnvärden"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "Redigera avvisade kolumnvärden"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Denied Column Values"
 msgstr "Avvisade kolumnvärden"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "Ändra lösenord"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Public Shelves"
 msgstr "Redigera publika hyllor"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 msgid "Expose selected Shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Read/Unread Section"
 msgstr "Visa läst/oläst val"

--- a/cps/translations/tr/LC_MESSAGES/messages.po
+++ b/cps/translations/tr/LC_MESSAGES/messages.po
@@ -19,1394 +19,1367 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "İstatistikler"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 #, fuzzy
 msgid "Server restarted, please reload page."
 msgstr "Sunucu yeniden başlatıldı, lütfen sayfayı yeniden yükleyin"
 
-#: cps/admin.py:210
+#: cps/admin.py
 #, fuzzy
 msgid "Performing Server shutdown, please close window."
 msgstr "Sunucu kapatıyor, lütfen pencereyi kapatın"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr ""
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr ""
 
-#: cps/admin.py:232
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr "%(eReadermail)s'a gönderilmek üzere başarıyla sıraya alındı"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr ""
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 
-#: cps/admin.py:414
+#: cps/admin.py
 msgid "Hardcover ID applied successfully"
 msgstr ""
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr ""
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr ""
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr ""
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr ""
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr ""
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Yönetim sayfası"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "OAuth Ayarları"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Temel Ayarlar"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Arayüz Ayarları"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr ""
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Tümü"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr ""
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr ""
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr ""
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr ""
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr ""
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr ""
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr ""
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr ""
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr ""
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr ""
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr ""
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr ""
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr ""
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr ""
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr ""
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr ""
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr ""
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr ""
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr ""
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr ""
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr ""
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
 msgstr ""
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1102
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr ""
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr ""
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr ""
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr ""
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Token bulunamadı"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr ""
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr ""
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr ""
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 
-#: cps/admin.py:1840
+#: cps/admin.py
 #, fuzzy
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr ""
 "Şifrenizi sıfırlayabilmek için lütfen geçerli bir kullanıcı adı giriniz"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr ""
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
 msgstr ""
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr ""
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr ""
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr ""
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr ""
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
 msgstr ""
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Deneme e-postası gönderilirken bir hata oluştu: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Lütfen önce e-posta adresinizi ayarlayın..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "E-posta sunucusu ayarları güncellendi"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 msgid "Email Your Users"
 msgstr ""
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Lütfen önce SMTP e-posta ayarlarını ayarlayın..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "Lütfen önce e-posta adresinizi ayarlayın..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "Yeni şifre e-Posta adresinize gönderildi"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
 msgstr ""
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
 "delivery."
 msgstr ""
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr ""
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr ""
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr ""
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr ""
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Bilinmeyen bir hata oluştu. Lütfen daha sonra tekrar deneyiniz."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "Başlık"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "%(nick)s kullanıcısını düzenle"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "%(user)s kullanıcısının şifresi sıfırlandı"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Lütfen önce SMTP e-posta ayarlarını ayarlayın..."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Log dosyası görüntüleyici"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Güncelleme paketi isteniyor"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Güncelleme paketi indiriliyor"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Güncelleme paketi ayıklanıyor"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Dosyalar değiştiriliyor"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Veritabanı bağlantıları kapalı"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Sunucu durduruyor"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr ""
 "Güncelleme tamamlandı, sayfayı yenilemek için lütfen Tamam'a tıklayınız"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Güncelleme başarısız:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "HTTP Hatası"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Bağlantı hatası"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Bağlantı kurulmaya çalışırken zaman aşımına uğradı"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Genel hata"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 #, fuzzy
 msgid "Update file could not be saved in temp dir"
 msgstr "%(filename)s dosyası geçici dizine kaydedilemedi"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr ""
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr ""
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr ""
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr ""
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr ""
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr ""
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr ""
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr ""
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr ""
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr ""
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 #, fuzzy
 msgid "Database Settings updated"
 msgstr "E-posta sunucusu ayarları güncellendi"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 #, fuzzy
 msgid "Database Configuration"
 msgstr "Özellik Yapılandırması"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Lütfen tüm alanları doldurun!"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "E-posta izin verilen bir servisten değil"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Yeni kullanıcı ekle"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "'%(user)s' kullanıcısı oluşturuldu"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "Bu e-posta adresi veya kullanıcı adı için zaten bir hesap var."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Kullanıcı '%(nick)s' silindi"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr ""
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "Başka yönetici kullanıcı olmadığından silinemedi"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr ""
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "'%(nick)s' kullanıcısı güncellendi"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr ""
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr ""
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Bağlantı hatası"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr ""
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "Sürüm bilgisi mevcut değil"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr ""
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr ""
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr ""
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "Bilinmeyen bir hata oluştu. Lütfen daha sonra tekrar deneyiniz."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "Bağlantı hatası"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Bağlantı hatası"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "%(file)s dosyası yüklendi"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr ""
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr ""
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr ""
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr ""
 
-#: cps/constants.py:265
+#: cps/constants.py
 #, fuzzy
 msgid "Finnish"
 msgstr "Bitti"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr ""
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr ""
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr ""
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr ""
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr ""
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr ""
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr ""
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr ""
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr ""
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr ""
 
-#: cps/constants.py:276
+#: cps/constants.py
 #, fuzzy
 msgid "Polish"
 msgstr "Yayınevi"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr ""
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr ""
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr ""
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr ""
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr ""
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr ""
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr ""
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr ""
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr ""
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr ""
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "yüklü değil"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr ""
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, python-format
 msgid "Change cover — %(title)s"
 msgstr ""
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Bağlantı hatası"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr ""
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Book ID"
 msgstr "eKitaplar"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Kitap Adı"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "Yazar"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr ""
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "Biçimler"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filename"
 msgstr "Kullanıcı adı"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr ""
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr ""
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "Yükleme"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "Bilinmeyen"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr ""
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "Geçersiz kitaplık seçildi"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "Okunmadı olarak işaretle"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "%(format)s biçimi diskte bulunamadı"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 msgid "EPUB Fixer started for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr ""
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr ""
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 msgid "Invalid image data format."
 msgstr ""
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr ""
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Hiçbiri"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "eKitabı Sil"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "eKitabı Sil"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "eKitabı Sil"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "Sonuçlar:"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 msgid "Invalid resolution strategy"
 msgstr ""
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Yükleme tamamlandı, işleniyor, lütfen bekleyin..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 msgid "Failed to queue upload for processing"
 msgstr ""
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Dönüştürme için kaynak ya da hedef biçimi eksik"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr ""
 "eKitap %(book_format)s formatlarına dönüştürülmek üzere başarıyla sıraya "
 "alındı"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Bu eKitabı dönüştürürken bir hata oluştu: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 #, fuzzy
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "'%(ext)s' uzantılı dosyaların bu sunucuya yüklenmesine izin verilmiyor"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr "'%(ext)s' uzantılı dosyaların bu sunucuya yüklenmesine izin verilmiyor"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "Yüklenecek dosyanın mutlaka bir uzantısı olması gerekli"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr ""
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "%(langname)s geçerli bir dil değil"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Metaveri başarıyla güncellendi"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr ""
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Bilinmeyen"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
@@ -1414,96 +1387,96 @@ msgstr ""
 "Yüklenen eKitap muhtemelen kitaplıkta zaten var. Yenisini yüklemeden "
 "değiştirmeyi düşünün: "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "%(filename)s dosyası geçici dizine kaydedilemedi"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr ""
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr ""
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr ""
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr ""
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "metaveri düzenle"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr ""
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr ""
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "%(path)s dizini oluşturulamadı. (İzin reddedildi)"
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "%(file)s dosyası kaydedilemedi."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "%(book)s kitabına %(ext)s dosya biçimi eklendi"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Token bulunamadı"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "%(format)s biçimi diskte bulunamadı"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
@@ -1511,7 +1484,7 @@ msgstr ""
 "Google Drive kurulumu tamamlanmadı, Google Drive'ı devre dışı bırakmayı ve "
 "tekrar etkinleştirmeyi deneyin"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1519,107 +1492,106 @@ msgstr ""
 "Geri yönlendirme alanı (callback domain) doğrulanamadı, lütfen Google "
 "geliştirici konsolunda alan adını doğrulamak için gerekli adımları izleyin."
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "%(book)d nolu kitap için %(format)s biçimi bulunamadı"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "%(fn)s eKitabı için %(format)s biçimi Google Drive'da bulunamadı"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s bulunamadı: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 #, fuzzy
 msgid "Send to eReader"
 msgstr "Kindle'a gönder"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "%(book)d nolu kitap için %(format)s biçimi bulunamadı"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "%(book)d nolu kitap için %(format)s biçimi bulunamadı"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 #, fuzzy
 msgid "Test Email"
 msgstr "Deneme e-Postası"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Kullanıcı Kayıt e-Postası: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "%(orig)s'dan %(format)s biçimine çevir ve Kindle'a gönder"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Send %(format)s to eReader"
 msgstr "%(format)s biçimlerini Kindle'a gönder"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "%(book)s send to eReader"
 msgstr "Kindle'a gönder"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "İstenilen dosya okunamadı. Yanlış izinlerden kaynaklanabilir?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr ""
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
 msgstr ""
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr ""
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
 "%(path)s"
 msgstr ""
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, fuzzy, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
@@ -1627,192 +1599,192 @@ msgstr ""
 "Kitap adını değiştirme sırasında hata oluştu ('%(src)s' → '%(dest)s'): "
 "%(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "%(file)s dosyası Google Drive'da bulunamadı"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 "Kitap adını değiştirme sırasında hata oluştu ('%(src)s' → '%(dest)s'): "
 "%(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "eKitap yolu %(path)s Google Drive'da bulunamadı"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr ""
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Bu kullanıcı adı zaten alındı"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr ""
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr ""
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr ""
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr ""
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr ""
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
 msgstr ""
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr ""
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr ""
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr ""
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr ""
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr ""
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr ""
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr ""
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr ""
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr ""
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr ""
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr ""
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr ""
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr ""
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "%(provider)s ile Kaydol"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "E-Posta sunucusu ayarlanmadı, lütfen yöneticinizle iletişime geçin!"
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1820,35 +1792,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "giriş yaptınız: '%(nickname)s'"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr ""
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1856,4153 +1828,4085 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr "E-Posta sunucusu ayarlanmadı, lütfen yöneticinizle iletişime geçin!"
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr ""
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr ""
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr ""
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "GitHub ile giriş yapılamadı."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Github'dan kullanıcı bilgileri alınamadı."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Google ile giriş yapılamadı."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Google'dan kullanıcı bilgileri alınamadı."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "Failed to log in with Generic OAuth."
 msgstr "GitHub ile giriş yapılamadı."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "GitHub Oauth hatası, lütfen tekrar deneyin."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr ""
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Google Oauth hatası, lütfen tekrar deneyin."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr ""
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr ""
 
-#: cps/opds.py:164
+#: cps/opds.py
 #, fuzzy
 msgid "Alphabetical Books"
 msgstr "eKitabı Sil"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr ""
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Popüler"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "İndirilme sayısına göre bu katalogdaki popüler yayınlar."
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr ""
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Değerlendirmeye göre bu katalogdaki popüler yayınlar."
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "Okunanlar"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "En en eKitaplar"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Rastgele eKitaplar"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Rastgele Kitap Göster"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Okunanlar"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Geçerli sürüm"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Okunmamışlar"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Yazarlar"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Yazara göre sıralanmış eKitaplar"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Yayıncılar"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Yayınevine göre sıralanmış eKitaplar"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Kategoriler"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Kategoriye göre sıralanmış eKitaplar"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Seriler"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Seriye göre sıralanmış eKitaplar"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Diller"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Dile göre sıralanmış eKitaplar"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Değerlendirmeler"
 
-#: cps/opds.py:243
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by Rating"
 msgstr "Kategoriye göre sıralanmış eKitaplar"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Biçimler"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Biçime göre sıralanmış eKitaplar"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr ""
 
-#: cps/opds.py:255
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in shelves"
 msgstr "Seriye göre sıralanmış eKitaplar"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Kitaplığı düzenle"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Seriye göre sıralanmış eKitaplar"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "Açıklama"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr ""
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Ara"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Giriş"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Token bulunamadı"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Token süresi doldu"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Başarılı! Lütfen cihazınıza dönün"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "eKitaplar"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Son eKitapları göster"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr ""
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr ""
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr ""
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr ""
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Read and Unread"
 msgstr "Okunan ve okunmayanları göster"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Okunmamışları göster"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Keşfet"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Category Section"
 msgstr "Kategori seçimini göster"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Series Section"
 msgstr "Seri seçimini göster"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Author Section"
 msgstr "Yazar seçimini göster"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Publisher Section"
 msgstr "Yayıncı seçimini göster"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Language Section"
 msgstr "Dil seçimini göster"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Ratings Section"
 msgstr "Değerlendirme seçimini göster"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show File Formats Section"
 msgstr "Dosya biçimi seçimini göster"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr ""
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Archived Books"
 msgstr "Son eKitapları göster"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr ""
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr ""
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr ""
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "eKitabı Sil"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Yayınlanma (sonra)"
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Yayınlanma (önce)"
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Değerlendirme <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Değerlendirme >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr ""
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Gelişmiş Arama"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "Geçersiz kitaplık seçildi"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 #, fuzzy
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "Maalesef bu kitaplığa eKitap eklemenize izin verilmiyor: %(shelfname)s"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "eKitap zaten bu kitaplıkta bulunuyor: %(shelfname)s"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "eKitap kitaplığa eklendi: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr ""
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "eKitaplar zaten bu kitaplıkta bulunuyor: %(name)s"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "eKitaplar kitaplığa eklendi: %(sname)s"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "eKitaplar kitaplığa eklenemedi: %(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "Geçersiz kitaplık seçildi"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "eKitaplar kitaplığa eklenemedi: %(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "eKitaplar zaten bu kitaplıkta bulunuyor: %(name)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "eKitaplar kitaplığa eklendi: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "eKitap kitaplıktan silindi: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr ""
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Kitaplık oluştur"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 #, fuzzy
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Maalesef bu kitaplıktan eKitap silmenize izin verilmiyor: %(sname)s"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Kitaplığı düzenle"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr ""
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 #, fuzzy
 msgid "Shelf successfully deleted"
 msgstr "Metaveri başarıyla güncellendi"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Kitaplık sıralamasını değiştir: '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr ""
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "%(title)s kitaplığı oluşturuldu."
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "%(title)s kitaplığı değiştirildi"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Bir hata oluştu"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr ""
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr ""
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Kitaplık: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Kitaplık açılırken hata oluştu. Kitaplık mevcut değil ya da erişilebilir "
 "değil"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Serileri Hariç Tut"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr ""
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr ""
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr ""
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Evet"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Hayır"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr ""
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Tema"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Açık"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Koyu"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr ""
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Kitaplığa ekle"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Yazar"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Gözat"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Kapak"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Sil"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr ""
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Yayınevi"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Okudum"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Başlık"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Yükleme"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Hesap"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Yönetim"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr ""
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Kaynak"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "Hakkında"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Açıklama"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Düzenleme"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr ""
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "Şifreleme"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Dil"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Şifre"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "İlerleme"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Değerlendirme"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr ""
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Durum"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Etiketler"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Görev"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Görevler"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Kullanıcı"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Kullanıcı adı"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr ""
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Bekleniyor"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Başarısız"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Başladı"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Bitti"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr ""
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr ""
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Bilinmeyen Durum"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "Güncelleme bilgileri okunurken beklenmeyen veri"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr "Yeni güncelleme mevcut değil. Zaten en son sürüme sahipsiniz."
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
@@ -6010,15 +5914,15 @@ msgstr ""
 "Yeni bir güncelleme mevcut. Son sürüme güncellemek için aşağıdaki düğmeye "
 "tıklayın."
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "Güncelleme bilgileri alınamadı"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr "Son kararlı sürüme güncellemek için aşağıdaki düğmeye tıklayın."
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
@@ -6027,1042 +5931,1010 @@ msgstr ""
 "Yeni bir güncelleme mevcut. Son sürüme güncellemek için aşağıdaki düğmeye "
 "tıklayın: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "Sürüm bilgisi mevcut değil"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Keşfet (Rastgele)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr ""
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr ""
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "Yazar: %(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Yayınevi: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Seri: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr ""
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Değerlendirme: %(rating)s yıldız"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Biçim: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Kategori: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Dil: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Popüler"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Popüler"
 
-#: cps/web.py:1193
+#: cps/web.py
 msgid "Error loading magic shelf"
 msgstr ""
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "Biçimler"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 msgid "Invalid request"
 msgstr ""
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr ""
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 msgid "Error creating shelf"
 msgstr ""
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Kitaplık oluştur"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 msgid "Shelf name is required"
 msgstr ""
 
-#: cps/web.py:1647
+#: cps/web.py
 msgid "Error updating shelf"
 msgstr ""
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "Kitaplığı düzenle"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "Token bulunamadı"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "Metaveri başarıyla güncellendi"
 
-#: cps/web.py:1710
+#: cps/web.py
 msgid "Error duplicating shelf"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 msgid "Error deleting shelf"
 msgstr ""
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "Kitaplığı düzenle"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 msgid "Error unhiding shelf"
 msgstr ""
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr ""
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Biçim listesi"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 #, fuzzy
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Lütfen önce SMTP e-posta ayarlarını ayarlayın..."
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "%(eReadermail)s'a gönderilmek üzere başarıyla sıraya alındı"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr ""
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "%(eReadermail)s'a gönderilmek üzere başarıyla sıraya alındı"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Kayıt ol"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 #, fuzzy
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr "E-Posta sunucusu ayarlanmadı, lütfen yöneticinizle iletişime geçin!"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr "E-Posta sunucusu ayarlanmadı, lütfen yöneticinizle iletişime geçin!"
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "E-posta adresinizle kaydolunmasına izin verilmiyor"
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "Onay e-Postası hesabınıza gönderildi."
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
 msgstr "E-Posta sunucusu ayarlanmadı, lütfen yöneticinizle iletişime geçin!"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "E-Posta sunucusu ayarlanmadı, lütfen yöneticinizle iletişime geçin!"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 #, fuzzy
 msgid "Cannot activate LDAP authentication"
 msgstr "LDAP Kimlik Doğrulaması etkinleştirilemiyor"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr ""
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, fuzzy, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "giriş yaptınız: '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "giriş yaptınız: '%(nickname)s'"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
 msgstr "E-Posta sunucusu ayarlanmadı, lütfen yöneticinizle iletişime geçin!"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
 "known"
 msgstr ""
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr ""
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 #, fuzzy
 msgid "Wrong Username or Password"
 msgstr "Yanlış Kullanıcı adı ya da Şifre"
 
-#: cps/web.py:2832
+#: cps/web.py
 #, fuzzy
 msgid "New Password was sent to your email address"
 msgstr "Yeni şifre e-Posta adresinize gönderildi"
 
-#: cps/web.py:2836
+#: cps/web.py
 #, fuzzy
 msgid "An unknown error occurred. Please try again later."
 msgstr "Bilinmeyen bir hata oluştu. Lütfen daha sonra tekrar deneyiniz."
 
-#: cps/web.py:2838
+#: cps/web.py
 #, fuzzy
 msgid "Please enter valid username to reset password"
 msgstr ""
 "Şifrenizi sıfırlayabilmek için lütfen geçerli bir kullanıcı adı giriniz"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, fuzzy, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "giriş yaptınız: '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 #, fuzzy
 msgid "Success! Profile Updated"
 msgstr "Profil güncellendi"
 
-#: cps/web.py:3164
+#: cps/web.py
 #, fuzzy
 msgid "Oops! An account already exists for this Email."
 msgstr "Bu e-posta adresi için bir hesap mevcut."
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr ""
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr ""
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "Kindle'a gönder"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "Kindle'a gönder"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 msgid "Auto-send completed successfully"
 msgstr ""
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr ""
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr ""
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, fuzzy, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "Kindle'a gönder"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr ""
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "%(format)s biçimi diskte bulunamadı"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 #, fuzzy
 msgid "Ebook converter failed with unknown error"
 msgstr "eKitap-Dönüştürücü hatası: %(error)s"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, fuzzy, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "eKitap-Dönüştürücü hatası: %(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre hatası: %(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "eKitap-Dönüştürücü hatası: %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr ""
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "eKitabı Sil"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "eKitabı Sil"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Güncelleme paketi ayıklanıyor"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Sonuçlar:"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 msgid "Hardcover Sync"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 #, fuzzy
 msgid "E-mail"
 msgstr "Deneme e-Postası"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 #, fuzzy
 msgid "Backing up Metadata"
 msgstr "metaveri düzenle"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "Kitaplıkta"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "Seriye göre sıralanmış eKitaplar"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Şifre değiştirmeye izin ver"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "OAuth Ayarları"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Ayarlar"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "bir seçenek seçin"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "Kitaplığa ekle"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 msgid "Downloads, fewest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "İndirme"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 msgid "Date added, newest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 msgid "Date added, oldest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Yazar"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Yazar"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Yayınlanma (önce)"
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Yayınlanma (önce)"
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Kitaplığa ekle"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "Kitaplığa ekle"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Send to eReader Email"
 msgstr "E-Posta adresiniz"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "Kindle'a gönder"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 #, fuzzy
 msgid "View Books"
 msgstr "Okunanlar"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Public Shelf"
 msgstr "Kitaplığı düzenle"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr ""
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr ""
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "E-posta sunucusu ayarları güncellendi"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr ""
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 #, fuzzy
 msgid "SMTP Port"
 msgstr "Port"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 #, fuzzy
 msgid "SMTP Login"
 msgstr "Giriş"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 #, fuzzy
 msgid "From Email"
 msgstr "E-Posta adresiniz"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr ""
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr ""
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Calibre Database Directory"
 msgstr "Calibre-Web yapılandırması güncellendi"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Log Seviyesi"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 #, fuzzy
 msgid "External Port"
 msgstr "Harici Uygulamalar"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Books per Page"
 msgstr "Dile göre sıralanmış eKitaplar"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Uploads"
 msgstr "Yükleme"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr ""
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Public Registration"
 msgstr "Yönetim"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr ""
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Reverse Proxy Login"
 msgstr "Ters Proxy Header Adı"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "Ters Proxy Header Adı"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Edit Basic Configuration"
 msgstr "Temel Ayarlar"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Edit UI Configuration"
 msgstr "Arayüz Ayarları"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Edit Calibre Database Configuration"
 msgstr "Calibre-Web yapılandırması güncellendi"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr ""
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Start Time"
 msgstr "Başladı"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr ""
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr ""
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr ""
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr ""
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr ""
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Setup KOReader Sync"
 msgstr "PDF Okuyucu"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr ""
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Yönetim"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Download Debug Package"
 msgstr "Güncelleme paketi indiriliyor"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr ""
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Restart"
 msgstr "Başlangıç"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr ""
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr ""
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Sürüm"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Detaylar"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "Güncelleme başarısız:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Güncelleme başarısız:"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Geçerli sürüm"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Check for Update"
 msgstr "Güncelle"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Güncelle"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr ""
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr ""
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr ""
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Updating, please do not reload this page"
 msgstr ""
 "Güncelleme tamamlandı, sayfayı yenilemek için lütfen Tamam'a tıklayınız"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7070,629 +6942,606 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Bu kitaplıktaki kitaplar"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Yükleniyor..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "Güncelleme başarısız:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Bağlantı hatası"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Seri: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "ile"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "Kitaplıkta"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "azalt"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "daha fazla"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "eKitabı Sil"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Biçimleri Sil:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Biçime dönüştür:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Biçimden dönüştür:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "select an option"
 msgstr "bir seçenek seçin"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Dönüştür:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "eKitabı dönüştür"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Hata"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Upload Format"
 msgstr "Yükleme"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 #, fuzzy
 msgid "Series ID"
 msgstr "Seriler"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Published Date"
 msgstr "Yayınlanma (sonra)"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr ""
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr ""
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr ""
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr ""
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr ""
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 msgid "Hardcover Sync Blacklist"
 msgstr ""
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr ""
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Fetch Metadata"
 msgstr "metaveri düzenle"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Anahtar Kelime"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Search keyword"
 msgstr "Anahtar kelime ara"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Yükleniyor..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Arama hatası!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr ""
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr ""
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr ""
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr ""
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 msgid "Update Title Sort automatically  "
 msgstr ""
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr ""
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Title"
 msgstr "Deneme e-Postası"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr ""
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Title Sort"
 msgstr "Başlık"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr ""
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Author Sort"
 msgstr "Yazar"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Authors"
 msgstr "Yazarlar"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Categories"
 msgstr "Kategoriler"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Series"
 msgstr "Serileri Hariç Tut"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Languages"
 msgstr "Dilleri Hariç Tut"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Yayınlanma (sonra)"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Publishers"
 msgstr "Yayıncılar"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter comments"
 msgstr "Servis adı girin"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Comments"
 msgstr "Servis adı girin"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Archived?"
 msgstr "Ara"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Read?"
 msgstr "Okudum"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter "
 msgstr "Kayıt ol"
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Emin misiniz?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr ""
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Into Book with Title:"
 msgstr "Kitap Adı"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr ""
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr ""
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr ""
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr ""
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr ""
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 #, fuzzy
 msgid "Edit Metadata"
 msgstr "metaveri düzenle"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr ""
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Ekle"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr "E-Posta sunucusu ayarlanmadı, lütfen yöneticinizle iletişime geçin!"
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Yeni şifre e-Posta adresinize gönderildi"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Kindle'a gönder"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Geri"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "UnRar aracı konumu"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7708,13 +7557,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7725,7 +7574,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7736,43 +7585,43 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr ""
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
 "can be wherever you desire"
 msgstr ""
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Google Drive kullan?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Google Drive Doğrula"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Google Drive Calibre klasörü"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "Metaveri İzleme Kanalı ID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Kaldır"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Calibre-Web yapılandırması güncellendi"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7782,133 +7631,133 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 msgid "Are you sure? This cannot be undone."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Calibre-Web yapılandırması güncellendi"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr ""
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Use Standard Authentication"
 msgstr "LDAP Kimlik Doğrulama kullan"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "LDAP Kimlik Doğrulama kullan"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "OAuth kullan"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Sunucu Ayarları"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Sunucu Port"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL certfile dosyası konumu (SSL olmayan sunucular için boş bırakın)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL keyfile dosyası konumu (SSL olmayan sunucular için boş bırakın)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Update Channel"
 msgstr "Güncelleme başarısız:"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Kararlı"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Gecelik"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr ""
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Log Dosyası Ayarları"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "Erişim dosyası konumu ve adı (girilmemişse access.log)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "Erişim Log'unu etkinleştir"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "Erişim dosyası konumu ve adı (girilmemişse access.log)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "Sunucu Ayarları"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Uploads"
 msgstr "Yüklemeye izin ver"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr ""
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Allowed Upload Fileformats"
 msgstr "Yüklemeye izin ver"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr ""
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr ""
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Use Email as Username"
 msgstr "Kullanıcı adı seç"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr ""
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7916,153 +7765,153 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr ""
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr ""
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Goodreads kullan"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Goodreads API Anahtarı"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 msgid "Enable Hardcover Sync"
 msgstr ""
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "Token süresi doldu"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Goodreads API Anahtarı"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8070,416 +7919,416 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "Ters Proxy Kimlik Doğrulamaya İzin Ver"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Giriş türü"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "LDAP Sunucu adı veya IP Adresi"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "LDAP Sunucu Portu"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Encryption"
 msgstr "Şifreleme"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Authentication"
 msgstr "LDAP Kimlik Doğrulama kullan"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr ""
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Administrator Username"
 msgstr "Yönetim"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr ""
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "LDAP Ayırt Edici Adı (DN)"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "LDAP Sunucusu OpenLDAP kullanıyor?"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr ""
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr ""
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr ""
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr ""
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr ""
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "metaveri düzenle"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
 msgstr ""
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "Arayüz Ayarları"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "Token bulunamadı"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "Bağlantı hatası"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "OAuth Ayarları"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Id"
 msgstr "%(provider)s OAuth Client Id"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Secret"
 msgstr "%(provider)s OAuth Client Secret"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "Yapılandırmayı Göster"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "Kullanıcı adı"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr ""
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "Deneme e-Postası"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr ""
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 msgid "OAuth Group Claim"
 msgstr ""
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr ""
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr ""
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "İndirmeye İzin Ver"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr ""
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Yüklemeye izin ver"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Düzenlemeye İzin ver"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Allow Delete Books"
 msgstr "eKitabı Sil"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Şifre değiştirmeye izin ver"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Genel Kitaplıkları düzenlemeye izin ver"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr ""
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "%(provider)s OAuth Kimlik Bilgisi Al"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "%(provider)s OAuth Client Id"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "%(provider)s OAuth Client Secret"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "Harici Uygulamalar"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr ""
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 msgid "Calibre E-Book Converter Settings"
 msgstr ""
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr ""
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "UnRar aracı konumu"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Security Settings"
 msgstr "OAuth Ayarları"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8487,339 +8336,334 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr ""
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr ""
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr ""
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Session protection"
 msgstr "bir seçenek seçin"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr ""
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr ""
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "User Password policy"
 msgstr "Kullanıcı şifresini sıfırla"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr ""
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr ""
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Yapılandırmayı Göster"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "Sil"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "caliBlur! Koyu Teması"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Yapılandırmayı Göster"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 msgid "Custom CSS"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "Sürüm"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Admin User"
 msgstr "Yönetim sayfası"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "Yönetim sayfası"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Language"
 msgstr "Dilleri Hariç Tut"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 msgid "Default interface language for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Visible Language of Books"
 msgstr "Dilleri Hariç Tut"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 msgid "Default book language filter for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Random Books in Detail View"
 msgstr "Rastgele Kitap Göster"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr ""
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Yükleme"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "Ara"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "İndirme"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Başlangıç"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8828,14 +8672,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8843,91 +8687,90 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on selected book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error scheduling EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "Sonuçlar:"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "Kullanıcı adı seç"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "Kitaplıkta"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer started for selected book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error starting EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Calibre-Web yapılandırması güncellendi"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8935,11 +8778,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -8950,11 +8793,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -8964,161 +8807,161 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 msgid "Enable Archived Book Cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9126,11 +8969,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9138,109 +8981,107 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "Metaveri başarıyla güncellendi"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 msgid "Identifiers (ISBN, etc.)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "Keşfet"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
 "investigation."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9248,157 +9089,157 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "OAuth Ayarları"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "Ayarlar"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "OAuth Ayarları"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9406,102 +9247,101 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "OAuth Ayarları"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9509,44 +9349,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Biçime dönüştür:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9554,2429 +9394,2403 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Detection"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "OAuth Ayarları"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Duplicate Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Biçimleri Sil:"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "metaveri düzenle"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Değerlendirme"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Sonraki"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Okunmadı olarak işaretle"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Okundu olarak işaretle"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "Okunmadı olarak işaretle"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "Okunmadı olarak işaretle"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Kitaplığa ekle"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Kitaplığa ekle"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr ""
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, fuzzy
 msgid "Add to archive"
 msgstr "Kitaplığa ekle"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "Kitaplığa ekle"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "Kitaplıkta"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "E-posta sunucusu ayarları güncellendi"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "Değerlendirme"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr ""
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr ""
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Açıklama:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "E-Posta adresiniz"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "E-Posta adresiniz"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "Biçimleri Sil:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 msgid "Failed to update tags"
 msgstr ""
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "%(file)s dosyası kaydedilemedi."
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr ""
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "eKitabı Sil"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "eKitabı Sil"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "eKitabı Sil"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "eKitabı Sil"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "Önceki"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "eKitabı Sil"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "eKitap Detayları"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "metaveri düzenle"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "Son eKitapları göster"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "Sonuçlar:"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr ""
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Biçimleri Sil:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 msgid "The following books will be permanently deleted:"
 msgstr ""
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "Okunmamışlar"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 msgid "The following book will be kept:"
 msgstr ""
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 msgid "The following books will be merged into it (and then deleted):"
 msgstr ""
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr ""
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr ""
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr ""
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Email Account Type"
 msgstr "Hesap"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Standard Email Account"
 msgstr "Hesap"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Gmail Account"
 msgstr "Hesap"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Setup Gmail Account"
 msgstr "Hesap"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr ""
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "SMTP Password"
 msgstr "Şifre"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr ""
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Save and Send Test Email"
 msgstr "E-Posta adresiniz"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr ""
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Servis ekle"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Servis adı girin"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr ""
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr ""
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "Arama hatası!"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 msgid "View on Hardcover"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "Yükleniyor..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject all pending matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "E-Posta sunucusu ayarlanmadı, lütfen yöneticinizle iletişime geçin!"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 #, fuzzy
 msgid "Create Issue"
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr ""
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 #, fuzzy
 msgid "Logout User"
 msgstr "Çıkış"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "Kitaplığı düzenle"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Show this shelf in your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "Kitaplığa ekle"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "Kitaplığı düzenle"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Kitaplığa ekle"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Anasayfa"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Toggle Navigation"
 msgstr "Log Dosyası Ayarları"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Search Library"
 msgstr "Kitaplıkta"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Calibre-Web deneme e-Postası"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Çıkış"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "Bu kitaplıktaki Seriler"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Sürüm bilgisi mevcut değil"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Calibre-Web deneme e-Postası"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "eKitabı Sil"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr ""
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Önceki"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "eKitap Detayları"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 msgid "This cannot be undone."
 msgstr ""
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "eKitabı Sil"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Yükleme"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Biçimleri Sil:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "eKitabı Sil"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Sonuçlar:"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "En İyiye Ölçeklendir"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "Ayarlar"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Kitaplığa ekle"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Okunmadı olarak işaretle"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Okunmadı olarak işaretle"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "eKitabı Sil"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "eKitabı Sil"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Bağlantı hatası"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr ""
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr ""
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "Şifre"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr ""
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 #, fuzzy
 msgid "Forgot Password?"
 msgstr "Şifre"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr ""
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 msgid "Log in with SSO"
 msgstr ""
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr ""
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Calibre-Web Log: "
 msgstr "Calibre-Web deneme e-Postası"
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "Akış çıktısı, görüntülenemiyor"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Show Access Log: "
 msgstr "Erişim Log'unu etkinleştir"
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr ""
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Download Access Log"
 msgstr "Erişim Log'unu etkinleştir"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 msgid "Share with Everyone (Public)"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Enter Tag"
 msgstr "Kayıt ol"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Choose File Location"
 msgstr "Dosya biçimi seçimini göster"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "name"
 msgstr "Kullanıcı adı"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Parent Directory"
 msgstr "Yön"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 #, fuzzy
 msgid "Ok"
 msgstr "Kitap"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Calibre-Web deneme e-Postası"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 #, fuzzy
 msgid "epub Reader"
 msgstr "PDF Okuyucu"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 msgid "Annotations"
 msgstr ""
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 #, fuzzy
 msgid "Black"
 msgstr "Geri"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr ""
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Sonraki Sayfa"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr ""
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 #, fuzzy
 msgid "Default"
 msgstr "Sil"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr ""
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr ""
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 #, fuzzy
 msgid "KaiTi"
 msgstr "Bekleniyor"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 #, fuzzy
 msgid "Arial"
 msgstr "Dikey"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 #, fuzzy
 msgid "Spread"
 msgstr "Okudum"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr ""
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr ""
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Kenar çubukları açıkken metni kaydır"
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Comic Reader"
 msgstr "PDF Okuyucu"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Klavye Kısayolları"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Önceki Sayfa"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Sonraki Sayfa"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page Display"
 msgstr "Yönetim sayfası"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "En İyiye Ölçeklendir"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "Genişliğe Ölçeklendir"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "Yüksekliğe Ölçeklendir"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "Asıla göre ölçeklendir"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Sağa çevir"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Sola çevir"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Resmi döndir"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page"
 msgstr "Yönetim sayfası"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr ""
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "Ölçeklendir"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "En İyi"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Genişlik"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Yükseklik"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "Asıl"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Çevir"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Döndür"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Yatay"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Dikey"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Direction"
 msgstr "Açıklama"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Soldan Sağa"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Sağdan Sola"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr ""
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 msgid "Remember Position"
 msgstr ""
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr ""
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr ""
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 #, fuzzy
 msgid "DJVU Reader"
 msgstr "PDF Okuyucu"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 #, fuzzy
 msgid "PDF Reader"
 msgstr "PDF Okuyucu"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 #, fuzzy
 msgid "txt Reader"
 msgstr "PDF Okuyucu"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr ""
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Kullanıcı adı seç"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "E-Posta adresiniz"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr ""
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr ""
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr ""
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr ""
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 #, fuzzy
 msgid "No Results Found"
 msgstr "Sonuçlar:"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 #, fuzzy
 msgid "Search Term:"
 msgstr "Arama hatası!"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Sonuçlar:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Published Date From"
 msgstr "Yayınlanma (sonra)"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Published Date To"
 msgstr "Yayınlanma (sonra)"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr ""
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Etiketleri Hariç Tut"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Serileri Hariç Tut"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Exclude Shelves"
 msgstr "Serileri Hariç Tut"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Dilleri Hariç Tut"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Uzantılar"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "Uzantıları Hariç Tut"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Rating Above"
 msgstr "Değerlendirme"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Rating Below"
 msgstr "Değerlendirme listesi"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr ""
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr ""
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Bu Kitaplığı sil"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr ""
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Popüler"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr ""
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr ""
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr ""
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "eKitabı Sil"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Hesap"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Token bulunamadı"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Bu Kitaplığı sil"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Kitaplığa ekle"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Kitaplıkta"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Kitaplıkta"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr ""
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr ""
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Token bulunamadı"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Hidden Book"
 msgstr "Popüler"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 #, fuzzy
 msgid "Library Statistics"
 msgstr "İstatistikler"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Bu kitaplıktaki kitaplar"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Bu kitaplıktaki Yazarlar"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Bu kitaplıktaki kategoriler"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Bu kitaplıktaki Seriler"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 #, fuzzy
 msgid "System Statistics"
 msgstr "İstatistikler"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 #, fuzzy
 msgid "Program"
 msgstr "İlerleme"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Yüklü Sürüm"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr ""
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr ""
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "Çevir"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
 msgstr ""
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 msgid "Scheduled item cancelled successfully"
 msgstr ""
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Calibre-Web deneme e-Postası"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "E-Posta adresiniz"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "Ayarlar"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Kullanıcı şifresini sıfırla"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "Sunucu Ayarları"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "E-Posta adresiniz"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "Dilleri Hariç Tut"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Language of Books"
 msgstr "Diller"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "Dilleri Hariç Tut"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "OAuth Ayarları"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Bağla"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Kaldır"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr ""
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 msgid "Expose only books in selected shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "OAuth Ayarları"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr ""
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "Yeni eklenen eKitaplar"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "Kitaplığı düzenle"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 #, fuzzy
 msgid "Delete User"
 msgstr "Sil"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -11984,164 +11798,164 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Şifre değiştirmeye izin ver"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Şifre değiştirmeye izin ver"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr ""
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr ""
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr ""
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit User"
 msgstr "%(nick)s kullanıcısını düzenle"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Username"
 msgstr "Kullanıcı adı seç"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Email"
 msgstr "Deneme e-Postası"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email"
 msgstr "E-Posta adresiniz"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email"
 msgstr "Deneme e-Postası"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "E-Posta adresiniz"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "Deneme e-Postası"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Locale"
 msgstr "Ölçeklendir"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Visible Book Languages"
 msgstr "Dilleri Hariç Tut"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr ""
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Allowed Tags"
 msgstr "Yüklemeye izin ver"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr ""
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr ""
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Change Password"
 msgstr "Şifre değiştirmeye izin ver"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Public Shelves"
 msgstr "Kitaplığı düzenle"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 msgid "Expose selected Shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Read/Unread Section"
 msgstr "Seri seçimini göster"

--- a/cps/translations/uk/LC_MESSAGES/messages.po
+++ b/cps/translations/uk/LC_MESSAGES/messages.po
@@ -19,47 +19,47 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Статистика"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 "База даних Calibre недоступна. Будь ласка, переналаштуйте шлях до бібліотеки."
 
-#: cps/admin.py:208
+#: cps/admin.py
 #, fuzzy
 msgid "Server restarted, please reload page."
 msgstr "Сервер перезавантажено, будь-ласка, перезавантажте сторінку"
 
-#: cps/admin.py:210
+#: cps/admin.py
 #, fuzzy
 msgid "Performing Server shutdown, please close window."
 msgstr "Виконується зупинка серверу, будь-ласка, закрийте вікно"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "Успішно! З'єднання з базою даних відновлено"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Невідома команда"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 "Успішно! Книги додано до черги для резервного копіювання метаданих. "
 "Перевірте результати у розділі «Завдання»."
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
@@ -67,221 +67,219 @@ msgstr ""
 "Помилка! Токен Hardcover недоступний. Вкажіть HARDCOVER_TOKEN параметр в "
 "Базовій Конфігурації."
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 "Успішно! Запущено завдання автоматичного завантаження книг у твердій "
 "палітурці. Перевірте хід виконання на панелі «Завдання»."
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr "Помилка пошуку даних на Hardcover: %(error)s"
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr "Огляд книг у твердій обкладинці"
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr "Помилка завантаження черги відгуків: %(error)s"
 
-#: cps/admin.py:414
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover ID applied successfully"
 msgstr "{} користувачі видалені успішно"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr "Збіг %(action)s"
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr "Немає очікуючих завдань, які потрібно відхилити"
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr "Відмова в %(count)s збігах"
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 "Розпочато оновлення кешу мініатюр для {} книг. Це може зайняти кілька хвилин."
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr "Не знайдено книжок з обкладинками до опрацювання."
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr "Не вдалося розпочати оновлення мініатюр: {}"
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Сторінка адміністратора"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "Налаштування OAuth"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Настройки сервера"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Конфігурація інтерфейсу"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 "Користувацький параметр номер %(column)d відсутній у базі даних Calibre"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Edit Users"
 msgstr "Керування сервером"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Всі"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Користувача не знайдено"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} користувачі видалені успішно"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Показати всі"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Неправильно сформований запит"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "Ім'я Гостя не можна змінити"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "Гість не може мати цю роль"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr "Не залишається Адміна, неможливо видалити цього користувача"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "Значення повинно бути TRUE або FALSE"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Не правильна роль"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "Гість не може мати такий вигляд"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "Неправильний вигляд"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr "Мова Гостя визначена автоматично і не може бути змінена"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Не вказано дійсної локалі"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Не вказано дійсної мови для книжок"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Параметр не знайдений"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "Не можна записати налаштування БД"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Неправильний параметр Читане"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Неправильний параметр Недоступне"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Реально бажаєте видалити Kobo Token?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "Реально бажаєте видалити цей домен?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "Реально бажаєте видалити цього користувача?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Ви справді хочете видалити книжкову полицю?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 #, fuzzy
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr "Ви справді хочете видалити книжкову полицю?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "Ви справді хочете змінити мову перегляду книжок для визначених користувачів?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr "Ви справді хочете змінити обрану роль для визначених користувачів?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
 msgstr "Ви справді хочете видалити книжкову полицю?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -289,138 +287,133 @@ msgstr ""
 "Ви справді хочете змінити обрані обмеження перегляду для визначених "
 "користувачів?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr "Ви справді хочете видалити книжкову полицю?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
 msgstr "Ви справді хочете видалити книжкову полицю?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 #, fuzzy
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Ви справді хочете видалити книжкову полицю?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Заборонити"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Дозволити"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "{} записів синхронізації видалено"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Токен не знайдено"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Тег не знайдено"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Помилкова Дія"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json не сконфігурований для CWA"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "Помилковий шлях до Logfile, вкажіть вірний"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "Помилковий шлях до Access Logfile, вкажіть вірний"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr "Будь-ласка, вкажіть LDAP Provider, Port, DN або User Object Identifier"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "Будь-ласка, вкажіть ім'я і пароль до LDAP Service"
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "Будь-ласка, вкажіть ім'я до LDAP Service"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Фільтр об’єктів групи LDAP повинен містити один ідентифікатор у форматі "
 "\"%s\""
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "У фільтрі об’єктів групи LDAP є непарні дужки"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Фільтр об’єктів користувачів LDAP повинен містити один ідентифікатор у "
 "форматі \"%s\""
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "У фільтрі об’єктів користувачів LDAP є непарні дужки"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 "Фільтр об’єктів членів LDAP повинен містити один ідентифікатор у форматі "
 "\"%s\""
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "У фільтрі об’єктів членів LDAP є непарні дужки"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
@@ -428,247 +421,240 @@ msgstr ""
 "Сертифікат LDAP CA, місцезнаходження сертифіката або ключа є недійсним. "
 "Введіть правильний шлях"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Додати нового Користувача"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "Змінити налаштування SMTP"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "Успіх! Gmail акаунт перевірений."
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Ой! Помилка БД: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
 msgstr "Тестовий email висланий до %(email)s, будь ласка перевірте Завдання"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "Помилка висилання тестового email: %(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "Будь-ласка, вкажіть ваш email спочатку..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "Налаштування Email Server оновлені"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "Керування сервером"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "Будь-ласка, спочатку сконфігуруйте параметри SMTP"
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 msgid "Please set an email address on your own account first..."
 msgstr ""
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "створити книжкову полицю"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
 msgstr ""
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
 "delivery."
 msgstr ""
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "Редагувати налаштування Запланованих Завдань"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "Вказано недійсний час початку завдання"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "Вказано недійсний час виконання завдання"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "Налаштування запланованих завдань оновлені"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Ой! Сталася невідома помилка. Спробуйте ще раз пізніше."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "Заголовок"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Змінити користувача %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "Успіх! Гасло користувача %(user)s оновлено"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "Будь-ласка, спочатку сконфігуруйте параметри SMTP"
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "Переглядач лог-файлів"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "Перевірка оновлень"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "Завантаження оновлень"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Розпакування оновлення"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "Заміна файлів"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "З'єднання з базою даних закрите"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Сервер зупиняється"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Оновлення встановлені, натисніть ok і перезавантажте сторінку"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Оновлення неуспішне:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "HTTP помилка"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Помилка зʼєднання"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "Перевищено час встановлення з'єднання"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Помилка"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr "Файл оновлення не може бути збережений"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "Не можна змінювати файлів під час оновлення"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "Не вдалося вилучити хоча б одного користувача LDAP"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "Не вдалося створити хоча б одного користувача LDAP"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "Помилка: %(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "Помилка: відсутній користувач у відповіді LDAP сервера"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "В БД не знайдено хоча б одного користувача LDAP"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} користувач успішно импортований"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr "Недійсний шлях до файлу книжки"
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "Розташування БД недійсне, вкажіть вірний шлях, будь ласка"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "Не вдалося записувати до БД"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "Розташування файлу ключів недійсне, вкажіть вірний шлях, будь ласка"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 "Розташування файлу сертифікатів недійсне, вкажіть вірний шлях, будь ласка"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
@@ -676,13 +662,13 @@ msgstr ""
 "Функцію автоматичного створення користувачів неможливо увімкнути без "
 "увімкнення аутентифікації через зворотний проксі-сервер"
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 "Для автоматичного створення користувачів необхідна дійсна назва заголовка "
 "зворотного проксі-сервера"
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
@@ -690,7 +676,7 @@ msgstr ""
 "Неправильний формат хосту перенаправлення OAuth. Будь ласка, вкажіть повну "
 "URL-адресу з протоколом (наприклад, https://your-domain.com)"
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
@@ -698,77 +684,77 @@ msgstr ""
 "Адреса перенаправлення OAuth не повинна містити шлях. Вказуйте лише базову "
 "URL-адресу (наприклад, https://your-domain.com)"
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr "Довжина гасла повинна бути від 1 до 40 символів"
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 #, fuzzy
 msgid "Database Settings updated"
 msgstr "З'єднання з базою даних закрите"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 #, fuzzy
 msgid "Database Configuration"
 msgstr "Особливі налаштування"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Будь-ласка, заповніть всі поля!"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "Email має недійсний домен"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Додати користувача"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Користувач '%(user)s' додан"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "Ой! Для такого email або імені вже є Користувач."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Користувача '%(nick)s' видалено"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "Не можна видалити Гостя"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "Не залишається адміна, не можна видалити користувача"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "Email не може залишитись пустим або в невірному форматі"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Користувача '%(nick)s' оновлено"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 "Зʼєднання успішне! Кінцевий пункт оглядача OIDC доступний. %(endpoints)s"
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
@@ -776,25 +762,25 @@ msgstr ""
 "Помилка зʼєднання: Кінцевий пункт OIDC не знайдений (404). Перевірте базовий "
 "URL."
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr "Помилка зʼєднання: Сервер повернув код статусу %(code)s"
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr "Помилка зʼєднання: Перевірте URL та стан мережі."
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 "Помилка зʼєднання: Час очікування перевищено. Сервер перевантажений або "
 "недоступний."
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
@@ -802,12 +788,12 @@ msgstr ""
 "Помилка зʼєднання: Сервер повернув неправильний JSON. Можливо це не кінцевий "
 "пункт."
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Помилка зʼєднання"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
@@ -816,76 +802,76 @@ msgstr ""
 "У метаданих відсутні обов’язкові поля OIDC: %(fields)s. Можливо, це не є "
 "дійсною кінцевим пунктом метаданих OIDC."
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr "Вірний URL метаданих! Знайдено %(count)s OAuth кінцевих пунктів."
 
-#: cps/admin.py:3322
+#: cps/admin.py
 msgid " User info endpoint is available."
 msgstr " Доступна інформація щодо кінцевого пункта користувача."
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 " Примітка: Інфо щодо кінцевого пункту користувача не знайдена - можливо "
 "проблема автентифікації."
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr "URL метаданих не знайдено. Перевірте URL, будь ласка."
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr "Помилка зʼєднання: Перевірте правильність URL або стан мережі."
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr "Помилка зʼєднання: Час очікування минув."
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr "Помилка зʼєднання: Невірний JSON у відповіді."
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "Помилка зʼєднання"
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "Помилка зʼєднання"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr "Помилка відновлення: шлях до бібліотеки Calibre не сконфігурований."
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr "Помилка відновлення: файл metadata.db не знайдено за адресою %(path)s"
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr "Помилка відновлення: файл app.db не знайдено за адресою %(path)s"
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Помилка зʼєднання"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 "Відновлення завершене, але не вдалося очистити app.db. Більше інформації в "
 "логах."
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
@@ -893,202 +879,201 @@ msgid ""
 msgstr ""
 "Відновлення завершене. Логі збережені до %(dir)s. Дані книжок оновлено."
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 msgid "No file uploaded."
 msgstr ""
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr "Чеська"
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr "Німецька"
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr "Грецька"
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr "Іспанська"
 
-#: cps/constants.py:265
+#: cps/constants.py
 #, fuzzy
 msgid "Finnish"
 msgstr "Завершено"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr "Французька"
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr "Галісійська"
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr "Угорська"
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr "Індонезійська"
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr "Італійська"
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr "Японська"
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr "Кхмерська"
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr "Корейська"
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr "Данська"
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr "Норвезька"
 
-#: cps/constants.py:276
+#: cps/constants.py
 #, fuzzy
 msgid "Polish"
 msgstr "Видавець"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr "Португальська"
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr "Португальська (Бразилія)"
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr "Російська"
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr "Словацька"
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr "Словенська"
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr "Шведська"
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr "Турецька"
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr "Українська"
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr "В'єтнамська"
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr "Китайська (проста, Китай)"
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr "Китайська (традиційна. Тайвань)"
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "не встановлено"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "Відсутні права на виконання"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, python-format
 msgid "Change cover — %(title)s"
 msgstr ""
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Помилка зʼєднання"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr ""
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr "Перемикання тем тимчасово вимкнено до виходу версії 5.0.0"
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
@@ -1096,460 +1081,448 @@ msgstr ""
 "Оновлення бібліотеки 🔄 Перевіряємо, чи не пропущено якихось книг, будь "
 "ласка, зачекайте..."
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr "Неправильний вираз cron для повторного сканування. Зміни не збережено."
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr "Мітка часу"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Book ID"
 msgstr "Книжки"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Назва книги"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "Автор"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr "Тип тригеру"
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "Формати файлів"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filename"
 msgstr "Ім'я користувача"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr "Інструкція?"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr "Номер виправлення"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr "Оригінал збережено?"
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr "Виправлення внесені"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr "Початковий формат"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "Формат завантаження"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "Невідомий"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr "✅ Усі служби моніторингу працюють як передбачено! 👍"
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr "Відбулася помилка"
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "Не правильна роль"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "Відмітити як не прочитане"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 msgid "EPUB file not found on disk."
 msgstr ""
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 msgid "EPUB Fixer started for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr ""
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr ""
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 msgid "Invalid image data format."
 msgstr ""
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Profile picture updated successfully."
 msgstr "{} користувачі видалені успішно"
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "Ні"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "Видалити книгу"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "Видалити книгу"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "Видалити книгу"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "Результати для:"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 #, fuzzy
 msgid "Invalid resolution strategy"
 msgstr "Не правильна роль"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr ""
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 msgid "Failed to queue upload for processing"
 msgstr ""
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr ""
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr ""
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr ""
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr ""
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr ""
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "Завантажувальний файл повинен мати розширення"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr "Неможливо відкрити книгу. Файл не існує або немає доступу."
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr ""
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr ""
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr ""
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr ""
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Невідомий"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
 msgstr ""
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr ""
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr ""
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr ""
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr ""
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "змінити метадані"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr ""
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr ""
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr ""
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr ""
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "Формат файлу %(ext)s додано до %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Токен не знайдено"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr ""
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
 msgstr ""
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
@@ -1557,296 +1530,295 @@ msgstr ""
 "Домен зворотнього зв'язку не підтверджено. Виконайте дії для підтвердження "
 "домену, будь-ласка"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr ""
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr ""
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr ""
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 #, fuzzy
 msgid "Send to eReader"
 msgstr "Відправити на Kindle"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr ""
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr ""
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 #, fuzzy
 msgid "Test Email"
 msgstr "Kindle"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr ""
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr ""
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Надіслати %(format)s до E-Reader"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "%(book)s send to eReader"
 msgstr "Відправити на Kindle"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr ""
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr ""
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
 msgstr ""
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr ""
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
 "%(path)s"
 msgstr ""
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr ""
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr ""
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr ""
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr ""
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr ""
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr ""
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr ""
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr ""
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr ""
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
 msgstr ""
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr ""
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr ""
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr ""
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr ""
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr ""
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr ""
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr ""
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr ""
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr ""
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr ""
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr ""
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr ""
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr ""
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr ""
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "Папка Calibre DB"
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1854,35 +1826,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "Ви увійшли як користувач: '%(nickname)s'"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr ""
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1890,5195 +1862,5095 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 msgid "OAuth system error. Please contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr ""
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr ""
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr ""
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr ""
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr ""
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr ""
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr ""
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 msgid "Failed to log in with Generic OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr ""
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr ""
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr ""
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr ""
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr ""
 
-#: cps/opds.py:164
+#: cps/opds.py
 #, fuzzy
 msgid "Alphabetical Books"
 msgstr "Видалити книгу"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr ""
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Популярні книги"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "Популярні книги в цьому каталозі, на основі кількості завантажень"
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Книги з найкращим рейтингом"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "Популярні книги з цього каталогу на основі рейтингу"
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "Прочитані книги"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Останні книги"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Випадковий список книг"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Показувати випадкові книги"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Прочитані книги"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Поточна версія"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Непрочитані книги"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Автори"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Книги відсортовані за автором"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Видавництва"
 
-#: cps/opds.py:219
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by publisher"
 msgstr "Книги відсортовані за автором"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Категорії"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Книги відсортовані за категоріями"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Серії"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Книги відсортовані за серією"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Мови"
 
-#: cps/opds.py:237
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by Languages"
 msgstr "Книги відсортовані за серією"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Рейтинги"
 
-#: cps/opds.py:243
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by Rating"
 msgstr "Книги відсортовані за категоріями"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Формати файлів"
 
-#: cps/opds.py:249
+#: cps/opds.py
 #, fuzzy
 msgid "Books ordered by file formats"
 msgstr "Книги відсортовані за серією"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr ""
 
-#: cps/opds.py:255
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in shelves"
 msgstr "Книги відсортовані за серією"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Змінити книжкову полицю"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Книги відсортовані за серією"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "Опис"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} зірок"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Пошук"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Ім'я користувача"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Токен не знайдено"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Час дії токено вичерпано"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Вдалося! Будь-ласка, поверніться до вашого пристрою"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Книжки"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Показувати останні книги"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Показувати популярні книги"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr ""
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr ""
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Показувати книги з найвищим рейтингом"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Read and Unread"
 msgstr "Показувати прочитані та непрочитані книги"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Показати не прочитані"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Огляд"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Category Section"
 msgstr "Показувати вибір категорії"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Series Section"
 msgstr "Показувати вибір серії"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Author Section"
 msgstr "Показувати вибір автора"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Publisher Section"
 msgstr "Показувати вибір серії"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Language Section"
 msgstr "Показувати вибір мови"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Ratings Section"
 msgstr "Показувати вибір серії"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show File Formats Section"
 msgstr "Показувати вибір серії"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Архівні книжки"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Archived Books"
 msgstr "Архівні книжки"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Список книжок"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr ""
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr ""
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Показувати книги з найвищим рейтингом"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Опубліковані після "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Опубліковано до "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Рейтинг <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Рейтинг >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr ""
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Розширений пошук"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr ""
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 #, fuzzy
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "Вибачте, але у вас немає дозволу для видалення книги з цієї полиці"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr ""
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "Книга додана на книжкову полицю: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr ""
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr ""
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr ""
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr ""
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 msgid "Invalid series specified"
 msgstr ""
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr ""
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Книга додана на книжкову полицю: %(sname)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "Книга додана на книжкову полицю: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "Книга видалена з книжкової полиці: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr ""
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "створити книжкову полицю"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 #, fuzzy
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Вибачте, але у вас немає дозволу для видалення книги з цієї полиці"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Змінити книжкову полицю"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr ""
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr ""
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "Змінити розташування книжкової полиці '%(name)s'"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr ""
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Створена книжкова полиця %(title)s"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Книжкова полиця %(title)s змінена"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Сталась помилка"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr ""
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr ""
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "Книжкова полиця: '%(name)s'"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Помилка при відкриванні полиці. Полиця не існує або до неї відсутній доступ"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Виключити серії"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "Анонім"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr ""
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Так"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Ні"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr ""
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "Тема"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr ""
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr ""
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr ""
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Додати на книжкову полицю"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Автор"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Перегляд"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Закрити"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Видалити"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Обʼєднати"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Видавець"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Прочитано"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Заголовок"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Додати нову книгу"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr ""
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Адмін"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Опубліковано"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Джерело"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "Про програму"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Заархівовано"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Опис"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Завантажити"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Редагувати"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr ""
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "Сховати"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Ідентифікатори"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Мова"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Пароль"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Порт"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Прогрес"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Рейтинг"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Зберегти"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr ""
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Статус"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Теги"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Завдання"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Завдання"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Користувач"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Ім'я користувача"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Показати"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Очікує"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr ""
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Розпочато"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Завершено"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "Закінчено"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "Відмінено"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Невідомий статус"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr ""
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr ""
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
 msgstr ""
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr ""
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr ""
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
 "%(version)s"
 msgstr ""
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr ""
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "Огляд (випадкові книги)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "Популярні книги (найбільш завантажувані)"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr ""
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr ""
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "Видавництво: %(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "Серії: %(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "Рейтинг: Відсутній"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "Рейтинг: %(rating)s зірок"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "Формат файлу: %(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "Категорія: %(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "Мова: %(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Популярні книги"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Популярні книги"
 
-#: cps/web.py:1193
+#: cps/web.py
 msgid "Error loading magic shelf"
 msgstr ""
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "Не правильна роль"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 #, fuzzy
 msgid "Invalid request"
 msgstr "Не правильна роль"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr ""
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 msgid "Error creating shelf"
 msgstr ""
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "створити книжкову полицю"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 msgid "Shelf name is required"
 msgstr ""
 
-#: cps/web.py:1647
+#: cps/web.py
 msgid "Error updating shelf"
 msgstr ""
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "Змінити книжкову полицю"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "Користувача не знайдено"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "{} користувачі видалені успішно"
 
-#: cps/web.py:1710
+#: cps/web.py
 msgid "Error duplicating shelf"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 msgid "Error deleting shelf"
 msgstr ""
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "Змінити книжкову полицю"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 msgid "Error unhiding shelf"
 msgstr ""
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Завантаження"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Список форматів файлу"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 #, fuzzy
 msgid "Please configure the SMTP mail settings first..."
 msgstr "Будь-ласка, спочатку сконфігуруйте параметри SMTP"
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr ""
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "Помилка при відправці книги: %(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 
-#: cps/web.py:2500
+#: cps/web.py
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr ""
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Зареєструватись"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr ""
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr ""
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr ""
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr ""
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
 msgstr "Папка Calibre DB"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "Папка Calibre DB"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr ""
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr ""
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, fuzzy, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "Ви увійшли як користувач: '%(nickname)s'"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "Ви увійшли як користувач: '%(nickname)s'"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
 msgstr "Папка Calibre DB"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
 "known"
 msgstr ""
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr ""
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 #, fuzzy
 msgid "Wrong Username or Password"
 msgstr "Помилка в імені користувача або паролі"
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr ""
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr ""
 
-#: cps/web.py:2838
+#: cps/web.py
 #, fuzzy
 msgid "Please enter valid username to reset password"
 msgstr "Помилка в імені користувача або паролі"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, fuzzy, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "Ви увійшли як користувач: '%(nickname)s'"
 
-#: cps/web.py:3158
+#: cps/web.py
 #, fuzzy
 msgid "Success! Profile Updated"
 msgstr "Профіль оновлено"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr ""
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 #, fuzzy
 msgid "Invalid book ID."
 msgstr "Не правильна роль"
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr ""
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "Відправити на Kindle"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "Відправити на Kindle"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-send completed successfully"
 msgstr "{} користувачі видалені успішно"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr ""
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr ""
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, fuzzy, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "Відправити на Kindle"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr ""
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr ""
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr ""
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr ""
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr ""
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr ""
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 #, fuzzy
 msgid "Reconnecting Calibre database"
 msgstr "Розташування БД Calibre"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "Видалити книгу"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Видалити книгу"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Розпакування оновлення"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Результати для:"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 msgid "Hardcover Sync"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 #, fuzzy
 msgid "E-mail"
 msgstr "Відправник"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 #, fuzzy
 msgid "Backing up Metadata"
 msgstr "змінити метадані"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "У бібліотеці"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "Книги відсортовані за серією"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Дозволити зміну пароля"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "створити книжкову полицю"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "Налаштування OAuth"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Налаштування"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "Обрати..."
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "Додати на книжкову полицю"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Публічно)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "Завантаження"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Завантаження"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 msgid "Date added, newest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 msgid "Date added, oldest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Автор"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Автор"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Опубліковано до "
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Опубліковано до "
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Додати на книжкову полицю"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "Додати на книжкову полицю"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Send to eReader Email"
 msgstr "Kindle"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "Відправити на Kindle"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 #, fuzzy
 msgid "View Books"
 msgstr "Переглянути логи"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Public Shelf"
 msgstr "Змінити книжкову полицю"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr ""
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr ""
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Змінити налаштування SMTP"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "SMTP-сервер"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "SMTP-порт"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "SMTP логін"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Відправник"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr ""
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr ""
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Папка Calibre DB"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Рівень логування"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "Зовнішній порт"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Кількість книг на сторінці"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Загрузка на сервер"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Анонімний перегляд"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Публічна реєстрація"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Magic Link Remote Login"
 msgstr "Включити віддалений логін (\"magic link\")"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr ""
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr ""
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Edit Basic Configuration"
 msgstr "Настройки сервера"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Edit UI Configuration"
 msgstr "Конфігурація інтерфейсу"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Edit Calibre Database Configuration"
 msgstr "Особливі налаштування"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "Заплановані завдання"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Start Time"
 msgstr "Розпочато"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "Максимальний час завдання"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr ""
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 #, fuzzy
 msgid "Reconnect Calibre Database"
 msgstr "Розташування БД Calibre"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr ""
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr ""
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 msgid "Setup KOReader Sync"
 msgstr ""
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr ""
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Адміністрування"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Download Debug Package"
 msgstr "Завантаження оновлень"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Переглянути логи"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Перезавантажити"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Вимкнути"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "Інформація про версію"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Версія"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Деталі"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "Оновлення неуспішне:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Канал оновлення"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Поточна версія"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Перевірка оновлень"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Встановити оновлення"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Впевнені що хочете перезавантажити?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Are you sure you want to shutdown?"
 msgstr "Впевнені що хочете перезавантажити?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Встановлення оновлень, будь-ласка, не оновлюйте сторінку"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7086,625 +6958,602 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Книг в цій бібліотеці"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Завантаження..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "Оновлення неуспішне:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Помилка зʼєднання"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Серії: %(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "через"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "У бібліотеці"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr ""
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Більше за"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Видалити книгу"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Видалити формати:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Convert book format:"
 msgstr "Конвертувати книгу"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Конвертувати з:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr ""
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Конвертувати в:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Конвертувати книгу"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Помилка"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Формат завантаження"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 #, fuzzy
 msgid "Series ID"
 msgstr "Серії"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Опубліковано"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Identifier Type"
 msgstr "Ідентифікатори"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Identifier Value"
 msgstr "Ідентифікатори"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Видалити"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Додати ідентифікатор"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr ""
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 msgid "Hardcover Sync Blacklist"
 msgstr ""
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "переглянути книгу після редагування"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Отримати метадані"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Ключове слово"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Search keyword"
 msgstr " Пошук по ключовому слову"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Завантаження..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Помилка пошуку!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr ""
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr ""
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr ""
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "створити книжкову полицю"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr "Очистити"
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 msgid "Update Title Sort automatically  "
 msgstr ""
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr ""
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Title"
 msgstr "Kindle"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr ""
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Title Sort"
 msgstr "Заголовок"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr ""
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Author Sort"
 msgstr "Автор"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Authors"
 msgstr "Автори"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Categories"
 msgstr "Категорії"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Series"
 msgstr "Виключити серії"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Languages"
 msgstr "Виключити мови"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Дата публікації"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter Publishers"
 msgstr "Видавництва"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Введіть коментар"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Comments"
 msgstr "Коментарі"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Archived?"
 msgstr "Заархівовано"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Read?"
 msgstr "Прочитано"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter "
 msgstr "Зареєструватись"
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Ви впевнені?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr ""
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Into Book with Title:"
 msgstr "Назва книги"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr ""
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr ""
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr ""
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr ""
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr ""
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Редагувати метадані"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "створити книжкову полицю"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr ""
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Додати"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 #, fuzzy
 msgid "Message"
 msgstr "Обʼєднати"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Kindle"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Відправити на Kindle"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Назад"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Розташування БД Calibre"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7720,13 +7569,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7737,7 +7586,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7748,43 +7597,43 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr ""
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
 "can be wherever you desire"
 msgstr ""
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Використовувати Google Drive?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Автентифікація Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Папка Calibre в Google Drive"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "Metadata Watch Channel ID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Скасувати"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Розташування БД Calibre"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7794,136 +7643,136 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "Впевнені що хочете перезавантажити?"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Розташування БД Calibre"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr ""
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr ""
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "Налаштування серверу"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Порт сервера"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Розташування сертифіката SSL (залиште його порожнім для серверів, які не "
 "використовують SSL)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 "Розташування ключових слів SSL (залиште його порожнім для серверів, які не "
 "використовують SSL)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "Канал оновлення"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "Стабільний"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "Нічний"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "Довірені хости (розділені комою)"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "Logfile налаштування"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "Розташування і назва логфайлу (calibre-web.log for no entry)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr ""
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "Розташування і назва логфайлу (calibre-web.log for no entry)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "Налаштування серверу"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "Дозволити завантаження книг на сервер"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr ""
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Allowed Upload Fileformats"
 msgstr "Формат завантаження"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "Дозволити анонімний перегляд"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "Дозволити публічну реєстрацію"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Use Email as Username"
 msgstr "Виберіть ім'я користувача"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "Включити віддалений логін (\"magic link\")"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7931,153 +7780,153 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr ""
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr ""
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Use Goodreads"
 msgstr "Використовувати Google Drive?"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 msgid "Enable Hardcover Sync"
 msgstr ""
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "Час дії токено вичерпано"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 msgid "Google Books API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8085,416 +7934,416 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Тип логіну"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr ""
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Server Port"
 msgstr "Порт сервера"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Encryption"
 msgstr "SSL"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr ""
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Administrator Username"
 msgstr "Адміністрування"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr ""
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr ""
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr ""
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr ""
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr ""
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr ""
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr ""
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "Автовизначення"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "Отримати метадані"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
 msgstr ""
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "Конфігурація інтерфейсу"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "Токен не знайдено"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "Помилка зʼєднання"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "Налаштування OAuth"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 msgid "OAuth Client Id"
 msgstr ""
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 msgid "OAuth Client Secret"
 msgstr ""
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "Переглянути налаштування"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "Ім'я користувача"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr ""
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "Відправник"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr ""
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 msgid "OAuth Group Claim"
 msgstr ""
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr ""
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "Налаштування по замовчуванню для нових користувачів"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Дозволити завантажувати з сервера"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr ""
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Дозволити завантаження на сервер"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Дозволити редагування книг"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Allow Delete Books"
 msgstr "Видалити книгу"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Дозволити зміну пароля"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Дозволити редагування публічних книжкових полиць"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr ""
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr ""
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr ""
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr ""
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "External binaries"
 msgstr "Зовнішній порт"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr ""
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 msgid "Calibre E-Book Converter Settings"
 msgstr ""
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr ""
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "Розташування БД Calibre"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Security Settings"
 msgstr "Налаштування OAuth"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8502,339 +8351,334 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr ""
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr ""
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr ""
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 msgid "Session protection"
 msgstr ""
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr ""
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr ""
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "User Password policy"
 msgstr "Скинути пароль користувача"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr ""
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr ""
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "Переглянути налаштування"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "Кількість показаних випадкових книг"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "Видалити"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "Regexp для ігнорування стовпців"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "Regexp для сортування по назві"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Переглянути налаштування"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 msgid "Custom CSS"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "Налаштування по замовчуванню для нових користувачів"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "Версія"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Керування сервером"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "Сторінка адміністратора"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Language"
 msgstr "Виключити мови"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "Налаштування по замовчуванню для нових користувачів"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Visible Language of Books"
 msgstr "Показувати книги на мовах"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "Можливості за замовчуванням для нових користувачів"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "Можливості за замовчуванням для нових користувачів"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Показувати випадкові книги при перегляді деталей"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Add Allowed/Denied Tags"
 msgstr "Дозволені теги"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr ""
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Додати нову книгу"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "Заархівовано"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "Завантажити"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Старт"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8843,14 +8687,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8858,94 +8702,93 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "Архівні книжки"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "{} користувачі видалені успішно"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error scheduling EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "Результати для:"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "Виберіть ім'я користувача"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "У бібліотеці"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "створити книжкову полицю"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "Архівні книжки"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error starting EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Зберегти налаштування і відправити тестове повідомлення"
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8953,11 +8796,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -8968,11 +8811,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -8982,162 +8825,162 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "Архівні книжки"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9145,11 +8988,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9157,109 +9000,107 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 msgid "Metadata Fields to Update"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Ідентифікатори"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "Огляд"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
 "investigation."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9267,157 +9108,157 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Налаштування OAuth"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "Налаштування"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "Налаштування OAuth"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9425,102 +9266,101 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Налаштування OAuth"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9528,44 +9368,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Конвертувати книгу"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9573,2436 +9413,2410 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Дозволити публічну реєстрацію"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Налаштування OAuth"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Дозволити публічну реєстрацію"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Дозволити публічну реєстрацію"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Видалити формати:"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Отримати метадані"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Рейтинг"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Далі"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Відмітити як не прочитане"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Відмітити як прочитане"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "Відмітити як не прочитане"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "Відмітити як не прочитане"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Додати в архів"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Відновити з архіву"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Відновити з архіву"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Додати в архів"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "Відновити з архіву"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "У бібліотеці"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "З'єднання з базою даних закрите"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "Рейтинг: Відсутній"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr ""
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr ""
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Опис:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "Kindle"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "Kindle"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "створити книжкову полицю"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "Видалити формати:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 msgid "Failed to update tags"
 msgstr ""
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 msgid "Failed to update shelves"
 msgstr ""
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr ""
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Видалити книгу"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "Показувати книги з найвищим рейтингом"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "Обрати..."
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "Видалити книгу"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Видалити книгу"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "Попередній перегляд"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "Видалити книгу"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "Деталі"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "змінити метадані"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "Архівні книжки"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "Результати для:"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr ""
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Видалити формати:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be permanently deleted:"
 msgstr "Книга буде видалена з БД Calibre"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "Непрочитані книги"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "Книга буде видалена з БД Calibre"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "Книга буде видалена з БД Calibre"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr ""
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr ""
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr ""
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr ""
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr ""
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr ""
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr ""
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr ""
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "Пароль SMTP"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Обмеження розміру вкладення"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Save and Send Test Email"
 msgstr "Kindle"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Allowed Domains (Whitelist)"
 msgstr "Заборонені домени (Чорний список)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Додати домен"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Введіть домен"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Заборонені домени (Чорний список)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr ""
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "Список"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "створити книжкову полицю"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "Помилка пошуку!"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "переглянути книгу після редагування"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "створити книжкову полицю"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "Завантаження..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr "Ви справді хочете видалити книжкову полицю?"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "створити книжкову полицю"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject all pending matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "Папка Calibre DB"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 #, fuzzy
 msgid "Create Issue"
 msgstr "створити книжкову полицю"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr ""
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 #, fuzzy
 msgid "Logout User"
 msgstr "Вийти"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "Змінити книжкову полицю"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Show this shelf in your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "Показати всі"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "Змінити книжкову полицю"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Додати на книжкову полицю"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr ""
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "Включити навігацію"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Search Library"
 msgstr "У бібліотеці"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Зберегти налаштування і відправити тестове повідомлення"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Вийти"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "Налаштування"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "Серій в цій бібліотеці"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Оновлення неуспішне:"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Зберегти налаштування і відправити тестове повідомлення"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Видалити книгу"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Please do not refresh the page"
 msgstr "Встановлення оновлень, будь-ласка, не оновлюйте сторінку"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "створити книжкову полицю"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Попередній перегляд"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Деталі"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Впевнені що хочете перезавантажити?"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Видалити книгу"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Формат завантаження"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Видалити формати:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Видалити книгу"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Результати для:"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 msgid "Scroll to top"
 msgstr ""
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "До:"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "Налаштування сервера"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Додати на книжкову полицю"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Відмітити як не прочитане"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Відмітити як не прочитане"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Видалити книгу"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Видалити книгу"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "створити книжкову полицю"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Помилка зʼєднання"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr ""
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr ""
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "Пароль SMTP"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Запам'ятати мене"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 #, fuzzy
 msgid "Forgot Password?"
 msgstr "Пароль"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Увійдіть в систему за допомогою magic link"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 #, fuzzy
 msgid "Log in with SSO"
 msgstr "Увійдіть в систему за допомогою magic link"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr ""
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Calibre-Web Log: "
 msgstr ""
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr ""
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr ""
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr ""
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Download Access Log"
 msgstr "Завантаження"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "зробити книжкову полицю доступною для всіх?"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Select Allowed/Denied Tags"
 msgstr "Дозволені теги"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Введіть тег"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "This book format will be permanently erased from database"
 msgstr "Книга буде видалена з БД Calibre"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "Книга буде видалена з БД Calibre"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "і з диску"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Оберіть розташування файлу"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "name"
 msgstr "Ім'я користувача"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Parent Directory"
 msgstr "Папка Calibre DB"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 #, fuzzy
 msgid "Ok"
 msgstr "Книга"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Зберегти налаштування і відправити тестове повідомлення"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 #, fuzzy
 msgid "epub Reader"
 msgstr "Засіб для читання txt-файлів"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "Дії"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 #, fuzzy
 msgid "Black"
 msgstr "Назад"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr ""
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Далі"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr ""
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 #, fuzzy
 msgid "Default"
 msgstr "Видалити"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr ""
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr ""
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 #, fuzzy
 msgid "KaiTi"
 msgstr "Очікує"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 #, fuzzy
 msgid "Arial"
 msgstr "Вертикально"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 #, fuzzy
 msgid "Spread"
 msgstr "Прочитано"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr ""
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr ""
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "Переформатувати текст, коли відкриті бічні панелі."
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Comic Reader"
 msgstr "Засіб для читання txt-файлів"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Previous Page"
 msgstr "Попередній перегляд"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Next Page"
 msgstr "Далі"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page Display"
 msgstr "Сторінка адміністратора"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr ""
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr ""
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr ""
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr ""
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Rotate Right"
 msgstr "Повернути"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Rotate Left"
 msgstr "Повернути"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr ""
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page"
 msgstr "Сторінка адміністратора"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr ""
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Scale"
 msgstr "Локалізація"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Краще"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Ширина"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Висота"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr ""
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Повернути"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr ""
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr ""
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Вертикально"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Direction"
 msgstr "Опис"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr ""
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr ""
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr ""
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Remember Position"
 msgstr "Запам'ятати мене"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr ""
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "Показати"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 #, fuzzy
 msgid "DJVU Reader"
 msgstr "Засіб для читання txt-файлів"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 #, fuzzy
 msgid "PDF Reader"
 msgstr "Засіб для читання txt-файлів"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 #, fuzzy
 msgid "txt Reader"
 msgstr "Засіб для читання txt-файлів"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Зареєструвати нового користувача"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Виберіть ім'я користувача"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Ваш email-адрес"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr ""
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr ""
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "Після цього ви автоматично ввійдете в систему на цьому пристрої."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr ""
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 #, fuzzy
 msgid "No Results Found"
 msgstr "Результати для:"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 #, fuzzy
 msgid "Search Term:"
 msgstr "Помилка пошуку!"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Результати для:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Дата публікації з"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Дата публікації до"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr ""
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "Виключити теги"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "Виключити серії"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Exclude Shelves"
 msgstr "Виключити серії"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "Виключити мови"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "Розширення"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Exclude Extensions"
 msgstr "Розширення"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Rating Above"
 msgstr "Рейтинг: Відсутній"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Rating Below"
 msgstr "Рейтинг: Відсутній"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "Від:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "До:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Видалити цю книжкову полицю"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr ""
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Популярні книги"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr ""
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr ""
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr ""
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Архівні книжки"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, python-format
 msgid "Add %(count)s"
 msgstr ""
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Токен не знайдено"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Видалити цю книжкову полицю"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Додати на книжкову полицю"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "У бібліотеці"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "У бібліотеці"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "зробити книжкову полицю доступною для всіх?"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr ""
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Користувача не знайдено"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Hidden Book"
 msgstr "Популярні книги"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Статистика бібліотеки Calibre"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Книг в цій бібліотеці"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Авторів в цій бібліотеці"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Категорій в цій бібліотеці"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Серій в цій бібліотеці"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Статистика системи"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "Програма"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Встановлена версія"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Тривалість"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Actions"
 msgstr "Дії"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "Повернути"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
 msgstr ""
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "{} користувачі видалені успішно"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Зберегти налаштування і відправити тестове повідомлення"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "Ваш email-адрес"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "Налаштування"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Скинути пароль користувача"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "Налаштування серверу"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "Kindle"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "Виключити мови"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Показувати книги на мовах"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "Показувати книги на мовах"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "Налаштування OAuth"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr ""
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr ""
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Створити/Переглянути"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 msgid "Expose only books in selected shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "Налаштування OAuth"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr ""
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "Прочитані книги"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "Змінити книжкову полицю"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Видалити цього користувача"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12010,166 +11824,166 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Дозволити зміну пароля"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Дозволити зміну пароля"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Створити/Переглянути"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr ""
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Обрати..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr ""
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit User"
 msgstr "Керування сервером"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Username"
 msgstr "Виберіть ім'я користувача"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Email"
 msgstr "Kindle"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email"
 msgstr "Kindle"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email"
 msgstr "Kindle"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "Kindle"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "Kindle"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Локалізація"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Visible Book Languages"
 msgstr "Показувати книги на мовах"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Allowed Tags"
 msgstr "Дозволені теги"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Дозволені теги"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Змінити заборонені теги"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Заборонені теги"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Allowed Column Values"
 msgstr "Дозволені теги"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Denied Column Values"
 msgstr "Змінити заборонені теги"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Denied Column Values"
 msgstr "Заборонені домени (Чорний список)"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Change Password"
 msgstr "Дозволити зміну пароля"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Edit Public Shelves"
 msgstr "Змінити книжкову полицю"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 msgid "Expose selected Shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Read/Unread Section"
 msgstr "Показувати вибір серії"

--- a/cps/translations/vi/LC_MESSAGES/messages.po
+++ b/cps/translations/vi/LC_MESSAGES/messages.po
@@ -17,260 +17,258 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "Thống kê"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 #, fuzzy
 msgid "Server restarted, please reload page."
 msgstr "Máy chủ đã khởi động lại,hãy tải lại trang"
 
-#: cps/admin.py:210
+#: cps/admin.py
 #, fuzzy
 msgid "Performing Server shutdown, please close window."
 msgstr "Máy chủ đang được tắt, hãy đóng cửa sổ này"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr ""
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "Lệnh không tồn tại"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr ""
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 
-#: cps/admin.py:414
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover ID applied successfully"
 msgstr "{} người dung đã đươc xoá thành công"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr ""
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr ""
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr ""
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr ""
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr ""
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "Trang admin"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "Thiết lập OAuth"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "Thiết lập cơ bản"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "Thiết lập UI"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "Chỉnh sửa người dùng"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "Tất cả"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "Không tìm thấy user"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "{} người dung đã đươc xoá thành công"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "Hiển thị tất cả"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "Yêu cầu không đúng định dạng"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "Tên người dung khách không thể thay đổi"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "Khách không thể mang vai trò này"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr "Không còn người dùng quản trị, không thể xoá vai trò admin"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "Giá trị phải là true hoặc false"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "Vai trò không hợp lệ"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "Tài khoản khách không có màn hình này"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "View không hợp lệ"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr "Ngôn ngữ của khách được xác định tự động và không thể đặt được"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "Địa chỉ cung cấp không hợp lệ"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "Ngôn ngữ sách không hợp lệ"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "Tham số không tồn tại"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr ""
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "Cột đọc không hợp lệ"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "Cột bị hạn chế không hợp lệ"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Bạn có thực sự muốn xóa Kobo Token không?"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "Bạn có thực sự muốn xóa miền này không?"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "Bạn có thực sự muốn xóa người dùng này không?"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "Bạn có chắc chắn muốn xóa giá này không?"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr "Bạn có chắc chắn muốn thay đổi ngôn ngữ của những người dùng đã chọn?"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 "Bạn có chắc chắn muốn thay đổi ngôn ngữ sách hiển thị cho (những) người dùng "
 "đã chọn không?"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 "Bạn có chắc chắn muốn thay đổi vai trò đã chọn cho (những) người dùng đã "
 "chọn không?"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
 msgstr "Bạn có chắc chắn muốn thay đổi những giới hạn đã chọn cho người dung?"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
@@ -278,14 +276,14 @@ msgstr ""
 "Bạn có chắc chắn muốn thay đổi các giới hạn hiển thị đã chọn cho (những) "
 "người dùng đã chọn không?"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 "Bạn có chắc chắn muốn thay đổi hành vi đồng bộ hóa giá cho (những) người "
 "dùng đã chọn không?"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
@@ -293,1520 +291,1494 @@ msgstr ""
 "Bạn có chắc chắn muốn thay đổi hành vi đồng bộ hóa giá cho (những) người "
 "dùng đã chọn không?"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "Bạn có chắc chắn muốn thay đổi vị trí thư viện Calibre không?"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "Từ chối"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "Cho phép"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "{} mục nhập đồng bộ hóa đã bị xóa"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "Không tìm thấy token"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "Tag không tồn tại"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "Hành động không hợp lệ"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr ""
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "Vị trí tệp nhật ký không hợp lệ, vui lòng nhập đường dẫn chính xác"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr ""
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr ""
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
 msgstr ""
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "Thêm người dùng mới"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr ""
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr ""
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "Lỗi cơ sở dữ liệu: %(error)s."
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
 msgstr ""
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr ""
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr ""
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr ""
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "Chỉnh sửa người dùng"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr ""
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 msgid "Please set an email address on your own account first..."
 msgstr ""
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "Mật khẩu mới đã được gửi đến email của bạn"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
 msgstr ""
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
 "delivery."
 msgstr ""
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr ""
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr ""
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr ""
 
-#: cps/admin.py:2139
+#: cps/admin.py
 #, fuzzy
 msgid "Scheduled tasks settings updated"
 msgstr "Thiết lập cơ sở dữ lieu đã được cập nhật"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "Lỗi không xác định xảy ra. Xin hãy thử lại sau."
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "Tên"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "Chỉnh sửa người dùng %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr ""
 
-#: cps/admin.py:2296
+#: cps/admin.py
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr ""
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr ""
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr ""
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr ""
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "Đang giải nén tệp cập nhật"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "They thế tập tin"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "Liên kết cơ sở dữ liệu đã được đóng"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "Đang dừng server"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "Cập nhật hoàn tất, ấn okay và tải lại trang"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "Cập nhật thất bại:"
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "Lỗi HTTP"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "Lỗi kết nối"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr ""
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "Lỗi chung"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr "File cập nhật không thể được lưu trong thư mục tạm thời"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr ""
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr ""
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr ""
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr ""
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr ""
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr ""
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr ""
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr ""
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr ""
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr ""
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "Thiết lập cơ sở dữ lieu đã được cập nhật"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "Thiết lập cơ sở dữ lieu :)))"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "Hãy điền hết các trường!"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "Địa chỉ email không hợp lệ"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "Thêm người dùng mới"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "Người dùng '%(user)s' đã được tạo"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "Người dùng với địa chỉ email hoặc tên đã tồn tại."
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "Người dùng '%(nick)s' đã bị xoá"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "Không thể xoá người dùng khách"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr ""
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr ""
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "Người dùng '%(nick)s' đã được cập nhật"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr ""
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr ""
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Lỗi kết nối"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr ""
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 
-#: cps/admin.py:3322
+#: cps/admin.py
 msgid " User info endpoint is available."
 msgstr ""
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr ""
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr ""
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr ""
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "Lỗi không xác định xảy ra. Xin hãy thử lại sau."
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "Lỗi kết nối"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "Lỗi kết nối"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "File %(file)s đã được tải lên"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr ""
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr ""
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr ""
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr ""
 
-#: cps/constants.py:265
+#: cps/constants.py
 #, fuzzy
 msgid "Finnish"
 msgstr "Đã hoàn thành"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr ""
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr ""
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr ""
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr ""
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr ""
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr ""
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr ""
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr ""
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr ""
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr ""
 
-#: cps/constants.py:276
+#: cps/constants.py
 #, fuzzy
 msgid "Polish"
 msgstr "Nhà xuất bản"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr ""
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr ""
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr ""
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr ""
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr ""
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr ""
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr ""
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr ""
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr ""
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr ""
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "chưa cài đặt"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr ""
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, fuzzy, python-format
 msgid "Change cover — %(title)s"
 msgstr "Đổi tác giả và tên sách"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "Lỗi kết nối"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr ""
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Book ID"
 msgstr "Sách"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "Tên sách"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "Tác giả"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr ""
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "Định dạng file"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filename"
 msgstr "tên"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr ""
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr ""
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "Định dạng tải lên"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "Không rõ"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr ""
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "Vai trò không hợp lệ"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "Gộp những sách đã chọn"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "Định dạng %(format)s không được tìm thấy trên đĩa"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB Fixer started for selected book."
 msgstr "Gộp những sách đã chọn"
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr ""
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr ""
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid image data format."
 msgstr "Định dạng email address không hợp lệ"
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Profile picture updated successfully."
 msgstr "{} người dung đã đươc xoá thành công"
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "None"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "Xoá sách"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "Xoá sách"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "Xoá sách"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "Không tìm thấy kết quả"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 #, fuzzy
 msgid "Invalid resolution strategy"
 msgstr "Vai trò không hợp lệ"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "Tải lên xong, đang xử lý, đợi chút ..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 #, fuzzy
 msgid "Failed to queue upload for processing"
 msgstr "Tạo đường dẫn cho ảnh bìa thất bại"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "Thiếu định dạng nguồn hoặc đích để convert"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr ""
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "Có lỗi xảy ra khi chuyển đổi định dạng cho sach: %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr ""
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr ""
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr ""
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr ""
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr ""
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "%(langname)s không phải là ngôn ngữ hợp lệ"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "Metadata đã được cập nhật thành công"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr ""
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "Không rõ"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
 msgstr ""
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr ""
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr ""
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr ""
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr ""
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr ""
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr ""
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr ""
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr ""
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "Lưu file thất bại %(file)s."
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr ""
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "Không tìm thấy token"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "Định dạng %(format)s không được tìm thấy trên đĩa"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
 msgstr ""
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
 msgstr ""
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr ""
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr ""
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "%(format)s không tìm thấy: %(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 #, fuzzy
 msgid "Send to eReader"
 msgstr "Gửi tới Kindle"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr ""
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr ""
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 #, fuzzy
 msgid "Test Email"
 msgstr "Test e-mail"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "Email đăng ký cho người dùng: %(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "Chuyển đổi %(orig)s thành %(format)s và chuyển tới Kindle"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Send %(format)s to eReader"
 msgstr "Gửi %(format)s tới Kindle"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s gửi tới Kindle"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "File được yêu cầu không thể đọc. Có thể do phân quyền bị sai?"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr ""
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
 msgstr ""
 "Xoá thư mục cho sách %(id)s thất bại, đường dẫn có subfolders: %(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "Xoá sách %(id)s thất bại: %(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
 "%(path)s"
 msgstr ""
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "File %(file)s không tìm thấy trẻn Google Drive"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Không tìm thấy được dẫn sách %(path)s trên Google Drive"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr ""
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "Username này đã bị sử dụng"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 #, fuzzy
 msgid "Invalid Email address format"
 msgstr "Định dạng email address không hợp lệ"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr ""
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "Lỗi tải xuống ảnh bìa"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr ""
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "Định dạng ảnh bìa lỗi"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
 msgstr ""
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "Tạo đường dẫn cho ảnh bìa thất bại"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr ""
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr ""
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr ""
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr ""
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr ""
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr ""
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr ""
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr ""
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr ""
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr ""
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr ""
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Thiết lập Kobo"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr ""
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "Thiết lập Calibre-Web đã cập nhật"
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1814,35 +1786,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr ""
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr ""
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1850,5192 +1822,5092 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 msgid "OAuth system error. Please contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr ""
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr ""
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr ""
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "Đăng nhập với Github thất bại."
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "Lấy thông tin user từ Github thất bại."
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "Đăng nhập với Google thất bại."
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "Lấy thông tin người dùng từ Google thất bại."
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "Failed to log in with Generic OAuth."
 msgstr "Đăng nhập với Github thất bại."
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "Oauth Github lỗi, xin thử lại sau."
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "Github Oauth lỗi: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Google Oauth lỗi, làm ơn thử lại sau."
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Google Oauth lỗi: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, fuzzy, python-brace-format
 msgid "OAuth error: {}"
 msgstr "Github Oauth lỗi: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 #, fuzzy
 msgid "Alphabetical Books"
 msgstr "Xoá sách"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr ""
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "Sách hot"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr ""
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "Top sách được đánh giá cao"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr ""
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "Sách đã tải"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "Sách mới nhất"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "Sách ngẫu nhiên"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "Hiển thị sách ngẫu nhiên"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "Sách đã đọc"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "Phiên bản hiện tại"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "Sách chưa đọc"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "Tác giả"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "Sách sắp xếp theo tác giả"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "Nhà phát hành"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "Sách sắp xếp theo nhà phát hành"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "Chủ đề"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "Sách sắp xếp theo thể loại"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "Series"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "Sách sắp xếp theo series"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "Ngôn ngữ"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "Sách sắp xếp theo ngôn ngữ"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "Đánh giá"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "Sách sắp xếp theo xếp hạng"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "Định dạng file"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "Sách sắp xếp theo định dạng"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "Giá sách"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "Sách tổ chức theo giá sách"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "Đồng bộ những giá sách đã chọn với Kobo"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "Sách tổ chức theo giá sách"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "Mô tả"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} sao"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "Tìm kiếm"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "Đăng nhập"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "Không tìm thấy token"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Token đã hết hạn"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "Thành công! Hãy quay lại thiết bị của bạn"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "Sách"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "Hiển thị sách gần đây"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "Hiển thị sách hot"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "Sách đã tải"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "Hiển thị sách đã tải"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "Hiện thị top những sách được đánh giá cao"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Read and Unread"
 msgstr "Hiển thị đã đọc và chưa đọc"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "Hiện thị sách chưa đọc"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "Khám phá"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Category Section"
 msgstr "Hiển thị chọn chủ đề"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Series Section"
 msgstr "Hiển thị chọn series"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Author Section"
 msgstr "Hiển thị chọn tác giả"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Publisher Section"
 msgstr "Hiển thị chọn nhà phát hành"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Language Section"
 msgstr "Hiển thị chọn ngôn ngữ"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Ratings Section"
 msgstr "Hiển thị chọn đánh giá"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show File Formats Section"
 msgstr "Hiển thị lựa chọn định dạng file"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "Sách đã lưu trữ"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Archived Books"
 msgstr "Hiện thị sách trong kho"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "Danh sách sách"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "Hiển thị danh sách sách"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr ""
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Hiện thị top những sách được đánh giá cao"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "Phát hành sau "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "Phát hành trước "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "Đánh giá <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "Đánh giá >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, fuzzy, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "Trạng thái đọc = %(status)s"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "Tìm kiếm nâng cao"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr ""
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "Xin lỗi bạn không có quyền thêm sách vào giá đó"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr ""
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "Sách đã được thêm vào giá: %(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr ""
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr ""
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr ""
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr ""
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 msgid "Invalid series specified"
 msgstr ""
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr ""
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "Sách đã được thêm vào giá: %(sname)s"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "Sách đã được thêm vào giá: %(sname)s"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "Sách đã được xoá khỏi giá: %(sname)s"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "Xin lỗi bạn không có quyền xoá sách khỏi giá này"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "Tạo một giá sách"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "Xin lỗi bạn không có quyền chỉnh sửa giá sách này"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "Chỉnh sửa giá sách"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr ""
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr ""
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr ""
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "Xin lỗi bạn không có quyền tạo một giá sách công khai"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "Giá sách %(title)s đã được tạo"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "Giá sách %(title)s đã được thay đổi"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "Có lỗi xảy ra"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr ""
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr ""
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr ""
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Giá sách"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr ""
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr ""
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr ""
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr ""
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "Có"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "Không"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "Read status"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr ""
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "Sáng"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "Tối"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr ""
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "Thêm vào giá sách"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "Tác giả"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "Tìm kiếm"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "Đóng"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "Xoá"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "Trộn"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "Nhà xuất bản"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "Đọc"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "Tên"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "Tải lên"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "Tài khoản"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "Admin"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "Đã phát hành"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "Nguồn"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "About"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "Lưu trữ"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "Huỷ bỏ"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "Mô tả"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "Tải xuống"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "Chỉnh sửa"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "Địa chỉ email"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr ""
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "Ẩn"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "Nhận diện"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "Ngôn ngữ"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "Mật khẩu"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "Cổng"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "Tiến độ"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "Đánh giá"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "Lưu"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "Chọn"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "Trạng thái"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "Đánh dấu"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "Nhiệm vụ"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "Nhiệm vụ"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "Người dùng"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "Tên người dùng"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "Xem"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "Đang chờ"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "Thất bại"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "Đã bắt đầu"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "Đã hoàn thành"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr ""
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 #, fuzzy
 msgid "Cancelled"
 msgstr "Huỷ bỏ"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "Trạng thái không xác định"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr ""
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr ""
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
 msgstr ""
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr ""
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr ""
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
 "%(version)s"
 msgstr ""
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr ""
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr ""
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr ""
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr ""
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr ""
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr ""
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr ""
 
-#: cps/web.py:906
+#: cps/web.py
 #, fuzzy
 msgid "Rating: None"
 msgstr "Đánh giá cao hơn"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr ""
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr ""
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr ""
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr ""
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "Sách hot"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "Sách ẩn"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "Lỗi tải xuống ảnh bìa"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "Định dạng email address không hợp lệ"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 #, fuzzy
 msgid "Invalid request"
 msgstr "Vai trò không hợp lệ"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr ""
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 #, fuzzy
 msgid "Error creating shelf"
 msgstr "Lỗi tải xuống ảnh bìa"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Tạo một giá sách"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 #, fuzzy
 msgid "Shelf name is required"
 msgstr "Đây là trường bắt buộc"
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "Lỗi tải xuống ảnh bìa"
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "Chỉnh sửa giá sách"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "Không tìm thấy user"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "{} người dung đã đươc xoá thành công"
 
-#: cps/web.py:1710
+#: cps/web.py
 #, fuzzy
 msgid "Error duplicating shelf"
 msgstr "Lỗi tải xuống ảnh bìa"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 #, fuzzy
 msgid "Error deleting shelf"
 msgstr "Lỗi tải xuống ảnh bìa"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "Lỗi tải xuống ảnh bìa"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 #, fuzzy
 msgid "Error unhiding shelf"
 msgstr "Lỗi tải xuống ảnh bìa"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "Tải xuống"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "Danh sách định dạng file"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr ""
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr ""
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr ""
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 
-#: cps/web.py:2500
+#: cps/web.py
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr ""
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "Đăng ký"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr ""
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr ""
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "Email của bạn không được cho phép để đăng ký"
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr ""
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
 msgstr "Thiết lập Calibre-Web đã cập nhật"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "Thiết lập Calibre-Web đã cập nhật"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr ""
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr ""
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr ""
 
-#: cps/web.py:2775
+#: cps/web.py
 #, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr ""
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
 msgstr "Thiết lập Calibre-Web đã cập nhật"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
 "known"
 msgstr ""
 
-#: cps/web.py:2801
+#: cps/web.py
 #, fuzzy, python-format
 msgid "Could not login: %(message)s"
 msgstr "Không thể đăng nhập: %(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 #, fuzzy
 msgid "Wrong Username or Password"
 msgstr "Tên đăng nhập hoặc mật khẩu không đúng"
 
-#: cps/web.py:2832
+#: cps/web.py
 #, fuzzy
 msgid "New Password was sent to your email address"
 msgstr "Mật khẩu mới đã được gửi đến email của bạn"
 
-#: cps/web.py:2836
+#: cps/web.py
 #, fuzzy
 msgid "An unknown error occurred. Please try again later."
 msgstr "Lỗi không xác định xảy ra. Xin hãy thử lại sau."
 
-#: cps/web.py:2838
+#: cps/web.py
 #, fuzzy
 msgid "Please enter valid username to reset password"
 msgstr "Tên đăng nhập hoặc mật khẩu không đúng"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr ""
 
-#: cps/web.py:3158
+#: cps/web.py
 #, fuzzy
 msgid "Success! Profile Updated"
 msgstr "Metadata đã được cập nhật thành công"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "Tìm thấy một tài khoản đã toàn tại cho địa chỉ email này"
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 #, fuzzy
 msgid "Invalid book ID."
 msgstr "Vai trò không hợp lệ"
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr ""
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "%(book)s gửi tới Kindle"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "Gửi tới Kindle"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-send completed successfully"
 msgstr "{} người dung đã đươc xoá thành công"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr ""
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr ""
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, fuzzy, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s gửi tới Kindle"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr ""
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "Định dạng %(format)s không được tìm thấy trên đĩa"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr ""
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr ""
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr ""
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr ""
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 #, fuzzy
 msgid "Reconnecting Calibre database"
 msgstr "Kết nối lại với cơ sở dữ liệu Calibre"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "Xoá sách"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "Xoá sách"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "Đang giải nén tệp cập nhật"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "Không tìm thấy kết quả"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "Mở thay đổi thứ tự"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 #, fuzzy
 msgid "E-mail"
 msgstr "Test e-mail"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 #, fuzzy
 msgid "Backing up Metadata"
 msgstr "Chỉnh sửa Metadata"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "Trong thư viện"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "Sách tổ chức theo giá sách"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "Đổi mật khẩu"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "Tạo một giá sách"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "Thiết lập OAuth"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "Thiết lập"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "chọn một lựa chọn"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "Thêm vào giá sách"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(Công khai)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "Tải xuống"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "Tải xuống"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 msgid "Date added, newest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 msgid "Date added, oldest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "Tác giả"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "Tác giả"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "Phát hành trước "
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "Phát hành trước "
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "Thêm vào giá sách"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "Thêm vào giá sách"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Send to eReader Email"
 msgstr "Kindle"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "Gửi tới Kindle"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "Xem sách"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "Giá công khai"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr ""
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr ""
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "Thiết lập máy chủ email"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "SMTP Hostname"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "Cổng SMTP"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "Đăng nhập SMTP"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "Từ E-mail"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Service"
 msgstr "Dịch vụ E-Mail"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "Gmail via Oauth2"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Thư mục cơ sở dữ liệu Calibre"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "Log Level"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr ""
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "Sách mỗi trang"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "Tải lên"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "Ẩn danh"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "Đăng ký công khai"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "Đăng nhập bằng Magic Link"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr ""
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr ""
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "Chỉnh sửa thiết lập cơ bản"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "Chỉnh sửa thiết lập UI"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "Chỉnh sửa thiết lập cơ sở dữ liệu Calibre"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr ""
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Start Time"
 msgstr "Đã bắt đầu"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr ""
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr ""
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 #, fuzzy
 msgid "Reconnect Calibre Database"
 msgstr "Kết nối lại với cơ sở dữ liệu Calibre"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr ""
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr ""
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Setup KOReader Sync"
 msgstr "trình đọc epub"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr ""
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "Quản trị"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "Tải xuống package debug"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "Xem logs"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "Khởi động lại"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "Tắt"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "Thiết lập máy chủ"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "Phiên bản"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "Chi tiết"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "Cập nhật thất bại:"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "Cập nhật thất bại:"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "Phiên bản hiện tại"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "Kiểm tra cập nhật"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "Bắt đầu cập nhật"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "Bạn có chắc chắn muốn khởi động lại?"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "Bạn có chắc muốn tắt?"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "Đang update, làm ơn đừng load lại trang này"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7043,616 +6915,593 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "Sách trong thư viện"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "Đang tải lên..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "Cập nhật thất bại:"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "Lỗi kết nối"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "Nguồn"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "via"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "Trong thư viện"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr ""
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "Cùng tác giả"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "Xoá sách"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "Xoá định dạng:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "Chuyển đổi định dạng sách:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "Chuyển đổi từ:"
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "select an option"
 msgstr "chọn một lựa chọn"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "Chuyển đổi tới:"
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "Chuyển đổi sách"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "Lỗi"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "Định dạng tải lên"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "Series ID"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "Ngày xuất bản"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "Kiểu nhận diện"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "Giá trị nhận diện"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "Xoá"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "Thêm nhận diện"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr ""
 "Lấy ảnh bìa từ URL (ảnh JPEG sẽ được tải xuống và lưu trong cơ sở dữ liệu)"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "Tải ảnh bìa từ ổ cứng"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "Mở thay đổi thứ tự"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "Xem sách sau khi lưu"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "Fetch Metadata"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "Từ khoá"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "Tìm kiếm từ khoá"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "Đang tải..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "Tìm kiếm lỗi!"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "Không tìm thấy kết quả! Hãy thử lại với từ khoá khác."
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "Đây là trường bắt buộc"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 #, fuzzy
 msgid " Exchange author & title"
 msgstr "Đổi tác giả và tên sách"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "Tạo một giá sách"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr ""
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Update Title Sort automatically  "
 msgstr "Cập nhật sắp xếp theo tên tự động"
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "Cập nhật sắp xếp theo tác giả tự động"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "Nhập tên sách"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "Nhập tên sách để sắp xếp"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "Tên sắp xếp"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "Nhập tác giả sắp xếp"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "Tên tác giả sắp xếp"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "Nhập tên tác giả"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "Nhập thể loại"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "Nhập tên series"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "Nhập ngôn ngữ"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "Ngày phát hành"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "Nhập tên nhà phát hành"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "Nhập nhận xét"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Comments"
 msgstr "Nhận xét"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Archived?"
 msgstr "Lưu trữ"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Read?"
 msgstr "Đọc"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "Nhập "
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "Bạn có thực sự chắc chắn?"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr ""
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Into Book with Title:"
 msgstr "Tên sách"
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr ""
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr ""
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr ""
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr ""
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr ""
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "Chỉnh sửa Metadata"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "Tạo một giá sách"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr ""
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "Thêm"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 #, fuzzy
 msgid "Message"
 msgstr "Trộn"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "Mật khẩu mới đã được gửi đến email của bạn"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "Gửi tới Kindle"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "Quay lại"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Vị trí cơ sở dữ liệu của Calibre"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7668,13 +7517,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7685,7 +7534,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7696,43 +7545,43 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr ""
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
 "can be wherever you desire"
 msgstr ""
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "Dùng Google Drive?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "Xác thực Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Thư mục Calibre trên Google Drive"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr ""
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "Thu hồi"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Kết nối lại với cơ sở dữ liệu Calibre"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7742,139 +7591,139 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "Bạn có chắc muốn tắt?"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Kết nối lại với cơ sở dữ liệu Calibre"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr "Đường dẫn DB mới không hợp lệ, xin hãy nhập đường dẫn hợp lệ"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr ""
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Server Configuration"
 msgstr "Thiết lập"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "Cổng máy chủ"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Update Channel"
 msgstr "Cập nhật thất bại:"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr ""
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Nightly"
 msgstr "Sáng"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr ""
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Logfile Configuration"
 msgstr "Thiết lập"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr ""
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Access Log"
 msgstr "Tải xuống log truy cập"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr ""
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "Thiết lập cơ sở dữ lieu :)))"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Uploads"
 msgstr "Cho phép tải lên"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr ""
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Allowed Upload Fileformats"
 msgstr "Định dạng tải lên"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Anonymous Browsing"
 msgstr "Ẩn danh"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Public Registration"
 msgstr "Đăng ký công khai"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Use Email as Username"
 msgstr "Chọn tên người dùng"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Magic Link Remote Login"
 msgstr "Đăng nhập bằng Magic Link"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7882,154 +7731,154 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr ""
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr ""
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "Sử dụng Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Goodreads API Key"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Hardcover Sync"
 msgstr "Mở thay đổi thứ tự"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "Token đã hết hạn"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Goodreads API Key"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8037,414 +7886,414 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "Kiểu đăng nhập"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr ""
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Server Port"
 msgstr "Cổng máy chủ"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Encryption"
 msgstr "SSL"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr ""
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "LDAP Administrator Username"
 msgstr "Quản trị"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr ""
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr ""
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr ""
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr ""
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr ""
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr ""
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr ""
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr ""
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "Fetch Metadata"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
 msgstr ""
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "Chỉnh sửa thiết lập UI"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "Không tìm thấy token"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "Lỗi kết nối"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "Thiết lập OAuth"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 msgid "OAuth Client Id"
 msgstr ""
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 msgid "OAuth Client Secret"
 msgstr ""
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "Thiết lập"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "Tên người dùng"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr ""
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "Dịch vụ E-Mail"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr ""
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 msgid "OAuth Group Claim"
 msgstr ""
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr ""
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr ""
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "Cho phép tải xuống"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "Cho phép xem eBook"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "Cho phép tải lên"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "Cho phép chỉnh sửa"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "Cho phép xoá sách"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "Cho phép thay đổi mật khẩu"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "Cho phép chỉnh sửa giá sách công khai"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr ""
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr ""
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr ""
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr ""
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "External binaries"
 msgstr "Nhập tên series"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr ""
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 msgid "Calibre E-Book Converter Settings"
 msgstr ""
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr ""
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "Vị trí cơ sở dữ liệu của Calibre"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Security Settings"
 msgstr "Thiết lập OAuth"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8452,338 +8301,333 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr ""
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr ""
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr ""
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Session protection"
 msgstr "chọn một lựa chọn"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr ""
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr ""
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "User Password policy"
 msgstr "Reset mật khẩu người dùng"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr ""
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr ""
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "View Configuration"
 msgstr "Thiết lập"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "No. of Random Books to Display"
 msgstr "Hiển thị sách ngẫu nhiên trong màn hình chi tiết"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "Xoá"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "calibur! Theme tối"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "Thiết lập"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 msgid "Custom CSS"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "Phiên bản"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "Người dùng quản trị"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "Trang admin"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "Ngôn ngữ mặc định"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 msgid "Default interface language for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "Ngôn ngữ hiển thị mặc định của sách"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 msgid "Default book language filter for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "Hiển thị sách ngẫu nhiên trong màn hình chi tiết"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Add Allowed/Denied Tags"
 msgstr "Chỉnh sửa những tags đươc cho phép"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "Thêm cho phép/từ chối giá trị cột tuỳ biến"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "Tải lên"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "Lưu trữ"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "Tải xuống"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "Bắt đầu"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8792,14 +8636,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8807,96 +8651,95 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "Gộp những sách đã chọn"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "{} người dung đã đươc xoá thành công"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "Lỗi tải xuống ảnh bìa"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "Không tìm thấy kết quả"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "Nhập tên người dùng"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "Tìm kiếm thư viện"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "Tạo một giá sách"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "Gộp những sách đã chọn"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "Lỗi tải xuống ảnh bìa"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Calibre-Web Log: "
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8904,11 +8747,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -8919,11 +8762,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -8933,162 +8776,162 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "Sách đã lưu trữ"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9096,11 +8939,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9108,110 +8951,108 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "Metadata đã được cập nhật thành công"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Nhận diện"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "Khám phá"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
 "investigation."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9219,157 +9060,157 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Thiết lập OAuth"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "Thiết lập"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "Thiết lập OAuth"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9377,103 +9218,102 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Đồng bộ những giá sách đã chọn với Kobo"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Thiết lập OAuth"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9481,44 +9321,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Chuyển đổi định dạng sách:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9526,990 +9366,972 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Đăng ký công khai"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Thiết lập OAuth"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Đăng ký công khai"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Đăng ký công khai"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Xoá định dạng:"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Fetch Metadata"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Đánh giá"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "Tiếp tục"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "Đánh dấu chưa đọc"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "Đánh dấu đã đọc"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "Đánh dấu chưa đọc"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "Đánh dấu chưa đọc"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "Thêm vào lưu trữ"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "Khôi phục từ lưu trữ"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "Khôi phục từ lưu trữ"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "Thêm vào lưu trữ"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "Khôi phục từ lưu trữ"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "Tìm kiếm thư viện"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "Thiết lập cơ sở dữ lieu đã được cập nhật"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "Đánh giá cao hơn"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "Sách %(index)s của %(range)s"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr ""
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "Mô tả:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "Kindle"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "Kindle"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "Tạo một giá sách"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "Xoá định dạng:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "Tạo đường dẫn cho ảnh bìa thất bại"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "Tạo đường dẫn cho ảnh bìa thất bại"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr ""
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "Xoá sách"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "Hiện thị top những sách được đánh giá cao"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "Chọn"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "Gộp những sách đã chọn"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "Xoá sách"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "Trước"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "Gộp những sách đã chọn"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "Chi tiết sách"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "Chỉnh sửa Metadata"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "Gộp những sách đã chọn"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "Không tìm thấy kết quả"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr ""
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "Xoá định dạng:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 msgid "The following books will be permanently deleted:"
 msgstr ""
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "Sách chưa đọc"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 msgid "The following book will be kept:"
 msgstr ""
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 msgid "The following books will be merged into it (and then deleted):"
 msgstr ""
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr ""
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr ""
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr ""
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "Chọn kiểu server"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Standard Email Account"
 msgstr "Dùng tài khoản email tiêu chuẩn"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Gmail Account"
 msgstr "Chọn kiểu server"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Setup Gmail Account"
 msgstr "Chọn kiểu server"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "Thu hồi quyền truy cập Gmail"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "Mật khẩu SMTP"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "Giới hạn kích thước file đính kèm"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Save and Send Test Email"
 msgstr "Lưu và gửi test E-mail"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "Domains được chấp nhận (Whitelist)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "Thêm domain"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "Nhập tên domain"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "Domain bị từ chối (Blacklist)"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 #, fuzzy
 msgid "Kobo Token:"
 msgstr "Token đồng bộ Kobo"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "Tạo một giá sách"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "Từ khoá tìm kiếm:"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "Xem sách sau khi lưu"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "Tạo một giá sách"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "Đang tải..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
@@ -10518,17 +10340,16 @@ msgstr ""
 "Bạn có chắc chắn muốn thay đổi vai trò đã chọn cho (những) người dùng đã "
 "chọn không?"
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "Tạo đường dẫn cho ảnh bìa thất bại"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
@@ -10536,1425 +10357,1418 @@ msgstr ""
 "Bạn có chắc chắn muốn thay đổi vai trò đã chọn cho (những) người dùng đã "
 "chọn không?"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "Tạo một giá sách"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "Tạo đường dẫn cho ảnh bìa thất bại"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "Thiết lập Calibre-Web đã cập nhật"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 #, fuzzy
 msgid "Create Issue"
 msgstr "Tạo một giá sách"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "Quay về trang chủ"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 #, fuzzy
 msgid "Logout User"
 msgstr "Đăng xuất"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "Chỉnh sửa giá sách"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show this shelf in your sidebar"
 msgstr "Đồng bộ giá sách này với thiết bị Kobo"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "Hiển thị tất cả"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "Giá công khai"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "Thêm vào giá sách"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "Trang chủ"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr ""
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "Tìm kiếm thư viện"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Calibre-Web test e-mail"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "Đăng xuất"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "Thiết lập"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "Tìm kiếm thư viện"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "Cập nhật thất bại:"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Calibre-Web test e-mail"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Xoá sách"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "Làm ơn đừng load lại trang"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Tạo một giá sách"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "Trước"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "Chi tiết sách"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Bạn có chắc muốn tắt?"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Gộp những sách đã chọn"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "Định dạng tải lên"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Xoá định dạng:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Xoá sách"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Không tìm thấy kết quả"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 msgid "Scroll to top"
 msgstr ""
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "Tới:"
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 msgid "Confirm"
 msgstr ""
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Thêm vào giá sách"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Gộp những sách đã chọn"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Đánh dấu chưa đọc"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Xoá sách"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "Xoá sách"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Tạo một giá sách"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Lỗi kết nối"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr ""
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr ""
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "Mật khẩu SMTP"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "Ghi nhớ tôi"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "Quên mật khẩu?"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "Đăng nhập với Magic Link"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 #, fuzzy
 msgid "Log in with SSO"
 msgstr "Đăng nhập với Magic Link"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "Hiển thị Calibre-Web Log: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Calibre-Web Log: "
 msgstr "Hiển thị Calibre-Web Log: "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr ""
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "Hiển thị log truy cập: "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "Tải xuống Calibre-Web Log"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "Tải xuống log truy cập"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "Chia sửa với tất cả"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Select Allowed/Denied Tags"
 msgstr "Chỉnh sửa những tags đươc cho phép"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "Thêm cho phép/từ chối giá trị cột tuỳ biến"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 #, fuzzy
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr "Thêm cho phép/từ chối giá trị cột tuỳ biến"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "Nhập Tag"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "Chọn file location"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "kiểu"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "tên"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "kích thước"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "Thư mục cha"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "Ok"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Calibre-Web test e-mail"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "trình đọc epub"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "Đánh giá"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 #, fuzzy
 msgid "Black"
 msgstr "Quay lại"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr ""
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "Trang tiếp theo"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr ""
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 #, fuzzy
 msgid "Default"
 msgstr "Xoá"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr ""
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr ""
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 #, fuzzy
 msgid "KaiTi"
 msgstr "Đang chờ"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 #, fuzzy
 msgid "Arial"
 msgstr "Dọc"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 #, fuzzy
 msgid "Spread"
 msgstr "Đọc"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 #, fuzzy
 msgid "Two columns"
 msgstr "Cột đọc không hợp lệ"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 #, fuzzy
 msgid "One column"
 msgstr "Cột đọc không hợp lệ"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr ""
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Trình đọc truyện tranh"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "Phím tắt"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "Trang trước"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "Trang tiếp theo"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page Display"
 msgstr "Trang admin"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr ""
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr ""
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Scale to Height"
 msgstr "Trái sang phải"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr ""
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "Xoay phải"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "Xoay trái"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "Lật ảnh"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page"
 msgstr "Trang admin"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr ""
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Scale"
 msgstr "Ngôn ngữ"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "Tốt nhất"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "Rộng"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "Cao"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr ""
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "Xoay"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "Lật"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "Ngang"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "Dọc"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Direction"
 msgstr "Mô tả"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "Trái sang phải"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "Phải sang trái"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Reset to Top"
 msgstr "Quay về trang chủ"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Remember Position"
 msgstr "Ghi nhớ tôi"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "Thanh cuộn"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "Hiện"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "Trình đọc DJVU"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "Trình đọc PDF"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "trình đọc txt"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "Đăng ký tải khoản mới"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "Chọn tên người dùng"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "Địa chỉ email của bạn"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "Magic Link - Xác thực thiết bị mới"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "Trên thiết bị khác, đăng nhập và thăm quan:"
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "Một khi xác nhận, bạn sẽ tự động đăng nhập trên thiết bị này."
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "Link xác nhận này sẽ hết hạn trong 10 phút."
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr ""
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "Không tìm thấy kết quả"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "Từ khoá tìm kiếm:"
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "Kết quả cho:"
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "Ngày phát hành từ"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "Ngày phát hành tới"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr ""
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr ""
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Exclude Series"
 msgstr "Nhập tên series"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Exclude Shelves"
 msgstr "Giá sách"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 #, fuzzy
 msgid "Exclude Languages"
 msgstr "Nhập ngôn ngữ"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr ""
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr ""
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "Đánh giá cao hơn"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "Đánh giá thấp hơn"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "Từ:"
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "Tới:"
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "Xoá giá sách này"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "Chỉnh sửa thông tin giá sách"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "Sách ẩn"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "Sắp xếp sách bằng tay"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "Khoá thay đổi thứ tự"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "Mở thay đổi thứ tự"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "Gộp những sách đã chọn"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "Tài khoản"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "Không tìm thấy token"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "Xoá giá sách này"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "Thêm vào giá sách"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "Tìm kiếm thư viện"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "Tìm kiếm thư viện"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "Chia sửa với tất cả"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "Đồng bộ giá sách này với thiết bị Kobo"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "Không tìm thấy user"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "Sách ẩn"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "Thống kê thư viện"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "Sách trong thư viện"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "Các tác giả trong thư viện"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "Các thể loại trong thư viện"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "Các series trong thư viện"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "Thống kê hệ thống"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 #, fuzzy
 msgid "Program"
 msgstr "Tiến độ"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "Phiên bản đã cài đặt"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "Thời gian chạy"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Actions"
 msgstr "Đánh giá"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "Xoay"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
 msgstr ""
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "{} người dung đã đươc xoá thành công"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Calibre-Web test e-mail"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "Địa chỉ email của bạn"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "Thiết lập"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "Reset mật khẩu người dùng"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "Thiết lập"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "Kindle"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "Nhập ngôn ngữ"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "Ngôn ngữ của sách"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "Ngôn ngữ sách không hợp lệ"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "Thiết lập OAuth"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "Link"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "Unlink"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Token đồng bộ Kobo"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "Tạo/xem"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "Ép đồng bộ tất cả với Kobo"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "Đồng bộ sách trên những giá được chọn với Kobo"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "Đồng bộ sách trên những giá được chọn với Kobo"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "Thiết lập OAuth"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Thêm cho phép/từ chối giá trị cột tuỳ biến"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Magic Shelves Order"
 msgstr "Đồng bộ những giá sách đã chọn với Kobo"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "Sách mới được thêm gần đây"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "Chỉnh sửa giá sách công khai"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "Xoá người dùng"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -11962,158 +11776,158 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "Đổi mật khẩu"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "Đổi mật khẩu"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "Tạo/xem"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr ""
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "Chọn..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "Bỏ chọn"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "Chỉnh sửa người dùng"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "Nhập tên người dùng"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Email"
 msgstr "Test e-mail"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email"
 msgstr "Kindle"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email"
 msgstr "Test e-mail"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "Kindle"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "Test e-mail"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "Ngôn ngữ"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "Những ngôn ngữ hiển thị cho sách"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "Chỉnh sửa những tags đươc cho phép"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "Tags được cho phép"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "Chỉnh sửa những tags bị từ chối"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "Tags bị từ chối"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "Chỉnh sửa những giá trị cột được cho phép"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "Giá trị cột được cho phép"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "Chỉnh sửa những cột giá trị bị từ chối"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "Những cột giá trị bị từ chối"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "Đổi mật khẩu"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "Chỉnh sửa giá sách công khai"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "Đồng bộ những giá sách đã chọn với Kobo"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "Đồng bộ những giá sách đã chọn với Kobo"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Read/Unread Section"
 msgstr "Hiển thị đã đọc và chưa đọc"

--- a/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
+++ b/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
@@ -19,42 +19,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "统计"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr "Calibre 数据库不可用。请重新配置书库路径。"
 
-#: cps/admin.py:208
+#: cps/admin.py
 msgid "Server restarted, please reload page."
 msgstr "服务器已重启，请刷新页面"
 
-#: cps/admin.py:210
+#: cps/admin.py
 msgid "Performing Server shutdown, please close window."
 msgstr "正在关闭服务器，请关闭窗口"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "数据库重新连接成功"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "未知命令"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr "成功！书籍已排队进行元数据备份，请检查任务列表以获取结果"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
@@ -62,597 +62,583 @@ msgstr ""
 "错误：没有可用的 Hardcover 令牌。请设置 HARDCOVER_TOKEN 环境变量或在基本配置"
 "中配置。"
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr "成功！Hardcover 自动获取任务已开始。请检查任务面板查看进度。"
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr "启动 Hardcover 自动获取任务出错：%(error)s"
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr "审查 Hardcover 匹配"
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr "加载审查队列出错：%(error)s"
 
-#: cps/admin.py:414
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover ID applied successfully"
 msgstr "成功删除 {} 个用户"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr "匹配 %(action)s"
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr "没有待拒绝的匹配"
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr "已拒绝 %(count)s 个匹配"
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr "已开始为 {} 本书籍刷新缩略图缓存。这可能需要几分钟。"
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr "未找到带有封面的书籍进行处理。"
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr "启动缩略图刷新失败：{}"
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "管理页"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "Hardcover API token"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "基本配置"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "界面配置"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr "自定义列号：%(column)d 在 Calibre 数据库中不存在"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "管理用户"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "全部"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "找不到用户"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "成功删除 {} 个用户"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "显示全部"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "格式错误的请求"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "访客名称无法更改"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "游客无法拥有此角色"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr "没有其余管理员账户，无法删除管理员角色"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "值必须为 true 或 false"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "无效角色"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "游客无法查看此页面"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "无效页面"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr "无法设置游客的本地化，该项设置的值将自动检测"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "无可用本地化"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "无有效书籍语言"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "参数未找到"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "设置数据库不可写"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "无效的阅读栏目"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "无效的限制栏目"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "您确定删除 Kobo 令牌吗？"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "您确定要删除此域吗？"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "您确定要删除此用户吗？"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "您确定要删除此书架吗？"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr "您确定要修改选定用户的本地化设置吗？"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr "您确定要修改选定用户的可见书籍语言吗？"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr "您确定要修改选定用户的选定角色吗？"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
 msgstr "您确定要修改选定用户的选定限制吗？"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
 msgstr "您确定要修改选定用户的选定可视化限制吗？"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr "您确定要更改所选用户的书架同步行为吗？"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
 msgstr "您确定要更改所选用户的书架同步行为吗？"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "您确定要更改 Calibre 库位置吗？"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "拒绝"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "允许"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "{} 同步项目被删除"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, fuzzy, python-brace-format
 msgid "Book {} not found"
 msgstr "找不到令牌"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "标签未找到"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "无效的动作"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json 未为 Web 应用程序配置"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "日志文件路径无效，请输入正确的路径"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "访问日志路径无效，请输入正确的路径"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr "请输入 LDAP 主机、端口、DN 和用户对象标识符"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "请输入一个 LDAP 服务账号和密码 "
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "请输入一个 LDAP 服务账号"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP 组对象过滤器需要一个具有“%s”格式标识符"
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "LDAP 组对象过滤器的括号不匹配"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP 用户对象过滤器需要一个具有“%s”格式标识符"
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "LDAP 用户对象过滤器的括号不匹配"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP 成员用户过滤器需要有一个“%s”格式标识符"
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "LDAP 成员用户过滤器中有不匹配的括号"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
 msgstr "LDAP CA证书、证书或密钥位置无效，请输入正确的路径"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "添加新用户"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "编辑邮件服务器设置"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "Gmail 账户验证成功"
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "数据库错误：%(error)s"
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
 msgstr "发送给 %(email)s 的测试邮件已加入队列。请检查任务结果"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "发送测试邮件时出错：%(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "请先配置您的邮箱地址..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "邮件服务器设置已更新"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 #, fuzzy
 msgid "Email Your Users"
 msgstr "管理用户"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "请先配置 SMTP 邮箱设置..."
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 #, fuzzy
 msgid "Please set an email address on your own account first..."
 msgstr "请先配置您的邮箱地址..."
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "新密码已发送到您的邮箱"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
 msgstr "发送给 %(email)s 的测试邮件已加入队列。请检查任务结果"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
 "delivery."
 msgstr "发送给 %(email)s 的测试邮件已加入队列。请检查任务结果"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr "编辑计划任务设置"
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr "指定任务的开始时间无效"
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr "指定任务的持续时间无效"
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr "已更新计划任务设置"
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "发生一个未知错误，请稍后再试"
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "标题"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "编辑用户 %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "用户 %(user)s 的密码已重置"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "请先配置 SMTP 邮箱设置..."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "日志文件查看器"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "正在请求更新包"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "正在下载更新包"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "正在解压更新包"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "正在替换文件"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "数据库连接已关闭"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "正在停止服务器"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "更新完成，请点击确定并刷新页面"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "更新失败："
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "HTTP 错误"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "连接错误"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "建立连接超时"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "一般错误"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr "更新文件无法保存在临时目录中"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "更新期间无法替换文件"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "未能获得任何 LDAP 用户"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "未能创建任何 LDAP 用户"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "错误：%(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "错误：在 LDAP 服务器的响应中没有返回用户"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "数据库中没有找到任何 LDAP 用户"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} 用户被成功导入"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr "书籍路径无效"
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "数据库路径无效，请输入正确的路径"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "数据库不可写入"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "密钥文件路径无效，请输入正确的路径"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr "证书文件路径无效，请输入正确的路径"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr "在未启用反向代理身份验证的情况下，无法启用自动创建用户"
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr "自动创建用户需要有效的反向代理标头名称"
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
@@ -660,1130 +646,1116 @@ msgstr ""
 "OAuth 重定向主机格式无效。请包含带有协议的完整 URL（例如，https://your-"
 "domain.com）"
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 "OAuth 重定向主机不应包含路径。仅使用基本 URL（例如，https://your-domain.com）"
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr "密码长度必须在1到40之间"
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "数据库设置已更新"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "数据库配置"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "请填写所有字段！"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "邮箱不在有效域中"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "添加新用户"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "用户“%(user)s”已创建"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "使用此邮箱或用户名的账号已经存在"
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "用户“%(nick)s”已删除"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "无法删除游客用户"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "管理员账户不存在，无法删除用户"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr "电子邮件地址不能为空，并且必须是有效的电子邮件"
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "用户“%(nick)s”已更新"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr "连接成功！OIDC 发现端点可访问。%(endpoints)s"
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr "连接失败：未找到 OIDC 发现端点 (404)。请检查基本 URL 是否正确。"
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr "连接失败：服务器返回状态码 %(code)s"
 
-#: cps/admin.py:3276
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr "连接失败：无法连接到服务器。"
 
-#: cps/admin.py:3278
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr "连接失败：请求超时。"
 
-#: cps/admin.py:3280
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr "连接失败：响应中的 JSON 无效。"
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Connection failed: %(error)s"
 msgstr "连接错误"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr "元数据缺少必填字段：%(fields)s"
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr "元数据 URL 有效！找到 %(count)s 个端点。"
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "无可用发布信息"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr " 注意：未找到用户信息端点 - 这可能会导致身份验证问题。"
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr "未找到元数据 URL (404)。请检查 URL 是否正确。"
 
-#: cps/admin.py:3333
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr "连接失败：无法连接到服务器。"
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr "连接失败：请求超时。"
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr "连接失败：响应中的 JSON 无效。"
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "发生一个未知错误，请稍后再试"
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "连接错误"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr "还原失败：未配置 Calibre 书库路径。"
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr "还原失败：在 %(path)s 未找到 metadata.db"
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr "还原失败：在 %(path)s 未找到 app.db"
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "连接错误"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr "还原已完成，但清理 app.db 失败。详情请查看日志。"
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr "还原完成。备份和还原日志已保存到 %(dir)s。所有关联书籍的数据均已重置。"
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 #, fuzzy
 msgid "No file uploaded."
 msgstr "文件 %(file)s 已上传"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr "捷克语"
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr "德语"
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr "希腊语"
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr "西班牙语"
 
-#: cps/constants.py:265
+#: cps/constants.py
 #, fuzzy
 msgid "Finnish"
 msgstr "已完成"
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr "法语"
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr "加利西亚语"
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr "匈牙利语"
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr "印尼语"
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr "意大利语"
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr "日语"
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr "高棉语"
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr "韩语"
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr "荷兰语"
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr "挪威语"
 
-#: cps/constants.py:276
+#: cps/constants.py
 #, fuzzy
 msgid "Polish"
 msgstr "出版社"
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr "葡萄牙语"
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr "葡萄牙语（巴西）"
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr "俄语"
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr "斯洛伐克语"
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr "斯洛文尼亚语"
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr "瑞典语"
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr "土耳其语"
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr "乌克兰语"
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr "越南语"
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr "简体中文"
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr "繁体中文"
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "未安装"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "缺少执行权限"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, fuzzy, python-format
 msgid "Change cover — %(title)s"
 msgstr "交换作者和标题"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "连接错误"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Could not render the e-reader preview."
 msgstr "找不到指定的目录"
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr "在 v5.0.0 之前暂时禁用主题切换"
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr "图书库刷新 🔄 正在检查是否有可能被遗漏的书籍，请稍候..."
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr "重复扫描的 cron 表达式无效。更改未保存。"
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr "时间戳"
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Book ID"
 msgstr "书籍 ID"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "书名"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Book Author"
 msgstr "作者"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr "触发类型"
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "文件路径"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filename"
 msgstr "文件名"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr "手动？"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr "未修复"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr "原始文件已备份？"
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr "已应用修复"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr "原始格式"
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "上传格式"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "未知"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr "✅ 所有监控服务均按预期运行！ 👍"
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr "🔴 导入服务正在运行，但元数据更改检测器未运行"
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr "🔴 元数据更改检测器正在运行，但导入服务未运行"
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr "⛔ 导入服务和元数据更改检测器均未运行"
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr "发生错误"
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "无效角色"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "合并选中的书籍"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "硬盘上找不到 %(format)s 格式"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB Fixer started for selected book."
 msgstr "合并选中的书籍"
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr "您必须是管理员才能访问此页面。"
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr "用户名和图像数据均为必填项。"
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid image data format."
 msgstr "无效的邮箱格式"
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Profile picture updated successfully."
 msgstr "成功删除 {} 个用户"
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "无"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "删除书籍"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "删除书籍"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "删除书籍"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "重复书籍"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr "重复扫描已完成（回退模式）"
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 #, fuzzy
 msgid "Invalid resolution strategy"
 msgstr "无效角色"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr "导入文件夹不可写。请检查您的 /cwa-book-ingest 卷权限。"
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr "格式上传缺少或无效的书籍 ID"
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr "无法上传格式：书库中已不存在该书籍"
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "上传完成，正在处理，请稍候..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 #, fuzzy
 msgid "Failed to queue upload for processing"
 msgstr "创建封面路径失败"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "转换的源格式或目的格式缺失"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "书籍已经被成功加入 %(book_format)s 格式转换队列"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "转换此书籍时出现错误： %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 #, fuzzy
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "不能上传文件扩展名为“%(ext)s”的文件到此服务器"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr "不能上传文件扩展名为“%(ext)s”的文件到此服务器"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "要上传的文件必须具有扩展名"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr "糟糕！选择书名无法打开。文件不存在或者文件不可访问"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr "用户没有权限上传封面"
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr "标识符不区分大小写，覆盖旧标识符"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "'%(langname)s' 不是一种有效语言"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "已成功更新元数据"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr "编辑书籍时出错: {}"
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "未知"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
 msgstr "上传的书籍可能已经存在，建议修改后重新上传： "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "文件 %(filename)s 无法保存到临时目录"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "移动封面文件失败 %(file)s：%(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "书籍的此格式副本已成功删除"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "书籍已成功删除"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr "您没有删除书籍的权限"
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "编辑元数据"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "%(seriesindex)s 不是一个有效的数值，忽略"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr "用户没有权限上传其他文件格式"
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "创建路径 %(path)s 失败 (权限不足)"
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "保存文件 %(file)s 失败"
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "已添加 %(ext)s 格式到 %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 #, fuzzy
 msgid "Book not found"
 msgstr "找不到令牌"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "硬盘上找不到 %(format)s 格式"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
 msgstr "Google Drive 设置未完成，请尝试停用并再次激活 Google 云端硬盘"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
 msgstr "回调域名尚未被校验，请在 Google 开发者控制台按步骤校验域名"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "找不到 ID 为 %(book)d 的书籍的 %(format)s 格式"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "Google Drive %(fn)s 上找不到 %(format)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "找不到 %(format)s：%(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "发送到电子阅读器"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "找不到 ID 为 %(book)d 的书籍的 %(format)s 格式"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "找不到 ID 为 %(book)d 的书籍的 %(format)s 格式"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 msgid "Test Email"
 msgstr "测试邮件"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "用户注册电子邮件：%(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "转换 %(orig)s 到 %(format)s 并发送到电子阅读器"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, python-format
 msgid "Send %(format)s to eReader"
 msgstr "发送 %(format)s 到电子阅读器"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s 发送到电子阅读器"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "无法读取请求的文件。可能有错误的权限设置？"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr "阅读状态无法设置: {}"
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
 msgstr "删除书的文件夹 %(id)s 失败，路径有子文件夹：%(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "删除书籍 %(id)s 失败：%(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
 "%(path)s"
 msgstr "仅从数据库中删除书籍 %(id)s，数据库中的书籍路径无效： %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr "将作者从“%(src)s”改为“%(dest)s”时失败，出错信息：%(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Google Drive 上找不到文件 %(file)s"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr "将标题从“%(src)s”改为“%(dest)s”时失败，出错信息：%(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Google Drive 上找不到书籍路径 %(path)s"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr "已存在使用此邮箱的账户"
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "此用户名已被使用"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr "无效的邮箱格式"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr "密码不符合密码验证规则"
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr "上传封面所需的 Python 模块 'advocate' 未安装"
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "下载封面时出错"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr "封面图片超过最大尺寸限制 %(size)s MB"
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr "封面文件不是有效的图片文件，或者无法存储它"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "封面格式出错"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
 msgstr "您没有访问本地主机或本地网络进行封面上传"
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "创建封面路径失败"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "封面文件只支持 jpg、jpeg、png、webp、bmp 文件"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr "封面文件内容无效"
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "仅将 jpg、jpeg 文件作为封面文件"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr "封面"
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "找不到 UnRar 执行文件"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr "执行 UnRar 时出错"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr "找不到指定的目录"
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr "请指定一个目录，而不是文件"
 
-#: cps/helper.py:2125
+#: cps/helper.py
 #, fuzzy
 msgid "Calibre binaries not viable"
 msgstr "数据库不可写入"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr "缺少 Calibre 执行文件: %(missing)s"
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "缺少执行权限"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing Calibre"
 msgstr "执行 UnRar 时出错"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr "将所有书籍加入元数据备份队列"
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Kobo 设置"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "使用 %(provider)s 注册"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
@@ -1792,25 +1764,25 @@ msgstr ""
 "登录失败：OAuth 令牌验证错误。这可能是由于作用域配置不匹配造成的。请检查您的 "
 "OAuth 作用域配置或联系您的管理员。"
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr "登录失败：OAuth 令牌已过期。请尝试重新登录。"
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr "登录失败：无法连接到用户信息端点。"
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "登录失败：OAuth 提供者返回了无效的用户资料。"
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1820,35 +1792,35 @@ msgstr ""
 "登录失败：OAuth 提供者响应中缺少必需的字段：%(fields)s。请检查您的 OAuth 配置"
 "或联系您的管理员。"
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr "链接 OAuth 帐户失败。请重试。"
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr "OAuth 错误：提供者返回了无效的用户信息。请重试。"
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "您现在已以“%(nickname)s”身份登录"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "链接到 %(oauth)s 成功"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1858,62 +1830,62 @@ msgstr ""
 "登录失败：没有用户帐户链接到您的 %(provider)s 帐户。请联系您的管理员以创建帐"
 "户或链接您现有的帐户。"
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr "OAuth 身份验证失败。请重试或联系管理员。"
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr "邮件服务未配置，请联系网站管理员！"
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "取消链接到 %(oauth)s 成功"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "取消链接到 %(oauth)s 失败"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "未连接到 %(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "使用 Github 登录失败"
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "从 Github 获取用户信息失败"
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "使用 Google 登录失败"
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "从 Google 获取用户信息失败"
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "Failed to log in with Generic OAuth."
 msgstr "使用 Github 登录失败"
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr "OAuth 身份验证失败：令牌验证错误。请重试。"
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr "由于意外错误，OAuth 身份验证失败。请联系管理员。"
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
@@ -1922,5117 +1894,5017 @@ msgstr ""
 "OAuth 错误：重定向 URI 无效。如果您反复遇到此错误，请在“管理” > “基本配置” > "
 "“OAuth”中配置“OAuth 重定向主机”设置。"
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "GitHub Oauth 错误，请重试"
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "GitHub Oauth 错误: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Google Oauth 错误，请重试"
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Google Oauth 错误: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, fuzzy, python-brace-format
 msgid "OAuth error: {}"
 msgstr "GitHub Oauth 错误: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "字母排序书籍"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "按字母排序的书籍"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "热门书籍"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "基于下载数的热门书籍"
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "最高评分书籍"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "基于评分的热门书籍"
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "已下载书籍"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "最新书籍"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "随机书籍"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "显示随机书籍"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "已读书籍"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "当前版本"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "未读书籍"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "作者"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "书籍按作者排序"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "出版社"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "书籍按出版社排序"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "分类"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "书籍按分类排序"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "丛书"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "书籍按丛书排序"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "语言"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "书籍按语言排序"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "评分"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "书籍按评分排序"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "文件格式"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "书籍按文件格式排序"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "书架列表"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "书架上的书"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "同步所选书架到 Kobo"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "书架上的书"
 
-#: cps/opds.py:317
+#: cps/opds.py
 #, fuzzy
 msgid "description"
 msgstr "简介"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} 星"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "搜索"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "登录"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "找不到令牌"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "令牌已过期"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "成功！请返回您的设备"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "书籍"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "显示最近查看的书籍"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "显示热门书籍"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "已下载书籍"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "显示下载过的书籍"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "显示最高评分书籍"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 msgid "Show Read and Unread"
 msgstr "显示已读或未读状态"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "显示未读"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "发现"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Category Section"
 msgstr "显示分类栏目"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Series Section"
 msgstr "显示丛书栏目"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Author Section"
 msgstr "显示作者栏目"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Publisher Section"
 msgstr "显示出版社栏目"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Language Section"
 msgstr "显示语言栏目"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Ratings Section"
 msgstr "显示评分栏目"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show File Formats Section"
 msgstr "显示文件格式栏目"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "归档书籍"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Archived Books"
 msgstr "显示归档书籍"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "书籍列表"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "显示书籍列表"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr "重复书籍"
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "显示最高评分书籍"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "出版时间晚于 "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "出版时间早于 "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "评分 <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "评分 >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, fuzzy, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "阅读状态 = %(status)s"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr "搜索自定义栏目时出错，请重启 Calibre-Web"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "高级搜索"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "指定的书架无效"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "对不起，您没有添加书籍到这个书架的权限"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "此书籍已经是书架 %(shelfname)s 的一部分"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr "%(book_id)s 是无效的书籍 ID，无法添加到书架"
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "此书籍已被添加到书架：%(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr "您没有向书架添加书籍的权限"
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "书籍已经在书架 %(name)s 中了"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "书籍已经被添加到书架 %(sname)s 中"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "无法添加书籍到书架：%(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "指定的书架无效"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "无法添加书籍到书架：%(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "书籍已经在书架 %(name)s 中了"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "书籍已经被添加到书架 %(sname)s 中"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "此书已从书架 %(sname)s 中删除"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr "抱歉，您没有从这个书架删除书籍的权限"
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "创建书架"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "对不起，您没有编辑这个书架的权限"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "编辑书架"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr "删除书架时出错"
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "书架已成功删除"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "修改书架 %(name)s 顺序"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr "抱歉，您没有创建公开书架的权限"
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "书架 %(title)s 已创建"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "书架 %(title)s 已修改"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "发生错误"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "公共书架：%(title)s 已经存在已经存在"
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "私有书架：%(title)s 已经存在已经存在"
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "书架：%(name)s"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "打开书架出错。书架不存在或不可访问"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "排除书架"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "匿名"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "无验证"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS 协议"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL 协议"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr "添加标签"
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "确认"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "没有"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "阅读状态"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "主题"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "浅色"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "深色"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr "棕色"
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "添加到书架"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "作者"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "按条件浏览"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "关闭"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "删除数据"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "合并"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "出版社"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "已读"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "标题"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "上传书籍"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "账号"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "管理权限"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "出版日期"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "源"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "关于"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr "任何"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "归档"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "取消"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr "转换"
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr "添加日期"
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "简介"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr "忽略"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "下载书籍"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "编辑书籍"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "邮箱地址"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "启用 Kobo 同步"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "加密"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "隐藏"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "书号"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "语言"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr "最后修改时间"
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "密码"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "端口"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "任务进度"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "评分"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS 协议"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS 协议"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "保存"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "选择"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr "发送"
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "任务状态"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr "在 Ko-fi 上支持我们 →"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "标签"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "任务信息"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "任务列表"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "用户名称"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "用户名"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "查看书籍"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "等待中"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "失败"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "已开始"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "已完成"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "已结束"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "已取消"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "未知状态"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "读取更新信息时出现异常数据"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr "无可用更新。您已经安装了最新版本"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
 msgstr "有新的更新。单击下面的按钮以更新到最新版本"
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "无法获取更新信息"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr "点击下面按钮更新到最新稳定版本"
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
 "%(version)s"
 msgstr "有新的更新。单击下面的按钮以更新到版本: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "无可用发布信息"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "发现 (随机书籍)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "热门书籍（最多下载）"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "%(user)s 下载过的书籍"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "作者：%(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "出版社：%(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "丛书：%(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr "评分：无"
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "评分：%(rating)s 星"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "文件格式：%(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "分类：%(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "语言：%(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 #, fuzzy
 msgid "Favorite Books"
 msgstr "热门书籍"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 #, fuzzy
 msgid "Hidden Books"
 msgstr "隐藏书籍"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "删除书架时出错"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr "魔法书架&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr "未提供规则"
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "无效的邮箱格式"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr "处理规则时出错"
 
-#: cps/web.py:1426
+#: cps/web.py
 #, fuzzy
 msgid "Invalid request"
 msgstr "无效角色"
 
-#: cps/web.py:1470
+#: cps/web.py
 #, fuzzy
 msgid "Name and rules are required"
 msgstr "用户名和图像数据均为必填项。"
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr "书架名称过长（最多 100 个字符）"
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 #, fuzzy
 msgid "Error creating shelf"
 msgstr "删除书架时出错"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "创建书架"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr "拒绝更改公开状态的权限"
 
-#: cps/web.py:1587
+#: cps/web.py
 #, fuzzy
 msgid "Shelf name is required"
 msgstr "此栏必须填写"
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "删除书架时出错"
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "编辑书架"
 
-#: cps/web.py:1668
+#: cps/web.py
 #, fuzzy
 msgid "Shelf not found"
 msgstr "找不到用户"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr "没有权限"
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "成功删除 {} 个用户"
 
-#: cps/web.py:1710
+#: cps/web.py
 #, fuzzy
 msgid "Error duplicating shelf"
 msgstr "删除书架时出错"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr "系统书架无法删除。您可以在用户资料设置中隐藏它们。"
 
-#: cps/web.py:1755
+#: cps/web.py
 #, fuzzy
 msgid "Error deleting shelf"
 msgstr "删除书架时出错"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr "您无法隐藏自己的书架。如果不想要它们，请直接删除。"
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr "书架已被隐藏"
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "删除书架时出错"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr "书架未被隐藏"
 
-#: cps/web.py:1818
+#: cps/web.py
 #, fuzzy
 msgid "Error unhiding shelf"
 msgstr "删除书架时出错"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "下载次数"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "文件格式列表"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr "请先配置 SMTP 邮箱设置..."
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr "请先配置您的 Kindle 邮箱"
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "书籍已经成功加入 %(eReadermail)s 的发送队列"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "糟糕！发送这本书籍的时候出现错误：%(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr "没有选择电子邮箱地址"
 
-#: cps/web.py:2473
+#: cps/web.py
 #, fuzzy
 msgid "Additional email addresses are disabled for your account."
 msgstr "选择邮箱地址:"
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "书籍已经成功加入 %(eReadermail)s 的发送队列"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr "请等待一分钟注册下一个用户"
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "注册"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 #, fuzzy
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr "邮件服务未配置，请联系网站管理员！"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr "邮件服务未配置，请联系网站管理员！"
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "您的电子邮件不允许注册"
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "确认邮件已经发送到您的邮箱"
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
 msgstr "Calibre-Web 实例未配置，请联系您的管理员！"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "邮件服务未配置，请联系网站管理员！"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr "无法激活 LDAP 认证"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr "标准登录已禁用。"
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr "下次登录前请等待一分钟"
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr "用户名不能为空"
 
-#: cps/web.py:2756
+#: cps/web.py
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "您现在已以“%(nickname)s”身份登录"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "您现在已以“%(nickname)s”身份登录"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
 msgstr "Calibre-Web 实例未配置，请联系您的管理员！"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr "身份验证成功，但未找到本地帐户。请联系您的管理员以创建帐户。"
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
 "known"
 msgstr "后备登录“%(nickname)s”：无法访问 LDAP 服务器，或用户未知"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr "无法登录：%(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 msgid "Wrong Username or Password"
 msgstr "用户名或密码错误"
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr "新密码已发送到您的邮箱"
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr "发生一个未知错误，请稍后再试"
 
-#: cps/web.py:2838
+#: cps/web.py
 msgid "Please enter valid username to reset password"
 msgstr "请输入有效的用户名进行密码重置"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "您现在已以“%(nickname)s”身份登录"
 
-#: cps/web.py:3158
+#: cps/web.py
 msgid "Success! Profile Updated"
 msgstr "资料已更新"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "使用此邮箱的账号已经存在"
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 #, fuzzy
 msgid "Invalid book ID."
 msgstr "无效角色"
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr "KOReader 同步插件"
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "找不到包含 OAuth 信息的有效 gmail.json 文件"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Preparing to send to eReader..."
 msgstr "%(book)s 发送到电子阅读器"
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Sending to eReader..."
 msgstr "发送到电子阅读器"
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-send completed successfully"
 msgstr "成功删除 {} 个用户"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 #, fuzzy
 msgid "Auto-Send"
 msgstr "发送"
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr "删除临时文件夹内容"
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s 发送到电子阅读器"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "Calibre 电子书转换器 %(tool)s 没有发现"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "硬盘上找不到 %(format)s 格式"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "发生未知错误，书籍转换失败"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Kepubify 转换失败：%(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr "找不到转换后的文件或文件夹 %(folder)s 中有多个文件"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre 运行失败，错误信息：%(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "电子书转换器失败： %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "正在重新连接到 Calibre 数据库"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr "清理已归档书籍的引用"
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "重复书籍"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "选择重复项"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "正在解压更新包"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "重复书籍"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr "重复扫描完成：%(count)s 个分组"
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr "重复扫描完成：%(count)s 个新分组"
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr "重复扫描完成：%(count)s 个分组已自动解决"
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 #, fuzzy
 msgid "Hardcover Sync"
 msgstr "启用 Kobo 同步"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "电子邮件"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr "正在备份元数据"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr "转换书库 – 完整运行"
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 #, fuzzy
 msgid "Convert Library"
 msgstr "在书库"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr "EPUB 修复程序 – 完整运行"
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr "EPUB 修复程序"
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr "生成了 %(count)s 个封面缩略图"
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr "封面缩略图"
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, fuzzy, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr "生成了 %(count)s 个丛书缩略图"
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr "正在清理封面缩略图缓存"
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "书架上的书"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "修改密码"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "创建书架"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Display settings"
 msgstr "安全设置"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Cover Settings"
 msgstr "设置"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "选择一个选项"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 #, fuzzy
 msgid "Add to Shelf"
 msgstr "添加到书架"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(公共)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "下载次数"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "下载次数"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "按图书日期排序，最新优先"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "按图书日期排序，最旧优先"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author A → Z"
 msgstr "作者"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Author Z → A"
 msgstr "作者"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, newest first"
 msgstr "出版时间早于 "
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Published, oldest first"
 msgstr "出版时间早于 "
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "按图书日期排序，最新优先"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "按图书日期排序，最旧优先"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr "用户&nbsp;&nbsp;👤"
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr "接收书籍的电子阅读器邮箱地址"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "发送到电子阅读器"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "查看书籍"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "公共书架"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr "管理用户头像"
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "导入 LDAP 用户"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "SMTP 邮件服务器设置"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "SMTP 主机名"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "SMTP 端口"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "SMTP 用户名"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "发件人邮箱"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr "电子邮件服务"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "使用 Oauth2 的 Gmail"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr "配置&nbsp;&nbsp;⚙️"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Calibre 数据库路径"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "日志级别"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "扩展端口"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "每页书籍数"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "上传"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "匿名浏览"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "开放注册"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "魔法链接远程登录"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "反向代理登录"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "反向代理头部名称"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "编辑基本配置"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "编辑界面配置"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "编辑 Calibre 数据库配置"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr "计划任务"
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr "任务开始运行的时间"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr "最长任务持续时间"
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr "计划的缩略图刷新"
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr "生成丛书封面缩略图"
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "重新连接到 Calibre 库"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr "生成元数据备份文件"
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr "刷新封面缩略图缓存"
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Setup KOReader Sync"
 msgstr "epub 阅读器"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Run Hardcover Auto-Fetch"
 msgstr "Hardcover API token"
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "管理"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "下载 Debug 包"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "查看日志文件"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "重启"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "停止"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr "版本信息"
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "版本"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "详情"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Update available"
 msgstr "更新失败："
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 #, fuzzy
 msgid "Update now"
 msgstr "更新通道"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "当前版本"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "检查更新"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "执行更新"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "您确定要重启吗？"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "确定"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "您确定要关闭吗？"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "正在更新，请不要刷新页面"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7040,426 +6912,404 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "本书籍在此书库中"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "正在上传..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Import failed."
 msgstr "更新失败："
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "Network error."
 msgstr "连接错误"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr "注意："
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "丛书：%(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "通过"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "在书库"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "减少"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "更多"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "删除书籍"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "删除格式:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "书籍格式转换:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "转换从："
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr "选择一个选项"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "转换到："
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "转换书籍"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "错误"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "上传格式"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "丛书编号"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "出版日期"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "书号类型"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "书号编号"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "移除"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "添加书号"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr "从 URL 获取封面（JPEG - 图片将下载并存储在数据库中）"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "从本地磁盘上传封面"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "启用 Kobo 同步"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr "将批注列入黑名单以禁止同步至 Hardcover"
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr "将阅读进度列入黑名单以禁止同步至 Hardcover"
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "查看保存书籍"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "获取元数据"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "关键字"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr " 搜索关键字 "
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr "所选元数据字段已应用到编辑表单中。"
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "加载中..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "搜索错误！"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "无搜索结果！请尝试另一个关键字"
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "此栏必须填写"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 #, fuzzy
 msgid " Exchange author & title"
 msgstr "交换作者和标题"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select all"
 msgstr "全选"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr "清除所有"
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Update Title Sort automatically  "
 msgstr "自动更新书名排序"
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "自动更新作者排序"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "输入书名"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "输入书名排序"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "书名排序"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "输入作者排序"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "作者排序"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "输入作者"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "输入分类"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "输入丛书"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "输入语言"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "出版日期"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "输入出版社"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr "输入简介"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Comments"
 msgstr "简介"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Archived?"
 msgstr "归档"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Read?"
 msgstr "已读"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr "输入"
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "您真的确认？"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "这本书籍将被合并："
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "合并到这本书籍："
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr "以下书籍将被删除："
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr "以下书籍将被归档："
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr "以下书籍将被取消归档："
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr "以下书籍将被标为已读："
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr "以下书籍将被标为未读："
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "编辑元数据"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr "编辑您想要更改的字段。空白字段将被忽略："
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
@@ -7467,189 +7317,188 @@ msgstr ""
 "作者、标签/类别、语言和出版社均支持多个值。请使用逗号分隔的值（例如：“Name1, "
 "Name2”）。"
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Select a Shelf"
 msgstr "创建书架"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr "请选择一个书架以添加所选书籍："
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr "-- 选择一个书架 --"
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "添加"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr "邮件服务未配置，请联系网站管理员！"
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 #, fuzzy
 msgid "Message"
 msgstr "合并"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "新密码已发送到您的邮箱"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "发送到电子阅读器"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "后退"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Calibre 数据库路径"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7665,13 +7514,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7682,7 +7531,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7697,11 +7546,11 @@ msgstr ""
 "books</code>，并在选中<b>将书籍文件与书库分离</b>选项后弹出的下方字段中输入 "
 "<code>/books</code>。"
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr "分离书库功能"
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
@@ -7710,32 +7559,32 @@ msgstr ""
 "<b>将书籍文件与书库分离</b> - <code>metadata.db</code> 文件应保留在 <code>/"
 "calibre-library</code> 中，但您的书库文件可以放在任何您想要的地方"
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "是否使用 Google Drive?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "认证 Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Google Drive Calibre 路径"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "元数据监视通道 ID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "撤回"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "重新连接到 Calibre 库"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7749,91 +7598,91 @@ msgstr ""
 "载等），但不会影响用户帐户或设置。<b>在执行任何破坏性操作之前，这两个数据库都"
 "将自动备份在 /config/backup 中。</b>恢复日志将与备份一起保存。"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "您确定要关闭吗？"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "重新连接到 Calibre 库"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr "新数据库路径无效，请输入有效的路径"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "使用标准认证"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "使用 LDAP 认证"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "使用 OAuth 认证"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "服务器配置"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "服务器端口"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL 证书文件路径 (非 SSL 服务器请留空)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL 密钥文件路径 (非 SSL 服务器请留空)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "更新通道"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "稳定版"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "夜间版"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr "可信主机（用逗号分隔）"
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "日志文件配置"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "访问日志路径和名称 (默认为 access.log)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "启用访问日志"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "访问日志路径和名称 (默认为 access.log)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "服务器配置"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr "保存到磁盘时转换标题和作者中的非英文字符"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
@@ -7841,39 +7690,39 @@ msgstr ""
 "在下载/转换/电子邮件时将元数据嵌入电子书文件（需要 Calibre/Kepubify 二进制文"
 "件）"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "启用上传"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr "（请确保用户也有上传权限）"
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "允许上传的文件格式"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "允许匿名浏览"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "启用注册"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "使用邮箱或用户名"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "启用魔法链接远程登录"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7881,155 +7730,155 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "代理未知请求到 Kobo 商店"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "服务器扩展端口 (用于转发的 API 调用的端口)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr "将 Kobo 阅读进度同步到 Hardcover (每个用户需要 API 密钥)"
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "使用 Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Goodreads API Key"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Enable Hardcover Sync"
 msgstr "启用 Kobo 同步"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr "Hardcover API Key"
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "令牌已过期"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Goodreads API Key"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -8037,11 +7886,11 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "允许反向代理认证方式"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
@@ -8050,11 +7899,11 @@ msgstr ""
 "信任反向代理提供的 \"Remote-User\" 头进行身份验证。这是一种身份验证方法，不同"
 "于下方的 HTTPS 安全设置。"
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr "通过 HTTPS 使用"
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
@@ -8062,11 +7911,11 @@ msgstr ""
 "启用安全的 cookie 设置（Secure，SameSite=Lax）。请**仅当**您通过 HTTPS 访问服"
 "务器时才启用此选项，否则您将被锁定。"
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr "从反向代理自动创建用户"
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
@@ -8075,115 +7924,115 @@ msgstr ""
 "当接收到有效的反向代理头时自动创建用户帐户。仅在您的反向代理身份验证已受到妥"
 "善保护时才启用。"
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "登录类型"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr "使用 OAuth (需要 HTTPS)"
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "LDAP 服务器主机名或 IP 地址"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "LDAP 服务器端口"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "LDAP 加密"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr "LDAP CA证书路径 (仅用于客户端证书认证)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr "LDAP 证书路径 (仅用于客户端证书认证)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr "LDAP 密钥文件路径 (仅用于客户端证书认证)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "LDAP 验证方式"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "简单"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "LDAP 管理员用户名"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "LDAP 管理员密码"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "LDAP 专有名称（DN）"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "LDAP 用户对象过滤器"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "LDAP 服务器为 OpenLDAP？"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr "从 LDAP 自动创建用户"
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr "当新用户通过 LDAP 身份验证时自动创建用户帐户。推荐在企业环境中使用。"
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr "用户导入需要以下设置"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "LDAP 组对象过滤器"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "LDAP 组名"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "LDAP 组成员字段"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "LDAP 成员用户过滤器探测"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "自动检测"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "自定义过滤器"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "LDAP 成员用户过滤器"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr "重要："
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
@@ -8191,74 +8040,74 @@ msgstr ""
 "OAuth 身份验证要求此服务器通过 HTTPS 进行访问。如果您使用的是 HTTP，登录将会"
 "失败。"
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr "通用 OAuth 提供商"
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr "OAuth 元数据 URL (用于自动发现)"
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "获取元数据"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr "留空以使用下面的手动配置"
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr "使用手动端点 URL（覆盖自动发现）"
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
 msgstr "选中此项以手动配置单个 OAuth 端点，而不是使用自动发现"
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "手动端点配置"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr "OAuth 基础 URL"
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr "授权端点"
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "令牌端点"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr "用户信息端点"
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "连接错误"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "OAuth 设置"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr "以空格分隔的 OAuth 范围列表"
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr "OAuth 重定向主机"
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
@@ -8267,7 +8116,7 @@ msgstr ""
 "为 OAuth 重定向设置一致的主机名，以防止出现“无效的重定向 URI”错误。包括协议"
 "（https://）。留空以使用自动检测。"
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
@@ -8275,75 +8124,75 @@ msgstr ""
 "需要满足以下条件之一：通过多个主机名访问、位于反向代理之后或遇到“无效的重定"
 "向 URI”错误。"
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Id"
 msgstr "%(provider)s OAuth 客户端 Id"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Secret"
 msgstr "%(provider)s OAuth 客户端 Secret"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "查看配置"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "用户名"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr "JWT 字段以提取用户名"
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "电子邮件服务"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr "JWT 字段以提取电子邮件"
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "OAuth 管理组"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr "OAuth 管理组"
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
@@ -8352,104 +8201,104 @@ msgstr ""
 "授予管理权限的 OAuth 组的名称。留空以禁用基于组的管理，或在“安全设置”中使用全"
 "局设置以获得更多控制。"
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "新用户默认权限设置"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "允许下载书籍"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "允许在线阅读"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "允许上传书籍"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "允许编辑书籍"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "允许删除书籍"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "允许修改密码"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "允许编辑公共书架"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr "登录按钮文本"
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "获取 %(provider)s OAuth 凭证"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "%(provider)s OAuth 客户端 Id"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "%(provider)s OAuth 客户端 Secret"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "扩展程序配置"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Path to Calibre Binaries"
 msgstr "Calibre 电子书转换器路径"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Calibre E-Book Converter Settings"
 msgstr "Calibre 电子书转换器设置"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "KEpubify 电子书转换器路径"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "UnRar 程序路径"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 msgid "Security Settings"
 msgstr "安全设置"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr "禁用标准登录 (用户名/密码)"
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
@@ -8457,11 +8306,11 @@ msgstr ""
 "隐藏标准登录表单。用户必须通过 OAuth 或 LDAP 登录。在启用之前，请确保您有可用"
 "的备用登录方法。"
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr "启用基于 OAuth 组的管理员角色管理"
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8471,338 +8320,333 @@ msgstr ""
 "启用后，管理员权限将根据 OAuth 组成员身份自动授予或撤销。禁用此选项可以在用户"
 "管理面板中手动管理管理员角色，以防止 OAuth 登录覆盖本地角色分配。"
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr "限制失败的登录尝试"
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr "配置限流器后端"
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr "限流器后端选项"
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr "检查上传时文件扩展名是否与文件内容匹配"
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Session protection"
 msgstr "会话保护"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr "基本"
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr "强"
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 msgid "User Password policy"
 msgstr "用户密码策略"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr "最小密码长度"
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr "必须使用数字"
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr "必须使用小写字符"
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr "必须使用大写字符"
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr "必须使用字符（适用于中文/日文/韩文字符）"
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr "必须使用特殊字符"
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "查看配置"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr "在浏览器选项卡和导航栏中显示的标题。"
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr "列表视图中每页显示的书籍数量 (1-200)。"
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "随机书籍显示数量"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr "主页上显示的随机书籍数量 (1-30)。"
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr "主页中书籍作者的最大显示数量（0=不隐藏）"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr "书籍详细信息中显示的最大作者数，超过将截断。设置为 0 以禁用。"
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Theme"
 msgstr "删除数据"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "黑暗主题"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr "新用户和匿名浏览的默认主题。用户可以在其配置文件中选择自己喜欢的主题。"
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "可忽略的自定义栏目（正则表达式）"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr "隐藏自定义列不在 UI 中显示的正则表达式模式。"
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "选择自定义栏目作为阅读状态"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "选择自定义栏目作为阅读状态"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "选择自定义栏目作为书籍可见性"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "按规则提取书名后排序（正则表达式）"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "查看配置"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Custom CSS"
 msgstr "自定义过滤器"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "新用户默认权限设置"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "版本"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "管理员用户"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Language & Display"
 msgstr "单页显示"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "默认语言"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "新用户默认权限设置"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr "默认显示书籍语言"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "新用户默认显示权限"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "新用户默认显示权限"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr "选择新用户默认可见的侧边栏部分。"
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "在主页显示随机书籍"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "添加显示或隐藏书籍的标签值"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "添加显示或隐藏书籍的自定义栏目值"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 #, fuzzy
 msgid "Upload a file"
 msgstr "上传书籍"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "归档"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 #, fuzzy
 msgid "Download Log"
 msgstr "下载书籍"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "开始"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr "安排 5 分钟"
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr "安排 15 分钟"
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr "转换书库计划成功"
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr "安排转换书库时出错"
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8811,14 +8655,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8826,96 +8670,95 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr "在单本书籍上运行"
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr "按书名/作者搜索"
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "合并选中的书籍"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "成功删除 {} 个用户"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "删除书架时出错"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "无搜索结果"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "输入用户名"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "搜索书库"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "创建书架"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "合并选中的书籍"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "删除书架时出错"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Calibre-Web 日志: "
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8923,11 +8766,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -8938,11 +8781,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -8952,41 +8795,41 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 "此工具改编自 <a href=\"https://github.com/innocenat\">innocenat</a> 制作的 "
-"<a href=\"https://kindle-epub-fix.netlify.app/\">kindle-epub-fix.netlify."
-"app</a> 工具。"
+"<a href=\"https://kindle-epub-fix.netlify.app/\">kindle-epub-"
+"fix.netlify.app</a> 工具。"
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
-"注意：启用此功能会在启动时启动校验和回填服务，该服务可能会暂时锁定 metadata."
-"db。要停止正在运行的回填，请在禁用后重新启动容器。"
+"注意：启用此功能会在启动时启动校验和回填服务，该服务可能会暂时锁定 "
+"metadata.db。要停止正在运行的回填，请在禁用后重新启动容器。"
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr "启用激进型 EPUB 修复模式 (风险较高)"
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
@@ -8994,12 +8837,12 @@ msgstr ""
 "激进模式会应用更具侵入性的修复，并将尝试置信度较低的编码转换。建议大多数库使"
 "用安全模式。"
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "归档书籍"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
@@ -9007,116 +8850,116 @@ msgstr ""
 "当书籍不再存在于 Calibre 库中时，删除 app.db 中过时的归档书籍引用。有助于保持"
 "归档计数的准确性。"
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr "清理计划："
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr "频繁的时间间隔"
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr "每 15 分钟"
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr "每 30 分钟"
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr "每小时"
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr "每 2 小时"
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr "每 4 小时"
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr "每 6 小时"
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr "每 12 小时"
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr "每日/每周/每月"
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr "每天特定时间"
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr "每周特定日期"
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr "每月特定日期"
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr "默认值：每天 03:00"
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr "星期："
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr "星期一"
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr "星期二"
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr "星期三"
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr "星期四"
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr "星期五"
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr "星期六"
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr "星期日"
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr "日期："
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr "(1-28)"
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr "时间："
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr "(服务器时区: %(tz)s)"
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr "为新书启用自动元数据获取"
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9124,11 +8967,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr "启用智能元数据应用"
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9139,12 +8982,12 @@ msgstr ""
 "时，才会替换现有数据。禁用后，将按原样使用首选提供商获取到的元数据替换现有数"
 "据。"
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "已成功更新元数据"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
@@ -9153,27 +8996,25 @@ msgstr ""
 "选择自动获取时应更新哪些元数据字段。未选中的字段在自动获取元数据期间绝不会被"
 "修改，从而保留您的现有数据。"
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr "标签/类型"
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "书号"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "封面"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr "提示"
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
@@ -9182,27 +9023,27 @@ msgstr ""
 "这些字段选择同时适用于智能和直接替换模式。智能模式还将对选定字段应用质量标"
 "准，而直接模式将使用提供商数据替换所有选定字段。"
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr "封面文件最大大小 (MB)："
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 1-200 MB (default: 15)"
 msgstr "范围: 5-120 分钟（默认: 15）"
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 "限制从元数据提供程序或 URL 下载的封面图片的最大大小，以防保存缓慢或停滞。"
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr "导入处理超时时间"
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
@@ -9211,19 +9052,19 @@ msgstr ""
 "处理单本书籍的最大时间（以分钟为单位），超时后将被移动到失败备份文件夹以供调"
 "查。"
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr "超时时间（分钟）:"
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr "范围: 5-120 分钟（默认: 15）"
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr "过时临时文件清理"
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
@@ -9232,30 +9073,30 @@ msgstr ""
 "被忽略的临时上传文件（.uploading, .part 等）可以在达到设定期限后被清理。将任"
 "意一个值设置为 0 即可禁用清理功能。更改将在下一个清理周期生效。"
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Stale temp age (minutes):"
 msgstr "超时时间（分钟）:"
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr "范围: 5-120 分钟（默认: 15）"
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr "清理过时临时文件的时间间隔（秒）："
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr "范围: 5-120 分钟（默认: 15）"
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr "新书自动发送延迟"
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9266,21 +9107,21 @@ msgstr ""
 "前留出时间完成元数据获取和其他处理。仅适用于在个人资料中启用了自动发送的用"
 "户。"
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Delay (minutes):"
 msgstr "超时时间（分钟）:"
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr "范围: 5-120 分钟（默认: 15）"
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr "自动获取元数据提供程序优先级"
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
@@ -9289,24 +9130,24 @@ msgstr ""
 "配置自动获取新书元数据时搜索元数据提供程序的顺序。拖放以重新排序提供程序。仅"
 "使用已启用的提供程序。"
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr "提供程序按从上到下的顺序尝试。拖动以重新排序。"
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr "启用的元数据提供程序"
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr "未选中的提供程序将被全局禁用。"
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "Hardcover API token"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
@@ -9315,12 +9156,12 @@ msgstr ""
 "自动获取并向书库中的书籍分配 Hardcover ID。在使用兼容的电子阅读器时，"
 "Hardcover ID 允许与 Hardcover.app 同步阅读进度和批注。"
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Token Required"
 msgstr "Hardcover API token"
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
@@ -9330,18 +9171,18 @@ msgstr ""
 "HARDCOVER_TOKEN，或在“基本配置”中配置全局 Token。如果没有有效的 Token，此功能"
 "将保持禁用状态。"
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
@@ -9350,24 +9191,24 @@ msgstr ""
 "自动在 Hardcover 中搜索没有 Hardcover ID 的书籍。高置信度的匹配项会自动应用；"
 "低置信度的匹配项会排队等待人工审核。"
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr "运行计划："
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr "自动运行 Hardcover ID 获取任务的频率"
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr "最小置信度阈值："
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr "范围: 5-120 分钟（默认: 15）"
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
@@ -9376,16 +9217,16 @@ msgstr ""
 "置信度分数高于此阈值的匹配项将自动应用。较低的分数将排队等待手动审查。较高的"
 "值=较少的自动匹配项，但精度较高。"
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr "批次大小："
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr "范围: 5-120 分钟（默认: 15）"
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
@@ -9393,16 +9234,16 @@ msgstr ""
 "每次计划运行要处理的书籍数量。较小的批次可降低 API 负载；较大的批次可更快地处"
 "理书库。"
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr "速率限制延迟 (秒)："
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr "范围: 5-120 分钟（默认: 15）"
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
@@ -9410,34 +9251,34 @@ msgstr ""
 "向 Hardcover 发出 API 请求之间的延迟。防止速率限制并保护您的 API 密钥。遇到错"
 "误时使用指数退避。"
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "设置"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "OAuth 设置"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9445,48 +9286,47 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr "启用翻译贡献通知"
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr "当禁用时，如果您选择的语言的翻译不完整，您将不再收到 Web UI 中的通知。"
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "同步所选书架到 Kobo"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
@@ -9494,11 +9334,11 @@ msgstr ""
 "激活后，您的魔法书架将作为收藏同步到您的 Kobo 设备。注意：您还必须在“基本配"
 "置”中启用 Kobo 同步。"
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "启用移动设备（&lt;768px）上的模糊背景"
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -9506,27 +9346,27 @@ msgstr ""
 "启用后，模糊封面背景效果也会在小屏幕上呈现。如果您注意到滚动或动画延迟，请禁"
 "用该功能。"
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "OAuth 设置"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 "启用后，所有导入的文件的副本将存储在 <i>/config/processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -9534,21 +9374,21 @@ msgstr ""
 "启用后，进行转换的导入文件的原始文件将存储在 /config/processed_books/"
 "converted"
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9559,11 +9399,11 @@ msgstr ""
 "败的文件打包成 zip 压缩文件。这有助于保持 /config/processed_books 的子目录井"
 "然有序，并最大限度地减少磁盘空间使用。"
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -9572,33 +9412,33 @@ msgstr ""
 "当启用自动转换功能时，所有导入的书籍都将自动转换为此处选择的格式（下面的忽略"
 "列表中选择的格式除外）"
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "书籍格式转换:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9606,83 +9446,83 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr "Calibre 可以在导入时检测重复的书名，并根据"
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr "自动合并"
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr "设置删除重复书籍的任一实例或保留两者（默认）。"
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr "丢弃重复导入，保留库中的副本"
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr "用新导入的文件覆盖库中的副本"
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "创建重复记录，保留两个副本"
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "启用注册"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr "重复检测方法"
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr "混合 (SQL 预过滤 + Python 验证)"
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr "仅 Python (最慢，最健壮)"
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr "仅传统 SQL (实验性)"
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
@@ -9690,53 +9530,53 @@ msgstr ""
 "混合模式使用快速 SQL 预过滤器缩小候选范围，然后应用健壮的 Python 逻辑获得最终"
 "结果。"
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "OAuth 设置"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr "配置后台重复扫描。这些扫描自动运行，不会阻塞 UI。"
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr "启用自动重复扫描"
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr "导入后扫描"
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr "每次导入后运行（去抖动）"
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Manual only"
 msgstr "手动？"
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr "导入后去抖动 (秒)"
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr "在最后一次导入后等待这么多秒，然后再开始后台扫描。"
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr "计划扫描 (cron 表达式)"
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr "留空以禁用计划扫描。例如："
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
@@ -9744,15 +9584,15 @@ msgstr ""
 "如果启用，导入后扫描和 cron 扫描都可以运行。使用“仅手动”可禁用导入后扫描，同"
 "时保留 cron 计划。"
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr "下一次计划扫描："
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
@@ -9761,41 +9601,41 @@ msgstr ""
 "配置使用哪些元数据字段来确定书籍是否重复。书籍必须匹配所有选定标准才会被视为"
 "重复。"
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr "在检测重复项时考虑书名"
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr "在检测重复项时考虑书籍作者"
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr "在检测重复项时考虑书籍语言"
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr "在检测重复项时考虑丛书"
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr "在检测重复项时考虑出版商"
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr "在检测重复项时考虑文件格式"
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr "必须选择至少一个标准。建议将书名和作者作为核心标准。"
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr "重复格式优先级排序"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
@@ -9804,11 +9644,11 @@ msgstr ""
 "配置在使用“最高质量格式”自动解决策略时首选哪些文件格式。拖放以按优先级重新排"
 "序格式（越高越好）。"
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr "提示："
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
@@ -9817,700 +9657,688 @@ msgstr ""
 "当使用“最高质量格式”策略解决重复项时，具有较高等级格式的书籍将被保留。较低优"
 "先级的格式将被删除。"
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr "重复通知和自动解决"
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr "配置如何接收有关重复书籍的通知，并可选择启用自动解决。"
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "启用 CWA 更新通知"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
-"检测到未解决的重复项时显示弹出通知。管理员和具有编辑权限的用户在登录时，将"
-"在“重复项”侧边栏按钮上看到一个徽章，并会看到一个弹出通知。"
+"检测到未解决的重复项时显示弹出通知。管理员和具有编辑权限的用户在登录时，将在"
+"“重复项”侧边栏按钮上看到一个徽章，并会看到一个弹出通知。"
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "启用注册"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr "警告："
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr "这将根据下面的策略自动删除书籍。原始文件将备份到"
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr "自动解决策略"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr "保留最新的"
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr "删除较旧的副本，保留最近添加的书籍"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr "保留最旧的"
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr "删除较新的副本，保留最早添加的"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Merge Formats"
 msgstr "原始格式"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr "将格式合并到最新书籍中，删除其余部分"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr "保留最高质量格式"
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr "根据您的重复格式优先级排序首选格式"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "获取元数据"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr "保留信息最完整的书籍"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr "保留最大文件大小"
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr "保留总文件大小最大的书籍"
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr "选择自动解决重复项时要保留的书籍。"
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "评分"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr "冷却期 (分钟)"
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 "两次自动解决之间的最短时间（0 表示禁用）。防止在批量导入期间发生快速删除。"
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 "自动解决会在重复扫描检测到新重复项后运行。被忽略的重复组永远不会自动解决。"
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr "查看 %(count)s 个待处理的匹配项"
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr "点击查看更多"
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "下一个"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "标为未读"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "标为已读"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as read"
 msgstr "标为未读"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Marked as unread"
 msgstr "标为未读"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Added to favorites"
 msgstr "添加到归档"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "从档案还原"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "从档案还原"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "添加到归档"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Restored from archive"
 msgstr "从档案还原"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Hide from your library"
 msgstr "搜索书库"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "数据库设置已更新"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "评分大于"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "%(range)s 第 %(index)s 册"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr "ID"
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr "UUID"
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr "UUID 已复制到剪贴板"
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr "无法复制 UUID"
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr "复制 UUID"
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 #, fuzzy
 msgid "File sizes"
 msgstr "字体大小"
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "简介:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "接收书籍的电子阅读器邮箱地址"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 msgid "Choose email addresses:"
 msgstr "选择邮箱地址:"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select All"
 msgstr "创建书架"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Additional email addresses:"
 msgstr "选择邮箱地址:"
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Enter additional email addresses (separated by commas):"
 msgstr "选择邮箱地址:"
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr "example@domain.com, another@domain.com"
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr "输入一个或多个电子邮件地址，用逗号分隔"
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select format:"
 msgstr "删除格式:"
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "创建封面路径失败"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "创建封面路径失败"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr "具有匹配标题和作者的书籍。建议通过可视化检查来识别真正的重复项。"
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "重复书籍"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "显示最高评分书籍"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr "选择重复项"
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "选择"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "合并选中的书籍"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "重复书籍"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Auto-Resolve Duplicates"
 msgstr "选择重复项"
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr "通过保留一本书并根据策略删除其他书籍，自动解决所有重复组。"
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr "策略："
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr "保留最新的 - 删除较旧的副本，保留最近添加的"
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr "保留最旧的 - 删除较新的副本，保留最早添加的"
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr "合并格式 - 将格式合并到最新书籍中，删除其余的"
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr "保留最高质量格式 - 根据您的重复格式优先级排序首选格式"
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr "保留最多元数据 - 保留信息最完整的书籍"
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr "保留最大文件大小 - 保留总文件大小最大的书籍"
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "上一个"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr "执行解决"
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr "这将永久删除书籍。原始文件将备份到"
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "合并选中的书籍"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr "忽略此重复组"
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "View book details"
 msgstr "书籍详情"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Edit book metadata"
 msgstr "编辑元数据"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Archive/delete book"
 msgstr "合并选中的书籍"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "无搜索结果"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr "您的书库中没有标题和作者组合重复的书籍。"
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr "此搜索查找标题和作者完全相同的书籍，以避免误报。"
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "删除格式:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr "此操作无法撤销！"
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be permanently deleted:"
 msgstr "此书籍将从数据库中永久删除"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 #, fuzzy
 msgid "Merge Books"
 msgstr "未读书籍"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "以下书籍将被删除："
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "此书籍将从数据库中永久删除"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr "注意：来源书籍的文件格式将被添加到目标书籍中。"
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr "解决预览"
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr "成功"
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr "选中的重复书籍已成功删除！"
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr "处理您的请求时发生错误。"
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "选择服务器类型"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr "标准电子邮件"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr "Gmail 账户"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr "设置 Gmail 账户"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "撤消 Gmail 访问权限"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "SMTP 密码"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "附件大小限制"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 msgid "Save and Send Test Email"
 msgstr "保存设置并发送测试邮件"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "允许注册的域名（白名单)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "添加域名"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "输入域名"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "禁止注册的域名（黑名单）"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr "(魔法)"
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
 msgstr "在文本编辑器中打开 .kobo/Kobo/Kobo eReader.conf，添加（或编辑）:"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Kobo Token:"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "列表"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr "Hardcover 匹配审核 🔖"
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr "全部处理完毕！"
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
@@ -10518,15 +10346,15 @@ msgstr ""
 "没有需要审核的待处理 Hardcover 匹配项。自动获取任务运行时，新匹配项将出现在此"
 "处。"
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr "返回管理面板"
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr "需要审核"
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
@@ -10535,11 +10363,11 @@ msgstr ""
 "%(count)s 本书存在模糊的 Hardcover 匹配项。请查看每个匹配项并选择正确结果，如"
 "果没有合适的匹配项，请跳过/拒绝。"
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr "待处理的匹配项"
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
@@ -10548,1083 +10376,1069 @@ msgstr ""
 "审核并批准书籍的模糊 Hardcover ID 匹配项。高置信度匹配项会自动应用；这些需要"
 "手动验证。"
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All Pending"
 msgstr "创建书架"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "搜索项："
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr "候选匹配项"
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr "前 %(count)s 个"
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr "置信度"
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "View on Hardcover"
 msgstr "查看保存书籍"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Reject All"
 msgstr "创建书架"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Processing..."
 msgstr "加载中..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
 msgstr "您确定要修改选定用户的选定角色吗？"
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr "✗ 拒绝所有匹配项"
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "创建封面路径失败"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr "您确定要修改选定用户的选定角色吗？"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "✗ Reject All Pending"
 msgstr "创建书架"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject all pending matches"
 msgstr "创建封面路径失败"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr "→ 暂时跳过"
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr "跳过匹配项失败"
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "Calibre-Web 实例未配置，请联系您的管理员！"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "创建问题"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "回到首页"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "登出账号"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr "移动端提示"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr "在桌面或平板设备上编辑魔法书架效果最佳。"
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr "刷新书架以使用最新更改进行更新"
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "编辑书架"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr "从侧边栏隐藏此书架"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show this shelf in your sidebar"
 msgstr "同步这个书架到 Kobo device"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Show Shelf"
 msgstr "显示全部"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 #, fuzzy
 msgid "Hide Shelf"
 msgstr "公共书架"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 #, fuzzy
 msgid "Add Series to Shelf"
 msgstr "添加到书架"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 #, fuzzy
 msgid "KOReader Sync is disabled."
 msgstr "KOReader 同步插件"
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "首页"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "切换导航"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "搜索书库"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "Caliebre-Web 电子书路径"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "注销"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 #, fuzzy
 msgid "Settings"
 msgstr "设置"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Refresh Library"
 msgstr "搜索书库"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 #, fuzzy
 msgid "New interface available"
 msgstr "无可用发布信息"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 #, fuzzy
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "Caliebre-Web 电子书路径"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr "查看更新日志"
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "重复书籍"
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr "在这里贡献！"
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "请不要刷新页面"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Create Shelf"
 msgstr "创建书架"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr "魔法书架 ✨"
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "上一个"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "书籍详情"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "此操作无法撤销！"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "合并选中的书籍"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Formats:"
 msgstr "上传格式"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "删除格式:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "删除书籍"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr "您的书库中有未解决的重复书籍"
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "无搜索结果"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr "稍后提醒我"
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "选择重复项"
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Scroll to top"
 msgstr "缩放到最佳"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "到："
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Confirm"
 msgstr "配置"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "添加到书架"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "合并选中的书籍"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "标为未读"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "删除书籍"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Delete books?"
 msgstr "删除书籍"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "创建书架"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "连接错误"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr "按首字母过滤"
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr "网格"
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 #, fuzzy
 msgid "Show Password"
 msgstr "SMTP 密码"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "记住我"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "忘记密码？"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "通过魔法链接登录"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 #, fuzzy
 msgid "Log in with SSO"
 msgstr "通过魔法链接登录"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr "标准登录已被禁用。请使用其他登录方法之一。"
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "显示 Calibre-Web 日志： "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 #, fuzzy
 msgid "Calibre-Web Log: "
 msgstr "显示 Calibre-Web 日志： "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "输出流，无法显示"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "显示访问日志： "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "下载 Calibre-Web 日志"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "下载访问日志"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr "系统模板"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr "这是一个预配置的模板书架。您可以自由编辑它。"
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "书架将被公开"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr "其他用户可以查看此书架。具有“编辑公共书架”权限的用户可以编辑/删除它。"
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "选择显示的与隐藏的标签"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "选择显示的自定义栏目值与隐藏的自定义栏目值"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "选择此用户显示的标签与隐藏的标签"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr "选择此用户显示的自定义栏目值与隐藏的自定义栏目值"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "输入标签"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "添加显示或隐藏书籍的值"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "书籍的此格式副本将从数据库中永久删除"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "此书籍将从数据库中永久删除"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "，包括从硬盘中"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr "Kobo 重要提示：被删除的书籍将保留在任何配对的 Kobo 设备上"
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
 msgstr "在安全删除图书之前，必须先将图书归档并与设备同步"
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "选择文件位置"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "类型"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "名称"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "大小"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "父目录"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "完成"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Caliebre-Web 电子书路径"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "epub 阅读器"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 #, fuzzy
 msgid "Annotations"
 msgstr "活动"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "黑色"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "字体大小"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 #, fuzzy
 msgid "Text margin"
 msgstr "下一页"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr "字体"
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 #, fuzzy
 msgid "Default"
 msgstr "删除数据"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr "雅黑"
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr "宋体"
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 #, fuzzy
 msgid "KaiTi"
 msgstr "楷体"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 #, fuzzy
 msgid "Arial"
 msgstr "Arial"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 #, fuzzy
 msgid "Spread"
 msgstr "已读"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 #, fuzzy
 msgid "Two columns"
 msgstr "双栏"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 #, fuzzy
 msgid "One column"
 msgstr "单栏"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "打开侧栏时重排文本"
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Comic 阅读器"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "快捷键"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "上一页"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "下一页"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 msgid "Single Page Display"
 msgstr "单页显示"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr "长条显示"
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "缩放到最佳"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "按宽度缩放"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "按高度缩放"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "缩放到原始大小"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "向右旋转"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "向左旋转"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "翻转图片"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "显示"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 msgid "Single Page"
 msgstr "单页"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr "长条"
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "缩放"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "最佳"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "宽度"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "高度"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "原始"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "旋转"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "翻转"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "水平"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "垂直"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Direction"
 msgstr "简介"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "从左到右"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "从右到左"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Reset to Top"
 msgstr "回到首页"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Remember Position"
 msgstr "记住我"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "工具栏"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "显示"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "DJVU 阅读器"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "PDF 阅读器"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "txt 阅读器"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "注册新账号"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "选择一个用户名"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "您的邮箱地址"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "魔法链接 - 授权新设备"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "在另一个设备上，登录并访问："
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "验证后，您将自动在新设备上登录"
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "此验证链接将在10分钟后失效"
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 "在计划维护期间自动刷新所有缩略图。无论此设置如何，始终会按需生成缩略图。"
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr "生成丛书封面缩略图"
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "无搜索结果"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "搜索项："
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "结果："
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "出版日期从"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "出版日期到"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr "空"
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "排除标签"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "排除丛书"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "排除书架"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "排除语言"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "扩展名"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "排除扩展名"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "评分大于"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "评分小于"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "从："
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "到："
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "删除此书架"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "编辑书架属性"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add Books"
 msgstr "隐藏书籍"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "手动排列书籍排列顺序"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "禁止改变顺序"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "允许改变顺序"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "%(count)s selected"
 msgstr "合并选中的书籍"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, fuzzy, python-format
 msgid "Add %(count)s"
 msgstr "账号"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "No books found."
 msgstr "找不到令牌"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Already on this shelf"
 msgstr "删除此书架"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Add books to"
 msgstr "添加到书架"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library…"
 msgstr "搜索书库"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 #, fuzzy
 msgid "Search your library"
 msgstr "搜索书库"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "书架将被公开"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "同步这个书架到 Kobo device"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 #, fuzzy
 msgid "Shelf order"
 msgstr "找不到用户"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "隐藏书籍"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "书库统计"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "本书籍在此书库中"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "位作者在此书库中"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "种分类在此书库中"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "套丛书在此书库中"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "系统统计"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr "程序"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "已安装版本"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "运行时间"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Actions"
 msgstr "活动"
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr "即将到来的计划发送"
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr "计划时间"
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "State"
 msgstr "旋转"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
@@ -11632,187 +11446,187 @@ msgstr ""
 "即将发送的邮件将被持久化，并在计划时间作为任务进入队列。您可以在运行之前取消"
 "待处理的发送。"
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr "即将到来的计划操作"
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr "类型"
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 "此处安排的转换库和 EPUB 修复程序运行将在重启后保留。取消可防止它们触发。"
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr "这个任务将被取消。此任务所有的更改都将被保存"
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
 msgstr "如果这是计划任务，则将在下一个计划的时间内重新运行"
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "选中的重复书籍已成功删除！"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr "取消计划项时出错"
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Update Calibre-Web NextGen"
 msgstr "Caliebre-Web 电子书路径"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Portainer:"
 msgstr "重要："
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 #, fuzzy
 msgid "Set up automatic updates"
 msgstr "启用自动重复扫描"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Your Profile"
 msgstr "您的邮箱地址"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "User Settings"
 msgstr "设置"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr "账号信息"
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr "如果您需要更改您的电子邮件地址或密码，可以在此处进行。"
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "重置用户密码"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "eReader Configuration"
 msgstr "服务器配置"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Email Address"
 msgstr "接收书籍的电子阅读器邮箱地址"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr "使用逗号分隔多个地址"
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr "用于您的电子阅读器设备的邮箱地址。使用逗号分隔多个地址。"
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr "启用发送到电子阅读器弹出窗口模式"
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
@@ -11821,126 +11635,126 @@ msgstr ""
 "启用或禁用“发送到电子阅读器”弹出模式，允许用户在发送到电子阅读器时输入额外的"
 "电子邮件地址并且只发送到选定的保存地址。"
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr "当禁用时，将不会提示而直接将邮件发送到所有已配置的电子阅读器地址。"
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr "自动将新书发送到我的电子阅读器"
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr "启用后，新导入的书籍将自动发送到上述所有已配置的电子阅读器邮箱地址。"
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr "语言和主题偏好"
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Interface Language"
 msgstr "输入语言"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "按语言显示书籍"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr "过滤库以仅显示特定语言的书籍。"
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "无有效书籍语言"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr "OAuth 及 API 集成"
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "OAuth 设置"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "链接"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "取消链接"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Hardcover API Token"
 msgstr "Hardcover API token"
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr "用于 Hardcover 元数据提供程序集成的 API token。"
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Kobo 同步 Token"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "新建或查看"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr "强制与 Kobo 完全同步"
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "仅同步所选书架中的书籍到 Kobo"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "仅同步所选书架中的书籍到 Kobo"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "安全设置"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr "选择在侧边栏导航中显示哪些部分。"
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "添加显示或隐藏书籍的自定义栏目值"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr "OPDS 目录顺序"
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
@@ -11948,79 +11762,79 @@ msgstr ""
 "通过按所需顺序列出条目 ID 来重新排序 OPDS 根目录。未知的 ID 将被忽略，缺失的"
 "条目将自动追加。"
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr "拖动以重新排序 OPDS 根条目。缺失的条目会自动追加。"
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr "用户权限"
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr "配置允许此用户执行哪些操作。"
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Magic Shelves Order"
 msgstr "同步所选书架到 Kobo"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr "选择您的魔法书架在侧边栏中的排序方式。"
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr "排序模式"
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr "手动（拖动以重新排序）"
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr "名称 (A-Z)"
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr "名称 (Z-A)"
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr "书籍数量（由多到少）"
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr "书籍数量（由少到多）"
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr "创建时间（最新的在前）"
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr "创建时间（最旧的在前）"
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Recently modified"
 msgstr "最近添加的书籍"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr "最久未修改时间"
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr "仅当排序模式设置为手动时，才会使用手动顺序。"
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr "魔法书架可见性"
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
@@ -12028,34 +11842,34 @@ msgstr ""
 "取消选中要从侧边栏隐藏的书架。系统书架无法删除，只能隐藏。来自其他用户的公共"
 "书架也可以隐藏。"
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr "默认系统书架："
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "编辑公共书架"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr "%(total)s 个默认书架中有 %(visible)s 个可见"
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr "%(total)s 个公共书架中有 %(visible)s 个可见"
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "删除此用户"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -12063,155 +11877,155 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "New app password"
 msgstr "修改密码"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Create app password"
 msgstr "修改密码"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "新建或查看"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "生成 Kobo Auth 地址"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr "可见"
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "选择..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "删除所选项"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "编辑用户"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "输入用户名"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 msgid "Enter Email"
 msgstr "输入邮箱"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "Enter eReader Email"
 msgstr "接收书籍的电子阅读器邮箱"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "eReader Email"
 msgstr "电子阅读器邮箱"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "接收书籍的电子阅读器邮箱"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "电子阅读器邮箱"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "本地化"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "可见书籍语言"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "编辑允许标签"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "允许标签"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "编辑被拒绝标签"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "被拒绝标签"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "编辑显示栏目值"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "显示栏目值"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "编辑隐藏栏目值"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "隐藏栏目值"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "修改密码"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "编辑公共书架"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "同步所选书架到 Kobo"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "同步所选书架到 Kobo"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 msgid "Show Read/Unread Section"
 msgstr "显示已读、未读栏目"
 

--- a/cps/translations/zh_Hant_TW/LC_MESSAGES/messages.po
+++ b/cps/translations/zh_Hant_TW/LC_MESSAGES/messages.po
@@ -19,42 +19,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr "統計"
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr "Calibre 資料庫不可用。請重新配置書庫路徑。"
 
-#: cps/admin.py:208
+#: cps/admin.py
 msgid "Server restarted, please reload page."
 msgstr "伺服器已重啟，請重整頁面"
 
-#: cps/admin.py:210
+#: cps/admin.py
 msgid "Performing Server shutdown, please close window."
 msgstr "正在關閉伺服器，請關閉視窗"
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr "資料庫重新連線成功"
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr "未知指令"
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid ""
 "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr "成功，書籍元數據備份已進入隊列。請檢查任務結果"
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or with "
 "HARDCOVER_SYNC_ENABLED."
 msgstr "錯誤：Hardcover 同步已禁用，在基本配置中啟用 啟用 Hardcover 同步 "
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
@@ -62,1739 +62,1711 @@ msgstr ""
 "錯誤：沒有可用的 Hardcover Token。請設定 HARDCOVER_TOKEN 環境變量或在基本配置"
 "中設定"
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for progress."
 msgstr "成功！Hardcover 自動獲取任務已開始，請檢查任務面板查看進度"
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr "啟用 Hardcover 自動獲取任務出錯：%(error)s"
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr "匹配 Hardcover 評論"
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr "載入評論隊列出錯：%(error)s"
 
-#: cps/admin.py:414
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover ID applied successfully"
 msgstr "成功刪除 {} 個用戶"
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr "匹配 %(action)s"
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr "沒有待拒絕的匹配"
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr "已拒絕 %(count)s 個匹配"
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few minutes."
 msgstr "已開始為 {} 本書籍重整縮圖快取，這可能需要幾分鐘"
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr "未找到帶有封面的書籍進行處理"
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr "開始重整縮圖失敗：{}"
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr "管理頁"
 
-#: cps/admin.py:653
+#: cps/admin.py
 #, fuzzy
 msgid "Hardcover token expires"
 msgstr "OAuth設定"
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr "基本配置"
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr "界面配置"
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, fuzzy, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr "自定義列號：%(column)d在Calibre數據庫中不存在"
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr "管理用戶"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr "全部"
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr "找不到用戶"
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr "成功刪除 {} 個用戶"
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr "顯示全部"
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr "格式錯誤的請求"
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr "訪客名稱無法更改"
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr "遊客無法擁有此角色"
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr "管理員賬戶不存在，無法刪除管理員角色"
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr "值必須是 true 或 false"
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr "無效角色"
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr "遊客無法擁有此視圖"
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr "無效視圖"
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr "訪客的本地化是自動偵測而無法設置的"
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr "無可用本地化"
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr "無有效書籍語言"
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr "參數未找到"
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr "設定資料庫為不可寫"
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed — "
 "books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr "無效的閱讀列"
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr "無效的限制列"
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr "Calibre-Web NextGen 配置已更新"
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "您確定刪除Kobo Token嗎？"
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr "您確定要刪除此網域嗎？"
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr "您確定要刪除此用戶嗎？"
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr "您確定要刪除此書架嗎？"
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr "您確定要修改選定用戶的本地化設置嗎？"
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr "您確定要修改選定用戶的可見書籍語言嗎？"
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr "您確定要修改選定用戶的選定角色嗎？"
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the selected "
 "user(s)?"
 msgstr "您確定要修改選定用戶的選定限制嗎？"
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for the "
 "selected user(s)?"
 msgstr "您確定要修改選定用戶的選定可視化限制嗎？"
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr "您確定要更改所選用戶的書架同步行為嗎？"
 
-#: cps/admin.py:1102
+#: cps/admin.py
 #, fuzzy
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected user(s)?"
 msgstr "您確定要更改所選用戶的書架同步行為嗎？"
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr "您確定要更改 Calibre 庫位置嗎？"
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force a "
 "full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr "拒絕"
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr "允許"
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr "{} 同步項目被刪除"
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, python-brace-format
 msgid "Book {} not found"
 msgstr "找不到 {} 書籍"
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive the "
 "book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so "
 "the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr "標籤未找到"
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr "無效的動作"
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr "client_secrets.json 未為 Web 應用程序配置"
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "日誌文件路徑無效，請輸入正確的路徑"
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr "訪問日誌路徑無效，請輸入正確的路徑"
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr "請輸入LDAP主機、端口、DN和用戶對象標識符"
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr "請輸入一個LDAP服務賬號和密碼 "
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr "請輸入一個LDAP服務賬號"
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP群組對象過濾器需要一個具有“%s”格式標識符號"
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr "LDAP群組對象過濾器的括號不匹配"
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP用戶對象過濾器需要一個具有“%s”格式標識符"
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr "LDAP用戶對象過濾器的括號不匹配"
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr "LDAP成員用戶過濾器需要有一個“%s”格式標識符號"
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr "LDAP成員用戶過濾器中有不匹配的括號"
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
 msgstr "LDAP CA證書、證書或密鑰位置無效，請輸入正確的路徑"
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr "添加新用戶"
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr "編輯郵件伺服器設定"
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr "Gmail 帳戶驗證成功"
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr "資料庫錯誤：%(error)s。"
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid ""
 "Test e-mail queued for sending to %(email)s, please check Tasks for result"
 msgstr "發送給%(email)s的測試郵件已進入隊列。請檢查任務結果"
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr "發送測試郵件時出錯：%(res)s"
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr "請先配置您的郵箱地址..."
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr "郵件伺服器設定已更新"
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 msgid "Email Your Users"
 msgstr "透過電子郵件聯絡你的用戶"
 
-#: cps/admin.py:2046
+#: cps/admin.py
 msgid ""
 "Please configure the email server under Edit Email Server Settings first."
 msgstr "請先在「編輯郵件伺服器設定」中設定郵件伺服器。"
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 msgid "Please set an email address on your own account first..."
 msgstr "請先在您的帳戶上設定電子郵件地址…"
 
-#: cps/admin.py:2073
+#: cps/admin.py
 #, fuzzy
 msgid "Please select at least one recipient."
 msgstr "新密碼已發送到您的郵箱"
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Test announcement email queued to %(email)s — check Tasks for the result."
 msgstr "發送給%(email)s的測試郵件已進入隊列。請檢查任務結果"
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, fuzzy, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
 "delivery."
 msgstr "發送給%(email)s的測試郵件已進入隊列。請檢查任務結果"
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr ""
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr ""
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr ""
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr ""
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr "發生一個未知錯誤，請稍後再試。"
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 #, fuzzy
 msgid "title"
 msgstr "標題"
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr "編輯用戶 %(nick)s"
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr "用戶 %(user)s 的密碼已重置"
 
-#: cps/admin.py:2296
+#: cps/admin.py
 #, fuzzy
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr "請先配置SMTP郵箱設置..."
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr "日誌文件查看器"
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr "正在請求更新包"
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr "正在下載更新包"
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr "正在解壓更新包"
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr "正在替換文件"
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr "數據庫連接已關閉"
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr "正在停止服務器"
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr "更新完成，請點擊確定並刷新頁面"
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr "更新失敗："
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr "HTTP錯誤"
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr "連接錯誤"
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr "建立連接超時"
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr "一般錯誤"
 
-#: cps/admin.py:2394
+#: cps/admin.py
 #, fuzzy
 msgid "Update file could not be saved in temp dir"
 msgstr "更新文件無法保存在臨時目錄中"
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr "更新時檔案無法替換變更"
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr "未能提取至少一個LDAP用戶"
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr "未能創建至少一個LDAP用戶"
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr "錯誤：%(ldaperror)s"
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr "錯誤：在LDAP服務器的響應中沒有返回用戶"
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr "數據庫中沒有找到至少一個LDAP用戶"
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr "{} 用戶被成功導入"
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr ""
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr "數據庫路徑無效，請輸入正確的路徑"
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr "數據庫不可寫入"
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr "密鑰文件路徑無效，請輸入正確的路徑"
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr "證書文件路徑無效，請輸入正確的路徑"
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL (e.g., "
 "https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr ""
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify path "
 "are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr "資料庫設定已更新"
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr "數據庫配置"
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr "請填寫所有欄位！"
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr "郵箱不在有效網域中"
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr "添加新用戶"
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr "用戶“%(user)s”已創建"
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "使用此郵箱或用戶名的賬號已經存在。"
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr "用戶“%(nick)s”已刪除"
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr "無法刪除訪客用戶"
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr "管理員賬戶不存在，無法刪除用戶"
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr ""
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr "用戶“%(nick)s”已更新"
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid ""
 "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
 msgstr ""
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr ""
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: %(error)s"
 msgstr "連接錯誤：%(error)s"
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr ""
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 
-#: cps/admin.py:3322
+#: cps/admin.py
 #, fuzzy
 msgid " User info endpoint is available."
 msgstr "無可用發佈信息"
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr ""
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr ""
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr ""
 
-#: cps/admin.py:3340
+#: cps/admin.py
 #, fuzzy
 msgid "An unknown error occurred."
 msgstr "發生一個未知錯誤，請稍後再試。"
 
-#: cps/admin.py:3352
+#: cps/admin.py
 #, fuzzy
 msgid "Restore already in progress."
 msgstr "連接錯誤"
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, fuzzy, python-format
 msgid "Restore failed: %(err)s"
 msgstr "連接錯誤"
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 msgid "No file uploaded."
 msgstr "無檔案上傳"
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr ""
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr ""
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr ""
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr ""
 
-#: cps/constants.py:265
+#: cps/constants.py
 msgid "Finnish"
 msgstr ""
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr ""
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr ""
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr ""
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr ""
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr ""
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr ""
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr ""
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr ""
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr ""
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr ""
 
-#: cps/constants.py:276
+#: cps/constants.py
 msgid "Polish"
 msgstr ""
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr ""
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr ""
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr ""
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr ""
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr ""
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr ""
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr ""
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr ""
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr ""
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr ""
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr "未安裝"
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr "缺少執行權限"
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, fuzzy, python-format
 msgid "Change cover — %(title)s"
 msgstr "交換作者和標題"
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 #, fuzzy
 msgid "Unknown cover source."
 msgstr "連接錯誤"
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr ""
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, please "
 "wait..."
 msgstr ""
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Book ID"
 msgstr "書籍 ID"
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr "書名"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Book Author"
 msgstr "作者"
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr ""
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Filepath"
 msgstr "文件格式"
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Filename"
 msgstr "檔名"
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr ""
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr ""
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "End Format"
 msgstr "上傳格式"
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Unknown User"
 msgstr "未知"
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid ""
 "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid ""
 "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr ""
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid book selection."
 msgstr "無效角色"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Selected book has no EPUB format."
 msgstr "合併選中的書籍"
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB file not found on disk."
 msgstr "硬碟上找不到 %(format)s 格式"
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "EPUB Fixer started for selected book."
 msgstr "合併選中的書籍"
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr ""
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr ""
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Invalid image data format."
 msgstr "無效的郵件地址格式"
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 #, fuzzy
 msgid "Profile picture updated successfully."
 msgstr "成功刪除 {} 個用戶"
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr "無"
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate Books"
 msgstr "刪除書籍"
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group dismissed"
 msgstr "刪除書籍"
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate group restored"
 msgstr "刪除書籍"
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 #, fuzzy
 msgid "Duplicate scan queued"
 msgstr "無搜索結果"
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 #, fuzzy
 msgid "Invalid resolution strategy"
 msgstr "無效角色"
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr "上傳完成，正在處理中，請稍候..."
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 #, fuzzy
 msgid "Failed to queue upload for processing"
 msgstr "創建封面路徑失敗"
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr "轉換的來源或目的格式不存在"
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr "書籍已經被成功加入到 %(book_format)s 格式轉換隊列"
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr "轉換此書籍時出現錯誤： %(res)s"
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 #, fuzzy
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr "不能上傳文件附檔名為“%(ext)s”的文件到此服務器"
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr "不能上傳文件附檔名為“%(ext)s”的文件到此服務器"
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr "要上傳的文件必須具有附檔名"
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not accessible"
 msgstr "糟糕！選擇書名無法打開。文件不存在或者文件不可訪問"
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr ""
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr "標識符不區分大小寫，覆蓋舊標識符"
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr "%(langname)s 不是一種有效語言"
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr "已成功更新元數據"
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr ""
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr "未知"
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
 msgstr "上傳的書籍可能已經存在，建議修改後重新上傳： "
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr "文件 %(filename)s 無法保存到臨時目錄"
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr "移動封面文件失敗 %(file)s：%(error)s"
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr "書籍格式已成功刪除"
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr "書籍已成功刪除"
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr ""
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr "編輯元數據"
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "%(seriesindex)s 不是一個有效的數值，忽略"
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr ""
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr "創建路徑 %(path)s 失敗(權限拒絕)。"
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr "保存文件 %(file)s 失敗。"
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr "已添加 %(ext)s 格式到 %(book)s"
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 msgid "Book not found"
 msgstr "找不到書籍"
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, fuzzy, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr "硬碟上找不到 %(format)s 格式"
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid ""
 "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
 msgstr "Google Drive 設置未完成，請嘗試停用並再次激活Google雲端硬碟"
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
 msgstr "回調網域名稱尚未被驗證，請在google開發者控制台按步驟驗證網域名稱"
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr "找不到id為 %(book)d 的書籍的 %(format)s 格式"
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr "Google Drive %(fn)s 上找不到 %(format)s"
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr "找不到 %(format)s：%(fn)s"
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr "發送到電子閱讀器"
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr "找不到id為 %(book)d 的書籍的 %(format)s 格式"
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr "找不到id為 %(book)d 的書籍的 %(format)s 格式"
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 #, fuzzy
 msgid "Test Email"
 msgstr "測試郵件"
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr "用戶註冊電子郵件：%(name)s"
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr "轉換 %(orig)s 到 %(format)s 並發送到Kindle"
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Send %(format)s to eReader"
 msgstr "發送 %(format)s 到Kindle"
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "%(book)s send to eReader"
 msgstr "%(book)s發送到Kindle"
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr "無法讀取請求的文件。可能有錯誤的權限設置？"
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr ""
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
 msgstr "刪除書的文件夾%(id)s失敗，路徑有子文件夾：%(path)s"
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr "刪除書籍 %(id)s失敗：%(message)s"
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid: "
 "%(path)s"
 msgstr "僅從數據庫中刪除書籍 %(id)s，數據庫中的書籍路徑無效： %(path)s"
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, fuzzy, python-format
 msgid ""
 "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr "將標題從“%(src)s”改為“%(dest)s”時失敗，錯誤錯信息：%(error)s"
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr "Google Drive上找不到文件 %(file)s"
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr "將標題從“%(src)s”改為“%(dest)s”時失敗，錯誤錯信息：%(error)s"
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr "Google Drive上找不到書籍路徑 %(path)s"
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr ""
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr "此用戶名已被使用"
 
-#: cps/helper.py:1337
+#: cps/helper.py
 #, fuzzy
 msgid "Invalid Email address format"
 msgstr "無效的郵件地址格式"
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr ""
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid ""
 "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr "下載封面時出錯"
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr "封面文件不是有效的圖片文件，或者無法儲存"
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr "封面格式出錯"
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
 msgstr ""
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr "創建封面路徑失敗"
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr "封面文件只支持jpg/jpeg/png/webp/bmp格式文件"
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr ""
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr "僅將jpg、jpeg文件作為封面文件"
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr ""
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr "找不到UnRar執行文件"
 
-#: cps/helper.py:2093
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing UnRar"
 msgstr "執行UnRar時出錯"
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr ""
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr ""
 
-#: cps/helper.py:2125
+#: cps/helper.py
 #, fuzzy
 msgid "Calibre binaries not viable"
 msgstr "數據庫不可寫入"
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, fuzzy, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr "缺少執行權限"
 
-#: cps/helper.py:2141
+#: cps/helper.py
 #, fuzzy
 msgid "Error executing Calibre"
 msgstr "執行UnRar時出錯"
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr ""
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr "Kobo 設置"
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr "使用 %(provider)s 註冊"
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 #, fuzzy
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
 msgstr "郵件服務未配置，請聯繫網站管理員！"
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1802,35 +1774,35 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr "您現在已以“%(nickname)s”身份登入"
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr "連接到%(oauth)s成功"
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. Please "
@@ -1838,5170 +1810,5070 @@ msgid ""
 "account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr "郵件服務未配置，請聯繫網站管理員！"
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr "取消連接到%(oauth)s成功"
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr "取消連接到%(oauth)s失敗"
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr "為連接到%(oauth)s"
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr "使用Github登入失敗。"
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr "從Github獲取用戶信息失敗。"
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr "使用Google登入失敗。"
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr "從Google獲取用戶信息失敗。"
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 #, fuzzy
 msgid "Failed to log in with Generic OAuth."
 msgstr "使用Github登入失敗。"
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin > "
 "Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr "GitHub Oauth 錯誤，請重試。"
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr "GitHub Oauth 錯誤: {}"
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr "Google Oauth 錯誤，請重試。"
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr "Google Oauth 錯誤: {}"
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, fuzzy, python-brace-format
 msgid "OAuth error: {}"
 msgstr "GitHub Oauth 錯誤: {}"
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr "字母排序書籍"
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr "按字母排序的書籍"
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr "熱門書籍"
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr "基於下載數的熱門書籍。"
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr "最高評分書籍"
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr "基於評分的熱門書籍。"
 
-#: cps/opds.py:182
+#: cps/opds.py
 #, fuzzy
 msgid "Recently added Books"
 msgstr "已下載書籍"
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr "最新書籍"
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr "隨機書籍"
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr "隨機顯示書籍"
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr "已讀書籍"
 
-#: cps/opds.py:201
+#: cps/opds.py
 #, fuzzy
 msgid "Books currently being read"
 msgstr "當前版本"
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr "未讀書籍"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr "作者"
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr "書籍按作者排序"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr "出版社"
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr "書籍按出版社排序"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr "分類"
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr "書籍按分類排序"
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr "叢書"
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr "書籍按叢書排序"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr "語言"
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr "書籍按語言排序"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr "評分"
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr "書籍按評分排序"
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr "文件格式"
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr "書籍按文件格式排序"
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr "書架列表"
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr "書架上的書"
 
-#: cps/opds.py:260
+#: cps/opds.py
 #, fuzzy
 msgid "Magic Shelves"
 msgstr "同步所選書架到 Kobo"
 
-#: cps/opds.py:261
+#: cps/opds.py
 #, fuzzy
 msgid "Books organized in magic shelves"
 msgstr "書架上的書"
 
-#: cps/opds.py:317
+#: cps/opds.py
 msgid "description"
 msgstr "簡介"
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr "{} 星"
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr "搜尋"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr "登入"
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr "找不到Token"
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr "Token已過期"
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr "成功！請返回您的設備"
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr "書籍"
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr "顯示最近書籍"
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr "顯示熱門書籍"
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr "已下載書籍"
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr "顯示下載過的書籍"
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr "顯示最高評分書籍"
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Read and Unread"
 msgstr "顯示閱讀狀態"
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr "顯示未讀"
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr "發現"
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Category Section"
 msgstr "顯示分類選擇"
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Series Section"
 msgstr "顯示叢書選擇"
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Author Section"
 msgstr "顯示作者選擇"
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Publisher Section"
 msgstr "顯示出版社選擇"
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Language Section"
 msgstr "顯示語言選擇"
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Ratings Section"
 msgstr "顯示評分選擇"
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show File Formats Section"
 msgstr "顯示文件格式選擇"
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr "歸檔書籍"
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 #, fuzzy
 msgid "Show Archived Books"
 msgstr "顯示歸檔書籍"
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr "收藏"
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr "顯示收藏"
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr "書籍列表"
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr "顯示書籍列表"
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr ""
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "顯示最高評分書籍"
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr "出版時間晚於 "
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr "出版時間早於 "
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr "評分 <= %(rating)s"
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr "評分 >= %(rating)s"
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr "閱讀狀態 = %(status)s"
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr "搜詢自定義欄位時出錯，請重啟 Calibre-Web"
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr "進階搜尋"
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr "指定的書架無效"
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr "對不起，您沒有添加書籍到這個書架的權限"
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr "此書籍已經是書架 %(shelfname)s 的一部分"
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr "此書籍已被添加到書架：%(sname)s"
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr ""
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr "書籍已經在書架 %(name)s 中了"
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr "書籍已經被添加到書架 %(sname)s 中"
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr "無法添加書籍到書架：%(sname)s"
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 #, fuzzy
 msgid "Invalid series specified"
 msgstr "指定的書架無效"
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr "無法添加書籍到書架：%(sname)s"
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr "書籍已經在書架 %(name)s 中了"
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, fuzzy, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr "書籍已經被添加到書架 %(sname)s 中"
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr "此書已從書架 %(sname)s 中刪除"
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr ""
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr "創建書架"
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr "對不起，您沒有編輯這個書架的權限"
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr "編輯書架"
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr ""
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr "書架已成功刪除"
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr "修改書架 %(name)s 順序"
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr ""
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr "書架 %(title)s 已創建"
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr "書架 %(title)s 已修改"
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr "發生錯誤"
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr "公共書架：%(title)s已經存在已經存在。"
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr "私有書架：%(title)s已經存在。"
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr "書架：%(name)s"
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "打開書架出錯。書架不存在或不可訪問"
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "排除書架"
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr "馬上閱讀"
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr "閱讀 {title}"
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr "匿名"
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr "無驗證"
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr "TLS協議"
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr "SSL協議"
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr "確認"
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr "沒有"
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after their "
 "formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr "閱讀狀態"
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr "主題"
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr "淺色"
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr "深色"
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr ""
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr "添加到書架"
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr "作者"
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr "瀏覽"
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr "關閉"
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr "刪除數據"
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files from "
 "your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr "包含描述"
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr "編輯元數據"
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr "編輯 {title}"
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr "顯示所以書籍"
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr "編輯預設視圖"
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr "語言 (使用,分隔)"
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr "亮色主題"
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr "登入失敗"
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr "標記已讀"
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr "標記未讀"
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr "合併"
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr "出版社"
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr "已讀"
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr "重設"
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr "重設密碼"
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr "標題"
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr "上傳書籍"
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr "賬號"
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr "管理權限"
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr "打開你的書庫"
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr "瀏覽標籤"
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr "瀏覽你的書庫"
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr "前往上傳"
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr "打開搜尋"
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr "返回到新 UI"
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr "出版日期"
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr "來源"
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr "完成"
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole "
 "server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr "從你的書庫中隨機挑選"
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr "關於"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr "帳號設定"
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr "添加到收藏"
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr "管理員群組"
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr "進階"
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr "進階搜尋"
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr "全部書架"
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr "任何"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr "任意格式"
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr "任何語言"
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr "任何叢書"
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr "任何標籤"
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr "歸檔"
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr "歸檔"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr "返回書庫"
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr "返回經典視圖"
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr "基本配置"
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr "取消"
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr "確認刪除 {name} 標籤"
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr "刪除書籍"
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr "刪除失敗"
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr "刪除 {name} 標籤"
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr "已刪除 {name} 標籤"
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr "簡介"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr "下載書籍"
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr "編輯書籍"
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr "郵箱地址"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr "啟用Kobo同步"
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr "加密"
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr "格式"
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr "格式 — 排除"
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr "格式 — 包含"
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr "前往你的書庫"
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr "隱藏"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr "書號"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr "語言"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr "語言 — 包含"
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr "上次修改"
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr "上次同步"
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr "書庫設定"
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr "載入中"
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr "載入中..."
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr "登入類型"
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr "日誌"
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr "合併書架"
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr "標為已讀"
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr "標為未讀"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr "匹配"
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr "我的帳號"
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr "最新"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr "下一頁"
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr "最舊"
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr "密碼"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr "端口"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr "任務進度"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr "評分"
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr "評分 (星數)"
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr "閱讀狀態"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr "SSL/TLS協議"
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr "STARTTLS協議"
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr "儲存"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr "搜尋書名，作者..."
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr "選擇"
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr "發送中..."
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr "叢書目錄"
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr "叢書 — 包含"
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr "登出"
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr "登入中..."
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr "智慧書架"
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr "開始掃描..."
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr "統計儀表板"
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr "任務狀態"
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr "在 Ko-fi 上支持我們 →"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr "表格視圖"
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr "標籤"
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr "標籤"
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr "標籤 — 排除"
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr "標籤 — 包含"
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr "任務信息"
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr "任務列表"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr "書名，作者，或 ISBN"
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr "最高評分"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr "UI / 顯示設定"
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr "取消歸檔"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr "取消隱藏"
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr "無書名"
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr "上傳失敗"
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr "上傳封面"
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr "上傳書籍"
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr "用戶名稱"
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr "用戶名"
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr "查看書籍"
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr "視圖設定"
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr "你的書庫"
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr "書籍"
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr "匹配書籍"
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr "{count} 本書"
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr "{count} 本書"
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr "返回書籍"
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr "返回登入"
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr "書庫"
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr "等待中"
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr "失敗"
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr "已開始"
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr "已完成"
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr "已結束"
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr "已取消"
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr "未知狀態"
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr "讀取更新信息時出現未預期數據"
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr "無可用更新。您已經安裝了最新版本"
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the latest "
 "version."
 msgstr "有新的更新。單擊下面的按鈕以更新到最新版本。"
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr "無法獲取更新信息"
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr "點擊下面按鈕更新到最新穩定版本。"
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to version: "
 "%(version)s"
 msgstr "有新的更新。單擊下面的按鈕以更新到版本: %(version)s"
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr "無可用發佈信息"
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr "發現(隨機書籍)"
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr "熱門書籍（最多下載）"
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr "%(user)s 下載過的書籍"
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr "作者：%(name)s"
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr "出版社：%(name)s"
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr "叢書：%(serie)s"
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr ""
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr "評分：%(rating)s 星"
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr "文件格式：%(format)s"
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr "分類：%(name)s"
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr "語言：%(name)s"
 
-#: cps/web.py:1103
+#: cps/web.py
 msgid "Favorite Books"
 msgstr "收藏書籍"
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 msgid "Hidden Books"
 msgstr "隱藏書籍"
 
-#: cps/web.py:1193
+#: cps/web.py
 #, fuzzy
 msgid "Error loading magic shelf"
 msgstr "下載封面時出錯"
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 #, fuzzy
 msgid "Invalid rules format"
 msgstr "無效的郵件地址格式"
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 msgid "Invalid request"
 msgstr "無效請求"
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr ""
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach "
 "your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 #, fuzzy
 msgid "Error creating shelf"
 msgstr "下載封面時出錯"
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "創建書架"
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 #, fuzzy
 msgid "Shelf name is required"
 msgstr "此欄必須填寫"
 
-#: cps/web.py:1647
+#: cps/web.py
 #, fuzzy
 msgid "Error updating shelf"
 msgstr "下載封面時出錯"
 
-#: cps/web.py:1652
+#: cps/web.py
 #, fuzzy
 msgid "Edit Magic Shelf"
 msgstr "編輯書架"
 
-#: cps/web.py:1668
+#: cps/web.py
 msgid "Shelf not found"
 msgstr "找不到書架"
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 #, fuzzy
 msgid "Shelf duplicated successfully"
 msgstr "成功刪除 {} 個用戶"
 
-#: cps/web.py:1710
+#: cps/web.py
 #, fuzzy
 msgid "Error duplicating shelf"
 msgstr "下載封面時出錯"
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 #, fuzzy
 msgid "Error deleting shelf"
 msgstr "下載封面時出錯"
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 #, fuzzy
 msgid "Error hiding shelf"
 msgstr "下載封面時出錯"
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 #, fuzzy
 msgid "Error unhiding shelf"
 msgstr "下載封面時出錯"
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr "下載次數"
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr "文件格式列表"
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr "請先配置SMTP郵箱設定..."
 
-#: cps/web.py:2400
+#: cps/web.py
 #, fuzzy
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr "請先設置您的kindle郵箱。"
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr "書籍已經成功加入 %(eReadermail)s 的發送隊列"
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr "糟糕！發送這本書籍的時候出現錯誤：%(res)s"
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 
-#: cps/web.py:2500
+#: cps/web.py
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr "書籍已經成功加入 %(eReadermail)s 的發送隊列"
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr "註冊"
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 #, fuzzy
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr "郵件服務未配置，請聯繫網站管理員！"
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid ""
 "Oops! Email server is not configured, please contact your administrator."
 msgstr "郵件服務未配置，請聯繫網站管理員！"
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr "您的電子郵件不允許註冊"
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr "確認郵件已經發送到您的郵箱。"
 
-#: cps/web.py:2624
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please "
 "contact your administrator."
 msgstr "Calibre-Web 實例未配置，請聯繫您的系統管理員！"
 
-#: cps/web.py:2704
+#: cps/web.py
 #, fuzzy
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr "郵件服務未配置，請聯繫網站管理員！"
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 #, fuzzy
 msgid "Cannot activate LDAP authentication"
 msgstr "無法激活LDAP認證"
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr ""
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, fuzzy, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr "您現在已以“%(nickname)s”身份登入"
 
-#: cps/web.py:2775
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
 msgstr "您現在已以“%(nickname)s”身份登入"
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 #, fuzzy
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
 msgstr "Calibre-Web 實例未配置，請聯繫您的系統管理員！"
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact your "
 "administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, fuzzy, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
 "known"
 msgstr "備援登入“%(nickname)s”：無法訪問LDAP伺服器，或用戶未知"
 
-#: cps/web.py:2801
+#: cps/web.py
 #, fuzzy, python-format
 msgid "Could not login: %(message)s"
 msgstr "無法登入：%(message)s"
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 #, fuzzy
 msgid "Wrong Username or Password"
 msgstr "用戶名或密碼錯誤"
 
-#: cps/web.py:2832
+#: cps/web.py
 #, fuzzy
 msgid "New Password was sent to your email address"
 msgstr "新密碼已發送到您的郵箱"
 
-#: cps/web.py:2836
+#: cps/web.py
 #, fuzzy
 msgid "An unknown error occurred. Please try again later."
 msgstr "發生一個未知錯誤，請稍後再試。"
 
-#: cps/web.py:2838
+#: cps/web.py
 #, fuzzy
 msgid "Please enter valid username to reset password"
 msgstr "請輸入有效的用戶名進行密碼重置"
 
-#: cps/web.py:2846
+#: cps/web.py
 #, fuzzy, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr "您現在已以“%(nickname)s”身份登入"
 
-#: cps/web.py:3158
+#: cps/web.py
 #, fuzzy
 msgid "Success! Profile Updated"
 msgstr "資料已更新"
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr "使用此郵箱的賬號已經存在。"
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr "無效書籍ID"
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr ""
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr "找不到包含 OAuth 信息的有效 gmail.json 文件"
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 msgid "Preparing to send to eReader..."
 msgstr "準備發送到電子閱讀器..."
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr "檢查可用格式..."
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 msgid "Sending to eReader..."
 msgstr "發送到電子閱讀器中..."
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 msgid "Auto-send completed successfully"
 msgstr "自動發送成功"
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr "自動發送"
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr ""
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr "%(book)s 發送到電子閱讀器"
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr "沒有發現Calibre 電子書轉換器%(tool)s"
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr "硬碟上找不到 %(format)s 格式"
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr "發生未知錯誤，書籍轉換失敗"
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr "Kepubify 轉換失敗：%(error)s"
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr "找不到轉換後的文件或文件夾%(folder)s中有多個文件"
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr "Calibre 運行失敗，錯誤信息：%(error)s"
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr "電子書轉換器失敗： %(error)s"
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr "Calibre 資料庫重新連線中"
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan"
 msgstr "刪除書籍"
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Finding duplicate groups"
 msgstr "刪除書籍"
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Updating duplicate cache"
 msgstr "正在解壓更新包"
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 #, fuzzy
 msgid "Duplicate scan pending: manual scan required"
 msgstr "無搜索結果"
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 msgid "Hardcover Sync"
 msgstr "Hardcover 同步"
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr "電子信箱地址"
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr "備份元數據"
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 msgid "Convert Library"
 msgstr "轉換書庫"
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Book organizer"
 msgstr "書架上的書"
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Change sort order"
 msgstr "修改密碼"
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Select multiple books"
 msgstr "創建書架"
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 msgid "Display settings"
 msgstr "顯示設定"
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 msgid "Cover Settings"
 msgstr "封面設定"
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Selection actions"
 msgstr "選擇一個選項"
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 msgid "Add to Shelf"
 msgstr "添加到書架"
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr "(公共)"
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, fewest first"
 msgstr "下載次數"
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Downloads, most first"
 msgstr "下載次數"
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, newest first"
 msgstr "按圖書日期排序，最新優先"
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Date added, oldest first"
 msgstr "按圖書日期排序，最舊優先"
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr "書名 A → Z"
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr "書名 Z → A"
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 msgid "Author A → Z"
 msgstr "作者 A → Z"
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 msgid "Author Z → A"
 msgstr "作者 Z → A"
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 msgid "Published, newest first"
 msgstr "最新出版"
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 msgid "Published, oldest first"
 msgstr "最早出版"
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, newest first"
 msgstr "按圖書日期排序，最新優先"
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 #, fuzzy
 msgid "Added to shelf, oldest first"
 msgstr "按圖書日期排序，最舊優先"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Send to eReader Email"
 msgstr "接收書籍的Kindle郵箱地址"
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 #, fuzzy
 msgid "Send to eReader Subject"
 msgstr "發送到Kindle"
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr "查看書籍"
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr "公共書架"
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr ""
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr "導入LDAP用戶"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr "SMTP郵件服務器設置"
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr "SMTP主機名"
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr "SMTP端口"
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr "SMTP用戶名"
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr "發信人信箱"
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr "電子信箱服務"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr "通過Oauth2的Gmail"
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr "Calibre 數據庫路徑"
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr "日誌級別"
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr "擴展端口"
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr "每頁書籍數"
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr "上傳"
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr "匿名瀏覽"
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr "開放註冊"
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr "魔法連接遠程登錄"
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr "反向代理登入"
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr "反向代理標頭名稱"
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr "編輯基本配置"
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr "編輯界面配置"
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr "編輯Calibre數據庫配置"
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr ""
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Start Time"
 msgstr "已開始"
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr ""
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr ""
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr "重新連線 Calibre 資料庫"
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr ""
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr ""
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 msgid "Setup KOReader Sync"
 msgstr "設定 KOReader 同步"
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr ""
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 #, fuzzy
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr "管理"
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, IPs, "
 "and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid ""
 "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr "下載除錯包"
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr "查看日誌文件"
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr "重啟"
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr "停止"
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr ""
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr "版本"
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr "詳情"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 msgid "Update available"
 msgstr "有新的更新可用"
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 msgid "Update now"
 msgstr "立即更新"
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr "當前版本"
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr "檢查更新"
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr "執行更新"
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr "您確定要重啟嗎？"
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr "確定"
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr "您確定要關閉嗎？"
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr "正在更新，請不要刷新頁面"
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and "
@@ -7009,611 +6881,588 @@ msgid ""
 "added to your account; sideloaded books not in the library are skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It is "
 "never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 #, fuzzy
 msgid "for books not in this library (skipped)"
 msgstr "本書籍在此書庫中"
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr "正在上傳..."
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 msgid "Import failed."
 msgstr "匯入失敗"
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 msgid "Network error."
 msgstr "網路錯誤"
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr "輸出 Markdown"
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr "輸出 CSV"
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr "輸出 JSON"
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, fuzzy, python-format
 msgid "Source: %(s)s"
 msgstr "叢書：%(serie)s"
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr "通過"
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr "在書庫"
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr "減少"
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr "更多"
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr "刪除書籍"
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr "刪除格式:"
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr "轉換書籍格式:"
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr "轉換從："
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "select an option"
 msgstr "選擇一個選項"
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr "轉換到："
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr "轉換書籍"
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr "錯誤"
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr "上傳格式"
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr "叢書編號"
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr "出版日期"
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr "書號類型"
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr "書號編號"
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr "移除"
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr "添加書號"
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
 msgstr "從URL獲取封面（JPEG - 圖片將下載並存儲在數據庫中）"
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr "從本地硬碟上傳封面"
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 #, fuzzy
 msgid "Hardcover Sync Blacklist"
 msgstr "啟用Kobo同步"
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr "查看保存書籍"
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr "獲取元數據"
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr "關鍵字"
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr "搜尋關鍵字"
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr "加載中..."
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr "搜索錯誤！"
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr "無搜索結果！請嘗試另一個關鍵字。"
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr "此欄必須填寫"
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 #, fuzzy
 msgid " Exchange author & title"
 msgstr "交換作者和標題"
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 msgid "Select all"
 msgstr "選擇全部"
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr "清除全部"
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Update Title Sort automatically  "
 msgstr "自動更新書名排序"
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr "自動更新作者排序"
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr "輸入書名"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr "輸入書名排序"
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr "書名排序"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr "輸入作者排序"
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr "作者排序"
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr "輸入作者"
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr "輸入分類"
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr "輸入叢書"
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr "輸入語言"
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr "出版日期"
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr "輸入出版社"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter comments"
 msgstr "輸入網域名"
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Comments"
 msgstr "輸入網域名"
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 msgid "Archived?"
 msgstr "歸檔？"
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 msgid "Read?"
 msgstr "已讀？"
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 #, fuzzy
 msgid "Enter "
 msgstr "書號"
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr "您真的確認？"
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr "這本書籍將被合併："
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr "合併到這本書籍："
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr ""
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr ""
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr ""
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr ""
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr ""
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr "編輯元數據"
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, and "
 "Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 msgid "Select a Shelf"
 msgstr "選擇一個書架"
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr "-- 選擇一個書架 --"
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr "新增"
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid ""
 "The email server is not configured yet, so announcements cannot be sent."
 msgstr "郵件服務未配置，請聯繫網站管理員！"
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued "
 "and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 #, fuzzy
 msgid "Message"
 msgstr "合併"
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on plain-"
 "text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Select all users with an email address"
 msgstr "新密碼已發送到您的郵箱"
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 #, fuzzy
 msgid "Send test to me"
 msgstr "發送到Kindle"
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr "後退"
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was a "
 "problem mounting your Calibre Database (metadata.db), or less likely, a "
 "problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre Database "
 "while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your Calibre "
 "Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr "Calibre 數據庫路徑"
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database (<code>metadata.db</"
 "code> file) should always be somewhere in <code>/calibre-library</code>.\n"
@@ -7629,13 +7478,13 @@ msgid ""
 "wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO NOT "
 "CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're bind "
 "to to your heart's content on the left-hand side but there's no reason to\n"
@@ -7646,7 +7495,7 @@ msgid ""
 "and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7657,43 +7506,43 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr ""
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library files "
 "can be wherever you desire"
 msgstr ""
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr "是否使用Google Drive?"
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr "驗證 Google Drive"
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr "Google Drive Calibre 目錄路徑"
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr "元數據監視通道ID"
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr "撤回"
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr "Calibre 數據庫路徑"
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can attempt "
 "to restore it from the OPF files in your library. This will <b>erase all per-"
@@ -7703,129 +7552,129 @@ msgid ""
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Are you sure? This cannot be undone."
 msgstr "您確定要關閉嗎？"
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 #, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
 msgstr "Calibre 數據庫路徑"
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr "新數據庫路徑無效，請輸入有效的路徑"
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr "使用標準認證"
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr "使用LDAP認證"
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr "使用OAuth認證"
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr "伺服器配置"
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr "伺服器端口"
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL 證書文件路徑(非SSL服務器請留空)"
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr "SSL 密鑰文件路徑(非SSL服務器請留空)"
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr "更新通道"
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr "穩定版"
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr "每日夜間版"
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr ""
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr "日誌文件配置"
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr "訪問日誌路徑和名稱(默認為access.log)"
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr "啟用訪問日誌"
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr "訪問日誌路徑和名稱(默認為access.log)"
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Feature Configuration"
 msgstr "伺服器配置"
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr "儲存到硬碟時同步轉換書名與作者中的非英語字元"
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
 "Kepubify binaries)"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr "啟用上傳"
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr ""
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr "允許上傳的文件格式"
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr "允許匿名瀏覽"
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr "啟用註冊"
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr "使用郵箱或用戶名"
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr "啟用魔法連接遠程登入"
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is preserved "
 "during upgrades. When enabled, each user gets a hide button on the book "
@@ -7833,153 +7682,153 @@ msgid ""
 "affecting other users. Recovery is via the profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr "代理未知請求到Kobo商店"
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. EPUB "
 "remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr "伺服器擴展端口(用於轉發的API調用的端口)"
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers whose "
 "aspect ratio does not match the screen. Padding is applied server-side; "
 "original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr "使用Goodreads"
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr "Goodreads API Key"
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 msgid "Enable Hardcover Sync"
 msgstr "啟用 Hardcover 同步"
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid ""
 "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to enable "
 "or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. It "
 "is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token status: rejected or expired."
 msgstr "Token已過期"
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Google Books API Key"
 msgstr "Goodreads API Key"
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests / "
 "IP / day, which is easily exhausted on shared servers (HTTP 429). Free key "
@@ -7987,415 +7836,415 @@ msgid ""
 "API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr "允許反向代理認證方式"
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for authentication. "
 "This is an authentication method, distinct from the HTTPS security setting "
 "below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY if "
 "you are accessing the server via HTTPS, otherwise you will be locked out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr "登入類型"
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr "LDAP服務器主機名或IP地址"
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr "LDAP伺服器端口"
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr "LDAP 加密"
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr "LDAP CA證書路徑(僅用於客戶端證書認證)"
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr "LDAP 證書路徑(僅用於客戶端證書認證)"
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr "LDAP密鑰文件路徑(僅用於客戶端證書認證)"
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr "LDAP 驗證方式"
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr "簡單"
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr "LDAP管理員用戶名"
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr "LDAP管理員密碼"
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr "LDAP專有名稱（DN）"
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr "LDAP用戶對象過濾器"
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr "LDAP伺服器是 OpenLDAP？"
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for new "
 "users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr "用戶導入需要以下設置"
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr "LDAP群組對象過濾器"
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr "LDAP群組名"
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr "LDAP群組成員欄位"
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr "LDAP成員用戶過濾器檢測"
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr "自動檢測"
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr "自定義過濾器"
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr "LDAP成員用戶過濾器"
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If you "
 "are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Metadata"
 msgstr "獲取元數據"
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of using "
 "auto-discovery"
 msgstr ""
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Manual Endpoint Configuration"
 msgstr "編輯界面配置"
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Token Endpoint"
 msgstr "找不到Token"
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Test Connection"
 msgstr "連接錯誤"
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Scopes"
 msgstr "OAuth設置"
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid redirect "
 "URI\" errors. Include protocol (https://). Leave empty to use automatic "
 "detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Id"
 msgstr "%(provider)s OAuth 客戶端Id"
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Client Secret"
 msgstr "%(provider)s OAuth 客戶端密鑰"
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Field Mapping Configuration"
 msgstr "查看配置"
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Username Field"
 msgstr "用戶名"
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr ""
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Email Field"
 msgstr "電子郵件服務"
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr ""
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "OAuth Group Claim"
 msgstr "LDAP群組名"
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- or "
 "space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one allowed "
 "group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic OAuth. "
 "Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr ""
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to disable "
 "group-based admin management, or use the global setting in Security Settings "
 "for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr "新用戶默認權限設置"
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr "允許下載書籍"
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr "允許在線閱讀"
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr "允許上傳書籍"
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr "允許編輯書籍"
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr "允許刪除書籍"
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr "允許修改密碼"
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr "允許編輯公共書架"
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic "
 "OAuth. Admin group membership still grants admin privileges when OAuth group-"
 "based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr ""
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr "獲取 %(provider)s OAuth憑證"
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr "%(provider)s OAuth 客戶端Id"
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr "%(provider)s OAuth 客戶端密鑰"
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr "擴展程序配置"
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Path to Calibre Binaries"
 msgstr "Calibre 電子書轉換器路徑"
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Calibre E-Book Converter Settings"
 msgstr "Calibre 電子書轉換器設置"
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr "Kepubify 電子書轉換器路徑"
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Location of Unrar binary"
 msgstr "UnRar程序路徑"
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 msgid "Security Settings"
 msgstr "安全設定"
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. Ensure "
 "you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based on "
 "OAuth group membership. Disable this to manually manage admin roles in the "
@@ -8403,335 +8252,330 @@ msgid ""
 "assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr ""
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr ""
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr ""
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "Session protection"
 msgstr "選擇一個選項"
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr ""
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr ""
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 #, fuzzy
 msgid "User Password policy"
 msgstr "重置用戶密碼"
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr ""
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr ""
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr "查看配置"
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr "隨機書籍顯示數量"
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr "主頁中書籍作者的最大顯示數量（0=不隱藏）"
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set to "
 "0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 msgid "Default Theme"
 msgstr "預設主題"
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr "黑暗主題"
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select their "
 "own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr "可忽略的自定義欄位（正則表達式）"
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr "選擇自定義欄位作為閱讀狀態"
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr "選擇自定義欄位作為閱讀狀態"
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr "選擇自定義欄位作為書籍可見性"
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid ""
 "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr "按規則提取書名後排序（正則表達式）"
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Site Customization"
 msgstr "查看配置"
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each "
 "user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 msgid "Custom CSS"
 msgstr "自定義 CSS"
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the built-"
 "in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr "新用戶默認權限設置"
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Permissions"
 msgstr "版本"
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr "管理員用戶"
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 msgid "Language & Display"
 msgstr "語言 & 顯示"
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr "預設語言"
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default interface language for new users."
 msgstr "新用戶默認權限設置"
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default Visible Language of Books"
 msgstr "按預設語言顯示書籍"
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 #, fuzzy
 msgid "Default book language filter for new users."
 msgstr "新用戶默認顯示權限"
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= override. "
 "Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr "新用戶默認顯示權限"
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr "在主頁顯示隨機書籍"
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr "添加顯示或隱藏書籍的標籤值"
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr "添加顯示或隱藏書籍的自定義欄位值"
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 msgid "Upload a file"
 msgstr "上傳檔案"
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run Archive"
 msgstr "歸檔"
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 msgid "Download Log"
 msgstr "下載日誌"
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr "開始"
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook files "
 "themselves for every book in your library, so the files on disk always match "
@@ -8740,14 +8584,14 @@ msgid ""
 "Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the NextGen "
 "Cover & Metadata Enforcement service either here in the Web UI or through "
 "the CLI, you will see the output of the most recent previous run below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever you "
 "want to check on the run's progress. If you wish to cancel a run that is "
@@ -8755,96 +8599,95 @@ msgid ""
 "terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Run on selected book"
 msgstr "合併選中的書籍"
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer scheduled successfully"
 msgstr "成功刪除 {} 個用戶"
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error scheduling EPUB Fixer"
 msgstr "下載封面時出錯"
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "No matches found"
 msgstr "無搜索結果"
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Enter a search term"
 msgstr "輸入用戶名"
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Failed to search library"
 msgstr "搜索書庫"
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Select a book first"
 msgstr "創建書架"
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "EPUB Fixer started for selected book"
 msgstr "合併選中的書籍"
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 #, fuzzy
 msgid "Error starting EPUB Fixer"
 msgstr "下載封面時出錯"
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr "Calibre-Web 日誌: "
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8852,11 +8695,11 @@ msgid ""
 "below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -8867,11 +8710,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files processed "
 "by NextGen will be checked and fixed to ensure maximum \n"
@@ -8881,162 +8724,162 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-fix.netlify.app/"
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which can "
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Archived Book Cleanup"
 msgstr "歸檔書籍"
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply metadata "
 "(title, author, description, cover, etc.) for newly ingested books using the "
@@ -9044,11 +8887,11 @@ msgid ""
 "book information, especially for books with poor or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it appears "
 "to be better quality (e.g., longer descriptions, higher resolution covers). "
@@ -9056,110 +8899,108 @@ msgid ""
 "preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Metadata Fields to Update"
 msgstr "已成功更新元數據"
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. Unchecked "
 "fields will never be modified during automatic metadata fetching, preserving "
 "your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
 msgstr "書號"
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Cover Image"
 msgstr "發現"
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
 "investigation."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes apply "
 "on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9167,157 +9008,157 @@ msgid ""
 "their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Hardcover Auto-Fetch Settings"
 msgstr "OAuth設置"
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in your "
 "docker-compose environment variables or configure a global token in Basic "
 "Configuration. Without a valid token, this feature will remain disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer "
 "auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce API "
 "load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and protects "
 "your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin panel "
 "at any time. Check the NextGen Stats page to see progress and review queued "
 "matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Web UI Settings"
 msgstr "設置"
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new version "
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic updates"
 msgstr "OAuth設置"
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a container "
@@ -9325,103 +9166,102 @@ msgid ""
 "a new image and swaps NextGen in safely, leaving your other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
 "interval checks once a day; \"cleanup\" removes the old image after each "
 "update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a "
 "setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "同步所選書架到 Kobo"
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "OAuth設置"
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -9429,44 +9269,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "轉換書籍格式:"
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -9474,2362 +9314,2336 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "啟用註冊"
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "OAuth設置"
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "啟用註冊"
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "啟用註冊"
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge Formats"
 msgstr "合併格式"
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "獲取元數據"
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "評分"
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr "下一個"
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or try "
 "again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like "
 "unmarked mail. The network edge briefly sees your IP to stop spam; we only "
 "use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr "標為未讀"
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr "標為已讀"
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 msgid "Marked as read"
 msgstr "已標為已讀"
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 msgid "Marked as unread"
 msgstr "已標為未讀"
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 msgid "Added to favorites"
 msgstr "已添加到收藏"
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Removed from favorites"
 msgstr "已從收藏中移除"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr "從歸檔檔案還原"
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr "添加到歸檔"
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 msgid "Restored from archive"
 msgstr "已從歸檔檔案還原"
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Hide from your library"
 msgstr "從你的書庫隱藏"
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr "取消隱藏"
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating updated"
 msgstr "郵件服務器設置已更新"
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Rating cleared"
 msgstr "評分大於"
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr "%(range)s 第%(index)s冊"
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr ""
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr "簡介:"
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Select eReader Email Addresses"
 msgstr "接收書籍的Kindle郵箱地址"
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Choose email addresses:"
 msgstr "接收書籍的Kindle郵箱地址"
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 msgid "Select All"
 msgstr "選擇全部"
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 msgid "Select format:"
 msgstr "選擇格式："
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update tags"
 msgstr "創建封面路徑失敗"
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 #, fuzzy
 msgid "Failed to update shelves"
 msgstr "創建封面路徑失敗"
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr ""
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Run Full Duplicate Scan"
 msgstr "刪除書籍"
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Scan for Duplicates Now"
 msgstr "顯示最高評分書籍"
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Select None"
 msgstr "選擇"
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Delete Selected"
 msgstr "合併選中的書籍"
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during imports "
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Duplicate scan is running."
 msgstr "刪除書籍"
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and deleting "
 "others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate Format "
 "Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Preview"
 msgstr "上一個"
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Merge Selected"
 msgstr "合併選中的書籍"
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 msgid "View book details"
 msgstr "顯示書籍詳情"
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 msgid "Edit book metadata"
 msgstr "編輯書籍元數據"
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 msgid "Archive/delete book"
 msgstr "歸檔/刪除書籍"
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "No Duplicate Books Found"
 msgstr "無搜索結果"
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid false "
 "positives."
 msgstr ""
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "Selected strategy:"
 msgstr "刪除格式:"
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be permanently deleted:"
 msgstr "此書籍將從數據庫中永久刪除"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Merge Books"
 msgstr "合併書籍"
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following book will be kept:"
 msgstr "此書籍將從數據庫中永久刪除"
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 #, fuzzy
 msgid "The following books will be merged into it (and then deleted):"
 msgstr "此書籍將從數據庫中永久刪除"
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr ""
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr ""
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr ""
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr "選擇伺服器類型"
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Standard Email Account"
 msgstr "使用標準電子郵件賬號"
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr "Gmail 帳號"
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr "設定 Gmail 帳號"
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr "撤消 Gmail 訪問權限"
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr "SMTP密碼"
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent as "
 "plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr "附件大小限制"
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 #, fuzzy
 msgid "Save and Send Test Email"
 msgstr "保存設置並發送測試郵件"
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr "允許註冊的網域名（白名單)"
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr "添加網域名"
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr "輸入網域名"
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr "禁止註冊的網域名（黑名單）"
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
 msgstr "在文本編輯器中打開.kobo/Kobo/Kobo eReader.conf，添加（或編輯）:"
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr "Kobo Token"
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr "列表"
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will "
 "appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr "返回管理面板"
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each match "
 "and select the correct result, or skip/reject if no good match exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 msgid "Reject All Pending"
 msgstr "拒絕全部"
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Search Query"
 msgstr "搜索項："
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr "匹配原因"
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 msgid "View on Hardcover"
 msgstr "在 Hardcover 查看"
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr "選擇此匹配"
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 msgid "Reject All"
 msgstr "拒絕全部"
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 msgid "Processing..."
 msgstr "處理中..."
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
 msgstr "您確定要修改選定用戶的選定角色嗎？"
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid "Failed to reject match"
 msgstr "創建封面路徑失敗"
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 #, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr "您確定要修改選定用戶的選定角色嗎？"
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Pending"
 msgstr "✗ 拒絕全部"
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject all pending matches"
 msgstr "拒絕所有匹配失敗"
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 #, fuzzy
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr "Calibre-Web 實例未配置，請聯繫您的系統管理員！"
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr "創建問題"
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr "回到首頁"
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr "登出賬號"
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 #, fuzzy
 msgid "Edit shelf rules"
 msgstr "編輯書架"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr "在側邊欄隱藏此書架"
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Show this shelf in your sidebar"
 msgstr "在側邊欄顯示此書架"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 msgid "Show Shelf"
 msgstr "顯示書架"
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 msgid "Hide Shelf"
 msgstr "隱藏書架"
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 msgid "Add Series to Shelf"
 msgstr "添加叢書到書架"
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr "KOReader 同步已禁用"
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr "開啟 NextGen 設定"
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr "首頁"
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr "切換導航"
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr "搜索書庫"
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr "切換到新 Calibre-Web NextGen 介面"
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr "切換到新 UI"
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr "登出"
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 msgid "Settings"
 msgstr "設定"
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 msgid "Refresh Library"
 msgstr "重整書庫"
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 msgid "New interface available"
 msgstr "有新介面可用"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr "新的 Calibre-Web NextGen 介面已就緒"
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr "嘗試新UI"
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr "查看更新日志"
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 msgid "Open Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr "請不要重整頁面"
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 msgid "Create Shelf"
 msgstr "創建書架"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr "上一個"
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr "書籍詳情"
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "您確定要關閉嗎？"
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Will be deleted"
 msgstr "合併選中的書籍"
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 msgid "Formats:"
 msgstr "格式"
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "刪除格式:"
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "刪除書籍"
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "無搜索結果"
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr "稍後提醒我"
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 msgid "Scroll to top"
 msgstr "滑動到最頂部"
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 #, fuzzy
 msgid "Top"
 msgstr "到："
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 msgid "Confirm"
 msgstr "確認"
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "已添加 {n} 本書到 {shelf}"
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "合併選中的書籍"
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "標為未讀"
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Deleted {n} books"
 msgstr "已刪除 {n} 本書"
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 msgid "Delete books?"
 msgstr "刪除書籍？"
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 msgid "Select at least one book first."
 msgstr "首先至少選擇一本書。"
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Request failed: {err}"
 msgstr "請求錯誤：{err}"
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr ""
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr ""
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 msgid "Show Password"
 msgstr "顯示密碼"
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr "記住我"
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr "忘記密碼？"
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 #, fuzzy
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr "通過魔法連接登入"
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 msgid "Log in with SSO"
 msgstr "通過 SSO 連接登入"
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr "顯示Calibre-Web日誌： "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Calibre-Web Log: "
 msgstr "Calibre-Web日誌： "
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr "輸出流，無法顯示"
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr "顯示訪問日誌： "
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr "下載Calibre-Web日誌"
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr "下載訪問日誌"
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 #, fuzzy
 msgid "Share with Everyone (Public)"
 msgstr "書架將被公開"
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr "選擇標籤值顯示或隱藏書籍"
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr "選擇自定義欄目值顯示或隱藏本用戶書籍"
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr "選擇標籤值顯示或隱藏書籍"
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr "選擇自定義欄目值顯示或隱藏本用戶書籍"
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr "輸入標籤"
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr "添加顯示或隱藏書籍的值"
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr "此書籍格式將從數據庫中永久刪除"
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr "此書籍將從數據庫中永久刪除"
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr "，包括從硬碟中"
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr "Kobo 重要說明：被刪除的書籍將保留在任何配對的 Kobo 設備上。"
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can safely "
 "be deleted."
 msgstr "必須先將書籍存檔並同步設備，然後才能安全地刪除書籍。"
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr "選擇文件位置"
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr "類型"
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr "名稱"
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr "大小"
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr "父目錄"
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr "完成"
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 #, fuzzy
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr "Caliebre-Web電子書路徑"
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr "epub閱讀器"
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 msgid "Annotations"
 msgstr "註解"
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr "打開註解頁"
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr "黑色"
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr "字體大小"
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 msgid "Text margin"
 msgstr "文字邊距"
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr "字體"
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 msgid "Default"
 msgstr "預設"
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr "正黑體"
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr "宋體"
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 msgid "KaiTi"
 msgstr "標楷體"
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 #, fuzzy
 msgid "Arial"
 msgstr "垂直"
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 #, fuzzy
 msgid "Spread"
 msgstr "已讀"
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 #, fuzzy
 msgid "Two columns"
 msgstr "無效的閱讀列"
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 #, fuzzy
 msgid "One column"
 msgstr "無效的閱讀列"
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr "打開側欄時重排文本。"
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr "Comic閱讀器"
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr "快捷鍵"
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr "上一頁"
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr "下一頁"
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page Display"
 msgstr "管理頁"
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr "縮放到最佳"
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr "按寬度縮放"
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr "按高度縮放"
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr "縮放到原始大小"
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr "向右旋轉"
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr "向左旋轉"
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr "翻轉圖片"
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr "顯示"
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Single Page"
 msgstr "管理頁"
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr ""
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr "縮放"
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr "最佳"
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr "寬度"
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr "高度"
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr "原始"
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr "旋轉"
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr "翻轉"
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr "水平"
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr "垂直"
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 msgid "Direction"
 msgstr "方向"
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr "從左到右"
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr "從右到左"
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Reset to Top"
 msgstr "回到首頁"
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 #, fuzzy
 msgid "Remember Position"
 msgstr "記住我"
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr "工具欄"
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr "顯示"
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr "DJVU閱讀器"
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr "PDF閱讀器"
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr "txt閱讀器"
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr "註冊新賬號"
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr "選擇一個用戶名"
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr "您的郵箱地址"
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr "魔法連接 - 授權新設備"
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr "在另一個設備上，登入並訪問："
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr "驗證後，您將自動在新設備上登入。"
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr "此驗證連接將在10分鐘後失效。"
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr ""
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr "無搜索結果"
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr "搜索項："
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr "結果："
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr "出版日期從"
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr "出版日期到"
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr "空"
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr "排除標籤"
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr "排除叢書"
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr "排除書架"
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr "排除語言"
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr "擴展名"
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr "排除擴展名"
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr "評分大於"
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr "評分小於"
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr "從："
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr "到："
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr "刪除此書架"
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr "編輯書架屬性"
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 msgid "Add Books"
 msgstr "新增書籍"
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr "手動排列書籍排列順序"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr "禁止改變順序"
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr "允許改變順序"
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, python-format
 msgid "%(count)s selected"
 msgstr "選中 %(count)s"
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, python-format
 msgid "Add %(count)s"
 msgstr "新增 %(count)s"
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 msgid "No books found."
 msgstr "找不到書籍"
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 msgid "Already on this shelf"
 msgstr "已經在此書架"
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 msgid "Add books to"
 msgstr "添加到書架"
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 msgid "Search your library…"
 msgstr "搜尋你的書庫..."
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 msgid "Search your library"
 msgstr "搜尋你的書庫"
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr "書架將被公開"
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr "同步這個書架到 Kobo device"
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr "排序已保存"
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 msgid "Shelf order"
 msgstr "書架排序"
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr "隱藏書籍"
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr "排序方式"
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr "書庫統計"
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr "本書籍在此書庫中"
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr "作者在此書庫中"
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr "分類在此書庫中"
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr "叢書在此書庫中"
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr "系統統計"
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 #, fuzzy
 msgid "Program"
 msgstr "任務進度"
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr "已安裝版本"
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr "運行時間"
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr ""
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr "排定時間"
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 msgid "State"
 msgstr "任務狀態"
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr "類型"
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid ""
 "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
 msgstr ""
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 #, fuzzy
 msgid "Scheduled item cancelled successfully"
 msgstr "成功刪除 {} 個用戶"
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 msgid "Update Calibre-Web NextGen"
 msgstr "更新 Calibre-Web NextGen"
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, and "
 "your library, settings and reading progress are safe — they live in your "
 "mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options you "
 "started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your usual "
 "docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update (check "
 "for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin "
 "from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web NextGen "
 "→ Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the container → "
 "Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "Your Profile"
 msgstr "個人檔案"
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "User Settings"
 msgstr "使用者設定"
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr "帳號資訊"
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid ""
 "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr "重置用戶密碼"
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 msgid "eReader Configuration"
 msgstr "電子閱讀器配置"
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 msgid "Send to eReader Email Address"
 msgstr "發送電子閱讀器郵箱地址"
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses with "
 "commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to "
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr "自動發送新書到電子閱讀器"
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr "語言 & 主題選擇"
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 msgid "Interface Language"
 msgstr "介面語言"
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr "按語言顯示書籍"
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Book Language Filter"
 msgstr "無有效書籍語言"
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr "OAuth & API 整合"
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr "OAuth設定"
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr "連線"
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr "取消連線"
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr "Hardcover API Token"
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr "Kobo 同步 Token"
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr "新建或查看"
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr "重新發送一本書到 Kobo"
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr "重新發送"
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next "
 "sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr "僅同步所選書架中的書籍到 Kobo"
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Expose only books in selected shelves to OPDS"
 msgstr "僅同步所選書架中的書籍到 Kobo"
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 msgid "Sidebar Display Settings"
 msgstr "側欄顯示設定"
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "添加顯示或隱藏書籍的自定義欄位值"
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Magic Shelves Order"
 msgstr "同步所選書架到 Kobo"
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr "排序模式"
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr "手動 (拖曳來排序)"
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr "按名稱排序 (A-Z)"
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr "按名稱排序 (Z-A)"
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr "按書籍數量排序（由多到少）"
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr "按書籍數量排序（由少到多）"
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr "按建立時間 (最新)"
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr "按建立時間 (最舊)"
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 msgid "Recently modified"
 msgstr "最近修改"
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr "預設系統書架"
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Public Shelves:"
 msgstr "編輯公共書架"
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr "刪除此用戶"
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only support "
 "HTTP Basic auth. Create an app password here, label it for the device "
@@ -11837,156 +11651,156 @@ msgid ""
 "app password at any time without affecting your active web session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 msgid "New app password"
 msgstr "新 app 密碼"
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it again."
 msgstr "為 %(label)s 創建 App 密碼。請複製密碼，將不再可見"
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr "新 App 密碼 (cleartext)"
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr "例如：Kobo Forma，KOReader iPad"
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 msgid "Create app password"
 msgstr "建立 app 密碼"
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr "標籤"
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 #, fuzzy
 msgid "Created"
 msgstr "新建或查看"
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr "上次使用"
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr "永不"
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr "生成Kobo Auth 地址"
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr "可見"
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr "選擇..."
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr "刪除選取選項"
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr "編輯用戶"
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr "輸入用戶名"
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter Email"
 msgstr "測試郵件"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email"
 msgstr "接收書籍的Kindle郵箱地址"
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email"
 msgstr "測試郵件"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Enter eReader Email Subject"
 msgstr "接收書籍的Kindle郵箱地址"
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "eReader Email Subject"
 msgstr "測試郵件"
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr "本地化"
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr "可見數據語言"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr "編輯允許標籤"
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr "允許標籤"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr "編輯拒絕標籤"
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr "拒絕標籤"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr "編輯顯示欄目值"
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr "顯示欄目值"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr "編輯隱藏欄目值"
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr "隱藏欄目值"
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr "修改密碼"
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr "編輯公共書架"
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr "同步所選書架到 Kobo"
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Expose selected Shelves to OPDS"
 msgstr "同步所選書架到 Kobo"
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 #, fuzzy
 msgid "Show Read/Unread Section"
 msgstr "顯示已讀/未讀選擇"

--- a/messages.pot
+++ b/messages.pot
@@ -19,1744 +19,1716 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: cps/about.py:59 cps/spa_strings.py:884
+#: cps/about.py cps/spa_strings.py
 msgid "Statistics"
 msgstr ""
 
-#: cps/admin.py:157
+#: cps/admin.py
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
 
-#: cps/admin.py:208
+#: cps/admin.py
 msgid "Server restarted, please reload page."
 msgstr ""
 
-#: cps/admin.py:210
+#: cps/admin.py
 msgid "Performing Server shutdown, please close window."
 msgstr ""
 
-#: cps/admin.py:218
+#: cps/admin.py
 msgid "Success! Database Reconnected"
 msgstr ""
 
-#: cps/admin.py:221
+#: cps/admin.py
 msgid "Unknown command"
 msgstr ""
 
-#: cps/admin.py:232
+#: cps/admin.py
 msgid "Success! Books queued for Metadata Backup, please check Tasks for result"
 msgstr ""
 
-#: cps/admin.py:246
+#: cps/admin.py
 msgid ""
 "Error: Hardcover sync is disabled. Enable it in Basic Configuration or "
 "with HARDCOVER_SYNC_ENABLED."
 msgstr ""
 
-#: cps/admin.py:254
+#: cps/admin.py
 msgid ""
 "Error: No Hardcover token available. Set HARDCOVER_TOKEN environment "
 "variable or configure in Basic Configuration."
 msgstr ""
 
-#: cps/admin.py:282
+#: cps/admin.py
 msgid ""
 "Success! Hardcover auto-fetch task started. Check Tasks panel for "
 "progress."
 msgstr ""
 
-#: cps/admin.py:287
+#: cps/admin.py
 #, python-format
 msgid "Error starting Hardcover auto-fetch task: %(error)s"
 msgstr ""
 
-#: cps/admin.py:326 cps/templates/admin.html:225
+#: cps/admin.py cps/templates/admin.html
 msgid "Review Hardcover Matches"
 msgstr ""
 
-#: cps/admin.py:333
+#: cps/admin.py
 #, python-format
 msgid "Error loading review queue: %(error)s"
 msgstr ""
 
-#: cps/admin.py:414
+#: cps/admin.py
 msgid "Hardcover ID applied successfully"
 msgstr ""
 
-#: cps/admin.py:431
+#: cps/admin.py
 #, python-format
 msgid "Match %(action)s"
 msgstr ""
 
-#: cps/admin.py:469
+#: cps/admin.py
 msgid "No pending matches to reject"
 msgstr ""
 
-#: cps/admin.py:475
+#: cps/admin.py
 #, python-format
 msgid "Rejected %(count)s match(es)"
 msgstr ""
 
-#: cps/admin.py:512
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Thumbnail cache refresh started for {} book(s). This may take a few "
 "minutes."
 msgstr ""
 
-#: cps/admin.py:514
+#: cps/admin.py
 msgid "No books with covers found to process."
 msgstr ""
 
-#: cps/admin.py:526
+#: cps/admin.py
 #, python-brace-format
 msgid "Failed to start thumbnail refresh: {}"
 msgstr ""
 
-#: cps/admin.py:633
+#: cps/admin.py
 msgid "Admin page"
 msgstr ""
 
-#: cps/admin.py:653
+#: cps/admin.py
 msgid "Hardcover token expires"
 msgstr ""
 
-#: cps/admin.py:661
+#: cps/admin.py
 msgid "Basic Configuration"
 msgstr ""
 
-#: cps/admin.py:699
+#: cps/admin.py
 msgid "UI Configuration"
 msgstr ""
 
-#: cps/admin.py:723 cps/admin.py:1500 cps/db.py:1575 cps/search.py:153
-#: cps/web.py:702 cps/web.py:1032
+#: cps/admin.py cps/db.py cps/search.py cps/web.py
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 
-#: cps/admin.py:741 cps/templates/admin.html:55
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Users"
 msgstr ""
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:459
-#: cps/templates/grid.html:14 cps/templates/list.html:19
+#: cps/admin.py cps/opds.py cps/spa_strings.py cps/templates/grid.html
+#: cps/templates/list.html
 msgid "All"
 msgstr ""
 
-#: cps/admin.py:812 cps/admin.py:2222
+#: cps/admin.py
 msgid "User not found"
 msgstr ""
 
-#: cps/admin.py:826
+#: cps/admin.py
 #, python-brace-format
 msgid "{} users deleted successfully"
 msgstr ""
 
-#: cps/admin.py:849 cps/api/options.py:52
-#: cps/templates/config_view_edit.html:186 cps/templates/user_edit.html:270
-#: cps/templates/user_edit.html:292 cps/templates/user_table.html:81
+#: cps/admin.py cps/api/options.py cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Show All"
 msgstr ""
 
-#: cps/admin.py:873 cps/admin.py:879
+#: cps/admin.py
 msgid "Malformed request"
 msgstr ""
 
-#: cps/admin.py:891 cps/admin.py:3167
+#: cps/admin.py
 msgid "Guest Name can't be changed"
 msgstr ""
 
-#: cps/admin.py:911
+#: cps/admin.py
 msgid "Guest can't have this role"
 msgstr ""
 
-#: cps/admin.py:923 cps/admin.py:2992
+#: cps/admin.py
 msgid "No admin user remaining, can't remove admin role"
 msgstr ""
 
-#: cps/admin.py:927 cps/admin.py:941
+#: cps/admin.py
 msgid "Value has to be true or false"
 msgstr ""
 
-#: cps/admin.py:929
+#: cps/admin.py
 msgid "Invalid role"
 msgstr ""
 
-#: cps/admin.py:933
+#: cps/admin.py
 msgid "Guest can't have this view"
 msgstr ""
 
-#: cps/admin.py:943
+#: cps/admin.py
 msgid "Invalid view"
 msgstr ""
 
-#: cps/admin.py:946
+#: cps/admin.py
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 
-#: cps/admin.py:950
+#: cps/admin.py
 msgid "No Valid Locale Given"
 msgstr ""
 
-#: cps/admin.py:961
+#: cps/admin.py
 msgid "No Valid Book Language Given"
 msgstr ""
 
-#: cps/admin.py:963 cps/editbooks.py:689
+#: cps/admin.py cps/editbooks.py
 msgid "Parameter not found"
 msgstr ""
 
-#: cps/admin.py:983 cps/admin.py:2153
+#: cps/admin.py
 msgid "Settings DB is not Writeable"
 msgstr ""
 
-#: cps/admin.py:1029
+#: cps/admin.py
 msgid ""
 "The title-sort rule was saved, but reordering the existing library failed"
 " — books may keep their previous order until you retry or edit them."
 msgstr ""
 
-#: cps/admin.py:1034
+#: cps/admin.py
 msgid "Invalid Read Column"
 msgstr ""
 
-#: cps/admin.py:1040
+#: cps/admin.py
 msgid "Invalid Restricted Column"
 msgstr ""
 
-#: cps/admin.py:1069 cps/admin.py:2848
+#: cps/admin.py
 msgid "Calibre-Web NextGen configuration updated"
 msgstr ""
 
-#: cps/admin.py:1081
+#: cps/admin.py
 msgid "Do you really want to delete the Kobo Token?"
 msgstr ""
 
-#: cps/admin.py:1083
+#: cps/admin.py
 msgid "Do you really want to delete this domain?"
 msgstr ""
 
-#: cps/admin.py:1085
+#: cps/admin.py
 msgid "Do you really want to delete this user?"
 msgstr ""
 
-#: cps/admin.py:1087
+#: cps/admin.py
 msgid "Are you sure you want to delete this shelf?"
 msgstr ""
 
-#: cps/admin.py:1089
+#: cps/admin.py
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1091
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change visible book languages for selected "
 "user(s)?"
 msgstr ""
 
-#: cps/admin.py:1093
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected role for the selected "
 "user(s)?"
 msgstr ""
 
-#: cps/admin.py:1095
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected restrictions for the "
 "selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1097
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change the selected visibility restrictions for "
 "the selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:1100
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change shelf sync behavior for the selected "
 "user(s)?"
 msgstr ""
 
-#: cps/admin.py:1102
+#: cps/admin.py
 msgid ""
 "Are you sure you want to change OPDS shelf exposure for the selected "
 "user(s)?"
 msgstr ""
 
-#: cps/admin.py:1104
+#: cps/admin.py
 msgid "Are you sure you want to change Calibre library location?"
 msgstr ""
 
-#: cps/admin.py:1106
+#: cps/admin.py
 msgid ""
 "Calibre-Web NextGen will search for updated Covers and update Cover "
 "Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:1109
+#: cps/admin.py
 msgid ""
 "Are you sure you want delete Calibre-Web NextGen's sync database to force"
 " a full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:1353 cps/admin.py:1359 cps/admin.py:1369 cps/admin.py:1379
-#: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
-#: cps/templates/user_table.html:58
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Deny"
 msgstr ""
 
-#: cps/admin.py:1355 cps/admin.py:1361 cps/admin.py:1371 cps/admin.py:1381
-#: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
-#: cps/templates/user_table.html:61
+#: cps/admin.py cps/templates/modal_dialogs.html cps/templates/user_table.html
 msgid "Allow"
 msgstr ""
 
-#: cps/admin.py:1414
+#: cps/admin.py
 #, python-brace-format
 msgid "{} sync entries deleted"
 msgstr ""
 
-#: cps/admin.py:1434
+#: cps/admin.py
 #, python-brace-format
 msgid "Book {} not found"
 msgstr ""
 
-#: cps/admin.py:1444
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Cleared sync state for book {0} (user {1}); the device will re-receive "
 "the book on next sync"
 msgstr ""
 
-#: cps/admin.py:1447
+#: cps/admin.py
 #, python-brace-format
 msgid ""
 "Book {0} was not in the sync record for user {1}; last_modified bumped so"
 " the device will receive on next sync"
 msgstr ""
 
-#: cps/admin.py:1491 cps/api/browse.py:97 cps/api/browse.py:170
-#: cps/spa_strings.py:84
+#: cps/admin.py cps/api/browse.py cps/spa_strings.py
 msgid "Tag not found"
 msgstr ""
 
-#: cps/admin.py:1509
+#: cps/admin.py
 msgid "Invalid Action"
 msgstr ""
 
-#: cps/admin.py:1636
+#: cps/admin.py
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr ""
 
-#: cps/admin.py:1793
+#: cps/admin.py
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:1799
+#: cps/admin.py
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:1834
+#: cps/admin.py
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 
-#: cps/admin.py:1840
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr ""
 
-#: cps/admin.py:1843
+#: cps/admin.py
 msgid "Please Enter a LDAP Service Account"
 msgstr ""
 
-#: cps/admin.py:1848
+#: cps/admin.py
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1850
+#: cps/admin.py
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1854
+#: cps/admin.py
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1856
+#: cps/admin.py
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1863
+#: cps/admin.py
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1865
+#: cps/admin.py
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1872
+#: cps/admin.py
 msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please "
 "Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:1905 cps/templates/admin.html:57
+#: cps/admin.py cps/templates/admin.html
 msgid "Add New User"
 msgstr ""
 
-#: cps/admin.py:1920 cps/templates/admin.html:105
-#: cps/templates/broadcast_email.html:9
+#: cps/admin.py cps/templates/admin.html cps/templates/broadcast_email.html
 msgid "Edit Email Server Settings"
 msgstr ""
 
-#: cps/admin.py:1939
+#: cps/admin.py
 msgid "Success! Gmail Account Verified."
 msgstr ""
 
-#: cps/admin.py:1963 cps/admin.py:1966 cps/admin.py:2575 cps/admin.py:2819
-#: cps/admin.py:2949 cps/admin.py:3210 cps/editbooks.py:1181
-#: cps/editbooks.py:2072 cps/shelf.py:148 cps/shelf.py:226 cps/shelf.py:297
-#: cps/shelf.py:332 cps/shelf.py:389 cps/shelf.py:464 cps/shelf.py:547
-#: cps/shelf.py:672 cps/tasks/convert.py:164 cps/web.py:3169
+#: cps/admin.py cps/editbooks.py cps/shelf.py cps/tasks/convert.py cps/web.py
 #, python-format
 msgid "Oops! Database Error: %(error)s."
 msgstr ""
 
-#: cps/admin.py:1973
+#: cps/admin.py
 #, python-format
 msgid "Test e-mail queued for sending to %(email)s, please check Tasks for result"
 msgstr ""
 
-#: cps/admin.py:1976
+#: cps/admin.py
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr ""
 
-#: cps/admin.py:1978
+#: cps/admin.py
 msgid "Please configure your e-mail address first..."
 msgstr ""
 
-#: cps/admin.py:1980
+#: cps/admin.py
 msgid "Email Server Settings updated"
 msgstr ""
 
-#: cps/admin.py:2020 cps/templates/admin.html:106
+#: cps/admin.py cps/templates/admin.html
 msgid "Email Your Users"
 msgstr ""
 
-#: cps/admin.py:2046
+#: cps/admin.py
 msgid "Please configure the email server under Edit Email Server Settings first."
 msgstr ""
 
-#: cps/admin.py:2051
+#: cps/admin.py
 msgid "Please enter a subject for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2054
+#: cps/admin.py
 msgid "Please enter a message body for the announcement email."
 msgstr ""
 
-#: cps/admin.py:2060
+#: cps/admin.py
 msgid "Please set an email address on your own account first..."
 msgstr ""
 
-#: cps/admin.py:2073
+#: cps/admin.py
 msgid "Please select at least one recipient."
 msgstr ""
 
-#: cps/admin.py:2079
+#: cps/admin.py
 msgid "No valid recipients — nothing was sent."
 msgstr ""
 
-#: cps/admin.py:2083
+#: cps/admin.py
 #, python-format
 msgid "Test announcement email queued to %(email)s — check Tasks for the result."
 msgstr ""
 
-#: cps/admin.py:2087
+#: cps/admin.py
 #, python-format
 msgid ""
 "Announcement email queued for %(num)s recipient(s) — check Tasks for "
 "delivery."
 msgstr ""
 
-#: cps/admin.py:2089
+#: cps/admin.py
 #, python-format
 msgid "%(num)s address(es) were skipped as invalid or duplicate."
 msgstr ""
 
-#: cps/admin.py:2112 cps/templates/admin.html:202
+#: cps/admin.py cps/templates/admin.html
 msgid "Edit Scheduled Tasks Settings"
 msgstr ""
 
-#: cps/admin.py:2124
+#: cps/admin.py
 msgid "Invalid start time for task specified"
 msgstr ""
 
-#: cps/admin.py:2129
+#: cps/admin.py
 msgid "Invalid duration for task specified"
 msgstr ""
 
-#: cps/admin.py:2139
+#: cps/admin.py
 msgid "Scheduled tasks settings updated"
 msgstr ""
 
-#: cps/admin.py:2149 cps/admin.py:2293 cps/admin.py:3206 cps/web.py:2567
+#: cps/admin.py cps/web.py
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr ""
 
-#: cps/admin.py:2172 cps/opds.py:316 cps/opds.py:354 cps/opds.py:357
-#: cps/web.py:3085 cps/web.py:3220
+#: cps/admin.py cps/opds.py cps/web.py
 msgid "title"
 msgstr ""
 
-#: cps/admin.py:2278 cps/admin.py:3198
+#: cps/admin.py
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr ""
 
-#: cps/admin.py:2290
+#: cps/admin.py
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr ""
 
-#: cps/admin.py:2296
+#: cps/admin.py
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr ""
 
-#: cps/admin.py:2307
+#: cps/admin.py
 msgid "Logfile viewer"
 msgstr ""
 
-#: cps/admin.py:2383
+#: cps/admin.py
 msgid "Requesting update package"
 msgstr ""
 
-#: cps/admin.py:2384
+#: cps/admin.py
 msgid "Downloading update package"
 msgstr ""
 
-#: cps/admin.py:2385
+#: cps/admin.py
 msgid "Unzipping update package"
 msgstr ""
 
-#: cps/admin.py:2386
+#: cps/admin.py
 msgid "Replacing files"
 msgstr ""
 
-#: cps/admin.py:2387
+#: cps/admin.py
 msgid "Database connections are closed"
 msgstr ""
 
-#: cps/admin.py:2388
+#: cps/admin.py
 msgid "Stopping server"
 msgstr ""
 
-#: cps/admin.py:2389
+#: cps/admin.py
 msgid "Update finished, please press okay and reload page"
 msgstr ""
 
-#: cps/admin.py:2390 cps/admin.py:2391 cps/admin.py:2392 cps/admin.py:2393
-#: cps/admin.py:2394 cps/admin.py:2395
+#: cps/admin.py
 msgid "Update failed:"
 msgstr ""
 
-#: cps/admin.py:2390 cps/updater.py:457 cps/updater.py:696 cps/updater.py:698
+#: cps/admin.py cps/updater.py
 msgid "HTTP Error"
 msgstr ""
 
-#: cps/admin.py:2391 cps/updater.py:459 cps/updater.py:700
+#: cps/admin.py cps/updater.py
 msgid "Connection error"
 msgstr ""
 
-#: cps/admin.py:2392 cps/updater.py:461 cps/updater.py:702
+#: cps/admin.py cps/updater.py
 msgid "Timeout while establishing connection"
 msgstr ""
 
-#: cps/admin.py:2393 cps/updater.py:463 cps/updater.py:704
+#: cps/admin.py cps/updater.py
 msgid "General error"
 msgstr ""
 
-#: cps/admin.py:2394
+#: cps/admin.py
 msgid "Update file could not be saved in temp dir"
 msgstr ""
 
-#: cps/admin.py:2395
+#: cps/admin.py
 msgid "Files could not be replaced during update"
 msgstr ""
 
-#: cps/admin.py:2419
+#: cps/admin.py
 msgid "Failed to extract at least One LDAP User"
 msgstr ""
 
-#: cps/admin.py:2468
+#: cps/admin.py
 msgid "Failed to Create at Least One LDAP User"
 msgstr ""
 
-#: cps/admin.py:2481
+#: cps/admin.py
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr ""
 
-#: cps/admin.py:2485
+#: cps/admin.py
 msgid "Error: No user returned in response of LDAP server"
 msgstr ""
 
-#: cps/admin.py:2521
+#: cps/admin.py
 msgid "At Least One LDAP User Not Found in Database"
 msgstr ""
 
-#: cps/admin.py:2523
+#: cps/admin.py
 #, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr ""
 
-#: cps/admin.py:2587
+#: cps/admin.py
 msgid "Books path not valid"
 msgstr ""
 
-#: cps/admin.py:2594
+#: cps/admin.py
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:2619
+#: cps/admin.py
 msgid "DB is not Writeable"
 msgstr ""
 
-#: cps/admin.py:2636
+#: cps/admin.py
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:2640
+#: cps/admin.py
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:2740
+#: cps/admin.py
 msgid ""
 "Auto-create users cannot be enabled without enabling reverse proxy "
 "authentication"
 msgstr ""
 
-#: cps/admin.py:2743
+#: cps/admin.py
 msgid "Auto-create users requires a valid reverse proxy header name"
 msgstr ""
 
-#: cps/admin.py:2762 cps/admin.py:2769
+#: cps/admin.py
 msgid ""
 "Invalid OAuth Redirect Host format. Please include the full URL with "
 "protocol (e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2766
+#: cps/admin.py
 msgid ""
 "OAuth Redirect Host should not include a path. Use only the base URL "
 "(e.g., https://your-domain.com)"
 msgstr ""
 
-#: cps/admin.py:2802
+#: cps/admin.py
 msgid "Password length has to be between 1 and 40"
 msgstr ""
 
-#: cps/admin.py:2825
+#: cps/admin.py
 msgid ""
 "KEPUB conversion was not queued. Check that the preference and Kepubify "
 "path are enabled."
 msgstr ""
 
-#: cps/admin.py:2875
+#: cps/admin.py
 msgid "Database Settings updated"
 msgstr ""
 
-#: cps/admin.py:2883
+#: cps/admin.py
 msgid "Database Configuration"
 msgstr ""
 
-#: cps/admin.py:2904 cps/web.py:2532
+#: cps/admin.py cps/web.py
 msgid "Oops! Please complete all fields."
 msgstr ""
 
-#: cps/admin.py:2913
+#: cps/admin.py
 msgid "E-mail is not from valid domain"
 msgstr ""
 
-#: cps/admin.py:2921
+#: cps/admin.py
 msgid "Add new user"
 msgstr ""
 
-#: cps/admin.py:2939
+#: cps/admin.py
 #, python-format
 msgid "User '%(user)s' created"
 msgstr ""
 
-#: cps/admin.py:2945
+#: cps/admin.py
 msgid "Oops! An account already exists for this Email. or name."
 msgstr ""
 
-#: cps/admin.py:2971
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr ""
 
-#: cps/admin.py:2974
+#: cps/admin.py
 msgid "Can't delete Guest User"
 msgstr ""
 
-#: cps/admin.py:2977
+#: cps/admin.py
 msgid "No admin user remaining, can't delete user"
 msgstr ""
 
-#: cps/admin.py:3161 cps/web.py:2900
+#: cps/admin.py cps/web.py
 msgid "Email can't be empty and has to be a valid Email"
 msgstr ""
 
-#: cps/admin.py:3202
+#: cps/admin.py
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr ""
 
-#: cps/admin.py:3267
+#: cps/admin.py
 #, python-format
 msgid "Connection successful! OIDC discovery endpoint is accessible.%(endpoints)s"
 msgstr ""
 
-#: cps/admin.py:3272
+#: cps/admin.py
 msgid ""
 "Connection failed: OIDC discovery endpoint not found (404). Check if the "
 "base URL is correct."
 msgstr ""
 
-#: cps/admin.py:3274 cps/admin.py:3331
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: Server returned status code %(code)s"
 msgstr ""
 
-#: cps/admin.py:3276
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network"
 " connectivity."
 msgstr ""
 
-#: cps/admin.py:3278
+#: cps/admin.py
 msgid ""
 "Connection failed: Request timed out. The server may be slow or "
 "unreachable."
 msgstr ""
 
-#: cps/admin.py:3280
+#: cps/admin.py
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
 msgstr ""
 
-#: cps/admin.py:3283
+#: cps/admin.py
 #, python-format
 msgid "Connection failed: %(error)s"
 msgstr ""
 
-#: cps/admin.py:3309
+#: cps/admin.py
 #, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
 msgstr ""
 
-#: cps/admin.py:3320
+#: cps/admin.py
 #, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 
-#: cps/admin.py:3322
+#: cps/admin.py
 msgid " User info endpoint is available."
 msgstr ""
 
-#: cps/admin.py:3324
+#: cps/admin.py
 msgid ""
 " Note: User info endpoint not found - this may cause authentication "
 "issues."
 msgstr ""
 
-#: cps/admin.py:3329
+#: cps/admin.py
 msgid "Metadata URL not found (404). Please check the URL is correct."
 msgstr ""
 
-#: cps/admin.py:3333
+#: cps/admin.py
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
 msgstr ""
 
-#: cps/admin.py:3335
+#: cps/admin.py
 msgid "Connection failed: Request timed out."
 msgstr ""
 
-#: cps/admin.py:3337
+#: cps/admin.py
 msgid "Connection failed: Invalid JSON in response."
 msgstr ""
 
-#: cps/admin.py:3340
+#: cps/admin.py
 msgid "An unknown error occurred."
 msgstr ""
 
-#: cps/admin.py:3352
+#: cps/admin.py
 msgid "Restore already in progress."
 msgstr ""
 
-#: cps/admin.py:3356
+#: cps/admin.py
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
 
-#: cps/admin.py:3361
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3366
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
 msgstr ""
 
-#: cps/admin.py:3438 cps/admin.py:3481
+#: cps/admin.py
 #, python-format
 msgid "Restore failed: %(err)s"
 msgstr ""
 
-#: cps/admin.py:3458
+#: cps/admin.py
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
 
-#: cps/admin.py:3477
+#: cps/admin.py
 #, python-format
 msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-"
 "linked data was reset."
 msgstr ""
 
-#: cps/annotations.py:70 cps/templates/annotations_import.html:4
+#: cps/annotations.py cps/templates/annotations_import.html
 msgid "Import Kobo annotations"
 msgstr ""
 
-#: cps/annotations.py:88
+#: cps/annotations.py
 msgid "No file uploaded."
 msgstr ""
 
-#: cps/annotations.py:96 cps/annotations.py:118
+#: cps/annotations.py
 #, python-format
 msgid "File exceeds %(max)d MB."
 msgstr ""
 
-#: cps/annotations.py:126
+#: cps/annotations.py
 msgid "Uploaded file is not a SQLite database."
 msgstr ""
 
-#: cps/annotations.py:524 cps/templates/annotations_view.html:4
+#: cps/annotations.py cps/templates/annotations_view.html
 #, python-format
 msgid "Annotations: %(title)s"
 msgstr ""
 
-#: cps/constants.py:261
+#: cps/constants.py
 msgid "Czech"
 msgstr ""
 
-#: cps/constants.py:262
+#: cps/constants.py
 msgid "German"
 msgstr ""
 
-#: cps/constants.py:263
+#: cps/constants.py
 msgid "Greek"
 msgstr ""
 
-#: cps/constants.py:264
+#: cps/constants.py
 msgid "Spanish"
 msgstr ""
 
-#: cps/constants.py:265
+#: cps/constants.py
 msgid "Finnish"
 msgstr ""
 
-#: cps/constants.py:266
+#: cps/constants.py
 msgid "French"
 msgstr ""
 
-#: cps/constants.py:267
+#: cps/constants.py
 msgid "Galician"
 msgstr ""
 
-#: cps/constants.py:268
+#: cps/constants.py
 msgid "Hungarian"
 msgstr ""
 
-#: cps/constants.py:269
+#: cps/constants.py
 msgid "Indonesian"
 msgstr ""
 
-#: cps/constants.py:270
+#: cps/constants.py
 msgid "Italian"
 msgstr ""
 
-#: cps/constants.py:271
+#: cps/constants.py
 msgid "Japanese"
 msgstr ""
 
-#: cps/constants.py:272
+#: cps/constants.py
 msgid "Khmer"
 msgstr ""
 
-#: cps/constants.py:273
+#: cps/constants.py
 msgid "Korean"
 msgstr ""
 
-#: cps/constants.py:274
+#: cps/constants.py
 msgid "Dutch"
 msgstr ""
 
-#: cps/constants.py:275
+#: cps/constants.py
 msgid "Norwegian"
 msgstr ""
 
-#: cps/constants.py:276
+#: cps/constants.py
 msgid "Polish"
 msgstr ""
 
-#: cps/constants.py:277
+#: cps/constants.py
 msgid "Portuguese"
 msgstr ""
 
-#: cps/constants.py:278
+#: cps/constants.py
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: cps/constants.py:279
+#: cps/constants.py
 msgid "Russian"
 msgstr ""
 
-#: cps/constants.py:280
+#: cps/constants.py
 msgid "Slovak"
 msgstr ""
 
-#: cps/constants.py:281
+#: cps/constants.py
 msgid "Slovenian"
 msgstr ""
 
-#: cps/constants.py:282
+#: cps/constants.py
 msgid "Swedish"
 msgstr ""
 
-#: cps/constants.py:283
+#: cps/constants.py
 msgid "Turkish"
 msgstr ""
 
-#: cps/constants.py:284
+#: cps/constants.py
 msgid "Ukrainian"
 msgstr ""
 
-#: cps/constants.py:285
+#: cps/constants.py
 msgid "Vietnamese"
 msgstr ""
 
-#: cps/constants.py:286
+#: cps/constants.py
 msgid "Chinese (Simplified, China)"
 msgstr ""
 
-#: cps/constants.py:287
+#: cps/constants.py
 msgid "Chinese (Traditional, Taiwan)"
 msgstr ""
 
-#: cps/converter.py:21
+#: cps/converter.py
 msgid "not installed"
 msgstr ""
 
-#: cps/converter.py:22
+#: cps/converter.py
 msgid "Execution permissions missing"
 msgstr ""
 
-#: cps/cover_picker.py:138 cps/spa_strings.py:483
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Back to edit metadata"
 msgstr ""
 
-#: cps/cover_picker.py:141 cps/spa_strings.py:164
-#: cps/templates/book_edit.html:39
+#: cps/cover_picker.py cps/spa_strings.py cps/templates/book_edit.html
 msgid "Back to book"
 msgstr ""
 
-#: cps/cover_picker.py:149
+#: cps/cover_picker.py
 #, python-format
 msgid "Change cover — %(title)s"
 msgstr ""
 
-#: cps/cover_picker.py:258
+#: cps/cover_picker.py
 msgid "This book's cover is locked. Unlock it first."
 msgstr ""
 
-#: cps/cover_picker.py:271
+#: cps/cover_picker.py
 msgid "Provide a cover URL."
 msgstr ""
 
-#: cps/cover_picker.py:278
+#: cps/cover_picker.py
 msgid "This book doesn't have an embedded cover we can extract."
 msgstr ""
 
-#: cps/cover_picker.py:282
+#: cps/cover_picker.py
 msgid "Unknown cover source."
 msgstr ""
 
-#: cps/cover_picker.py:311
+#: cps/cover_picker.py
 msgid "Could not save lock state."
 msgstr ""
 
-#: cps/cover_picker.py:358
+#: cps/cover_picker.py
 msgid "Only http(s) URLs can be previewed."
 msgstr ""
 
-#: cps/cover_picker.py:382
+#: cps/cover_picker.py
 msgid "Could not render the e-reader preview."
 msgstr ""
 
-#: cps/cover_picker.py:385
+#: cps/cover_picker.py
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:591 cps/cover_picker.py:605 cps/spa_strings.py:558
+#: cps/cover_picker.py cps/spa_strings.py
 msgid "Cover save failed."
 msgstr ""
 
-#: cps/cwa_functions.py:180
+#: cps/cwa_functions.py
 msgid "Theme switching is temporarily disabled until v5.0.0"
 msgstr ""
 
-#: cps/cwa_functions.py:295
+#: cps/cwa_functions.py
 msgid ""
 "Library Refresh 🔄 Checking for any books that may have been missed, "
 "please wait..."
 msgstr ""
 
-#: cps/cwa_functions.py:997
+#: cps/cwa_functions.py
 msgid "Invalid cron expression for duplicate scans. Changes were not saved."
 msgstr ""
 
-#: cps/cwa_functions.py:1109
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen User Settings"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Timestamp"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/cwa_functions.py:1157
-#: cps/templates/tasks.html:43 cps/templates/user_edit.html:342
+#: cps/cwa_functions.py cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Book ID"
 msgstr ""
 
-#: cps/cwa_functions.py:1155 cps/templates/book_edit.html:125
-#: cps/templates/search_form.html:8
+#: cps/cwa_functions.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Book Title"
 msgstr ""
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Book Author"
 msgstr ""
 
-#: cps/cwa_functions.py:1155
+#: cps/cwa_functions.py
 msgid "Trigger Type"
 msgstr ""
 
-#: cps/cwa_functions.py:1157 cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Filepath"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1163
-#: cps/cwa_functions.py:1166 cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Filename"
 msgstr ""
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "Manual?"
 msgstr ""
 
-#: cps/cwa_functions.py:1161
+#: cps/cwa_functions.py
 msgid "No. Fixes"
 msgstr ""
 
-#: cps/cwa_functions.py:1161 cps/cwa_functions.py:1166
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Backed Up?"
 msgstr ""
 
-#: cps/cwa_functions.py:1163
+#: cps/cwa_functions.py
 msgid "Fixes Applied"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "Original Format"
 msgstr ""
 
-#: cps/cwa_functions.py:1168
+#: cps/cwa_functions.py
 msgid "End Format"
 msgstr ""
 
-#: cps/cwa_functions.py:1244 cps/cwa_functions.py:1273
+#: cps/cwa_functions.py
 msgid "Unknown User"
 msgstr ""
 
-#: cps/cwa_functions.py:1381
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Stats & Activity"
 msgstr ""
 
-#: cps/cwa_functions.py:1765
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History"
 msgstr ""
 
-#: cps/cwa_functions.py:1774
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Enforcement History (w/ Paths)"
 msgstr ""
 
-#: cps/cwa_functions.py:1783
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Import History"
 msgstr ""
 
-#: cps/cwa_functions.py:1792
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full Conversion History"
 msgstr ""
 
-#: cps/cwa_functions.py:1801
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/out Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1810
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Full EPUB Fixer History (w/ Paths & Fixes)"
 msgstr ""
 
-#: cps/cwa_functions.py:1828
+#: cps/cwa_functions.py
 msgid "✅ All Monitoring Services are running as intended! 👍"
 msgstr ""
 
-#: cps/cwa_functions.py:1830
+#: cps/cwa_functions.py
 msgid "🔴 The Ingest Service is running but the Metadata Change Detector is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1832
+#: cps/cwa_functions.py
 msgid "🔴 The Metadata Change Detector is running but the Ingest Service is not"
 msgstr ""
 
-#: cps/cwa_functions.py:1834
+#: cps/cwa_functions.py
 msgid "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
 msgstr ""
 
-#: cps/cwa_functions.py:1836
+#: cps/cwa_functions.py
 msgid "An Error has occurred"
 msgstr ""
 
-#: cps/cwa_functions.py:2013 cps/cwa_functions.py:2041
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Convert Library"
 msgstr ""
 
-#: cps/cwa_functions.py:2167 cps/cwa_functions.py:2193
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - EPUB Fixer Service"
 msgstr ""
 
-#: cps/cwa_functions.py:2251
+#: cps/cwa_functions.py
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
 
-#: cps/cwa_functions.py:2258
+#: cps/cwa_functions.py
 msgid "Invalid book selection."
 msgstr ""
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:490
+#: cps/cwa_functions.py cps/spa_strings.py
 msgid "Book not found."
 msgstr ""
 
-#: cps/cwa_functions.py:2270
+#: cps/cwa_functions.py
 msgid "Selected book has no EPUB format."
 msgstr ""
 
-#: cps/cwa_functions.py:2274
+#: cps/cwa_functions.py
 msgid "EPUB file not found on disk."
 msgstr ""
 
-#: cps/cwa_functions.py:2289
+#: cps/cwa_functions.py
 msgid "EPUB Fixer started for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2292
+#: cps/cwa_functions.py
 msgid "Failed to start EPUB Fixer for selected book."
 msgstr ""
 
-#: cps/cwa_functions.py:2575 cps/cwa_functions.py:2583
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen - Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/cwa_functions.py:2634
+#: cps/cwa_functions.py
 msgid "An enforcement run is already in progress."
 msgstr ""
 
-#: cps/cwa_functions.py:2657
+#: cps/cwa_functions.py
 msgid "Could not start the enforcement run."
 msgstr ""
 
-#: cps/cwa_functions.py:2708
+#: cps/cwa_functions.py
 msgid "You must be an admin to access this page."
 msgstr ""
 
-#: cps/cwa_functions.py:2723
+#: cps/cwa_functions.py
 msgid "Both username and image data are required."
 msgstr ""
 
-#: cps/cwa_functions.py:2731
+#: cps/cwa_functions.py
 msgid "Invalid image data format. Must be a valid image."
 msgstr ""
 
-#: cps/cwa_functions.py:2739
+#: cps/cwa_functions.py
 msgid "Unsupported image type. Only PNG and JPEG are allowed."
 msgstr ""
 
-#: cps/cwa_functions.py:2751
+#: cps/cwa_functions.py
 msgid "Image is too large. Please use an image smaller than 500KB."
 msgstr ""
 
-#: cps/cwa_functions.py:2755
+#: cps/cwa_functions.py
 msgid "Invalid Base64 image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2759
+#: cps/cwa_functions.py
 msgid "Invalid image data format."
 msgstr ""
 
-#: cps/cwa_functions.py:2764
+#: cps/cwa_functions.py
 msgid "Error validating image data."
 msgstr ""
 
-#: cps/cwa_functions.py:2782
+#: cps/cwa_functions.py
 msgid "Profile picture updated successfully."
 msgstr ""
 
-#: cps/cwa_functions.py:2795
+#: cps/cwa_functions.py
 msgid "Calibre-Web NextGen Profile Picture Management (WIP)"
 msgstr ""
 
-#: cps/db.py:1985 cps/spa_strings.py:57 cps/templates/config_edit.html:371
-#: cps/templates/config_view_edit.html:79
-#: cps/templates/config_view_edit.html:90 cps/templates/email_edit.html:41
-#: cps/web.py:845 cps/web.py:879 cps/web.py:924 cps/web.py:964 cps/web.py:993
-#: cps/web.py:2009 cps/web.py:2046 cps/web.py:2097 cps/web.py:2129
-#: cps/web.py:2168
+#: cps/db.py cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/config_view_edit.html cps/templates/email_edit.html cps/web.py
 msgid "None"
 msgstr ""
 
-#: cps/duplicates.py:596 cps/duplicates.py:607
+#: cps/duplicates.py
 msgid "Duplicate Books"
 msgstr ""
 
-#: cps/duplicates.py:1352
+#: cps/duplicates.py
 msgid "Duplicate group already dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1374
+#: cps/duplicates.py
 msgid "Duplicate group dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1417
+#: cps/duplicates.py
 msgid "Duplicate group restored"
 msgstr ""
 
-#: cps/duplicates.py:1419
+#: cps/duplicates.py
 msgid "Duplicate group was not dismissed"
 msgstr ""
 
-#: cps/duplicates.py:1499
+#: cps/duplicates.py
 msgid "Duplicate scan queued"
 msgstr ""
 
-#: cps/duplicates.py:1577
+#: cps/duplicates.py
 msgid "Duplicate scan completed (fallback)"
 msgstr ""
 
-#: cps/duplicates.py:1652
+#: cps/duplicates.py
 msgid "Invalid resolution strategy"
 msgstr ""
 
-#: cps/editbooks.py:125 cps/editbooks.py:182
+#: cps/editbooks.py
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
 
-#: cps/editbooks.py:134
+#: cps/editbooks.py
 msgid "Missing or invalid book id for format upload"
 msgstr ""
 
-#: cps/editbooks.py:140
+#: cps/editbooks.py
 msgid "Cannot upload format: Book no longer exists in library"
 msgstr ""
 
-#: cps/api/upload.py:103 cps/api/upload.py:148 cps/editbooks.py:165
-#: cps/editbooks.py:196 cps/templates/book_edit.html:94
-#: cps/templates/layout.html:375
+#: cps/api/upload.py cps/editbooks.py cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Upload done, processing, please wait..."
 msgstr ""
 
-#: cps/editbooks.py:170 cps/editbooks.py:200
+#: cps/editbooks.py
 msgid "Failed to queue upload for processing"
 msgstr ""
 
-#: cps/editbooks.py:216
+#: cps/editbooks.py
 msgid "Source or destination format for conversion missing"
 msgstr ""
 
-#: cps/editbooks.py:224
+#: cps/editbooks.py
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
 msgstr ""
 
-#: cps/editbooks.py:228
+#: cps/editbooks.py
 #, python-format
 msgid "There was an error converting this book: %(res)s"
 msgstr ""
 
-#: cps/editbooks.py:384 cps/editbooks.py:1432 cps/editbooks.py:2019
+#: cps/editbooks.py
 msgid "File type isn't allowed to be uploaded to this server"
 msgstr ""
 
-#: cps/editbooks.py:389 cps/editbooks.py:1438 cps/editbooks.py:2030
+#: cps/editbooks.py
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
 msgstr ""
 
-#: cps/editbooks.py:393 cps/editbooks.py:1442 cps/editbooks.py:2035
+#: cps/editbooks.py
 msgid "File to be uploaded must have an extension"
 msgstr ""
 
-#: cps/editbooks.py:950 cps/editbooks.py:1703 cps/web.py:812 cps/web.py:3350
-#: cps/web.py:3531 cps/web.py:3677
+#: cps/editbooks.py cps/web.py
 msgid ""
 "Oops! Selected book is unavailable. File does not exist or is not "
 "accessible"
 msgstr ""
 
-#: cps/editbooks.py:990 cps/editbooks.py:2102
+#: cps/editbooks.py
 msgid "User has no rights to upload cover"
 msgstr ""
 
-#: cps/editbooks.py:998
+#: cps/editbooks.py
 msgid "Cover is locked. Unlock it on the cover-picker page first."
 msgstr ""
 
-#: cps/editbooks.py:1032 cps/editbooks.py:1420
+#: cps/editbooks.py
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
 msgstr ""
 
-#: cps/editbooks.py:1044 cps/editbooks.py:1394 cps/editbooks.py:1822
+#: cps/editbooks.py
 #, python-format
 msgid "'%(langname)s' is not a valid language"
 msgstr ""
 
-#: cps/editbooks.py:1166
+#: cps/editbooks.py
 msgid "Metadata successfully updated"
 msgstr ""
 
-#: cps/editbooks.py:1186
+#: cps/editbooks.py
 #, python-brace-format
 msgid "Error editing book: {}"
 msgstr ""
 
-#: cps/editbooks.py:1279 cps/editbooks.py:1329 cps/editbooks.py:2120
-#: cps/updater.py:685 cps/uploader.py:142 cps/uploader.py:151
+#: cps/editbooks.py cps/updater.py cps/uploader.py
 msgid "Unknown"
 msgstr ""
 
-#: cps/editbooks.py:1333
+#: cps/editbooks.py
 msgid ""
 "Uploaded book probably exists in the library, consider to change before "
 "upload new: "
 msgstr ""
 
-#: cps/editbooks.py:1450
+#: cps/editbooks.py
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 
-#: cps/editbooks.py:1470
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to Move Cover File %(file)s: %(error)s"
 msgstr ""
 
-#: cps/editbooks.py:1558 cps/editbooks.py:1560
+#: cps/editbooks.py
 msgid "Book Format Successfully Deleted"
 msgstr ""
 
-#: cps/editbooks.py:1567 cps/editbooks.py:1569
+#: cps/editbooks.py
 msgid "Book Successfully Deleted"
 msgstr ""
 
-#: cps/editbooks.py:1684
+#: cps/editbooks.py
 msgid "You are missing permissions to delete books"
 msgstr ""
 
-#: cps/editbooks.py:1727
+#: cps/editbooks.py
 msgid "edit metadata"
 msgstr ""
 
-#: cps/editbooks.py:1781
+#: cps/editbooks.py
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr ""
 
-#: cps/editbooks.py:2024
+#: cps/editbooks.py
 msgid "User has no rights to upload additional file formats"
 msgstr ""
 
-#: cps/editbooks.py:2048
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to create path %(path)s (Permission denied)."
 msgstr ""
 
-#: cps/editbooks.py:2055
+#: cps/editbooks.py
 #, python-format
 msgid "Failed to store file %(file)s."
 msgstr ""
 
-#: cps/editbooks.py:2079
+#: cps/editbooks.py
 #, python-format
 msgid "File format %(ext)s added to %(book)s"
 msgstr ""
 
-#: cps/editbooks.py:2381
+#: cps/editbooks.py
 msgid "Book not found"
 msgstr ""
 
-#: cps/editbooks.py:2385
+#: cps/editbooks.py
 msgid "Book has no file formats on disk to reload from"
 msgstr ""
 
-#: cps/editbooks.py:2406
+#: cps/editbooks.py
 #, python-format
 msgid "Book file not found on disk: %(path)s"
 msgstr ""
 
-#: cps/editbooks.py:2426
+#: cps/editbooks.py
 #, python-format
 msgid "Could not parse metadata from %(format)s file: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2547
+#: cps/editbooks.py
 #, python-format
 msgid "Could not rename the book folder to match the reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2569
+#: cps/editbooks.py
 #, python-format
 msgid "Could not save reloaded metadata: %(err)s"
 msgstr ""
 
-#: cps/editbooks.py:2575
+#: cps/editbooks.py
 #, python-format
 msgid "Reloaded %(n)d field(s) from on-disk %(fmt)s"
 msgstr ""
 
-#: cps/editbooks.py:2578
+#: cps/editbooks.py
 msgid "On-disk metadata matches current — no fields updated"
 msgstr ""
 
-#: cps/gdrive.py:43
+#: cps/gdrive.py
 msgid ""
 "Google Drive setup not completed, try to deactivate and activate Google "
 "Drive again"
 msgstr ""
 
-#: cps/gdrive.py:81
+#: cps/gdrive.py
 msgid ""
 "Callback domain is not verified, please follow steps to verify domain in "
 "google developer console"
 msgstr ""
 
-#: cps/helper.py:185 cps/spa_strings.py:101 cps/templates/email_edit.html:61
+#: cps/helper.py cps/spa_strings.py cps/templates/email_edit.html
 msgid "This Email has been sent via Calibre-Web NextGen."
 msgstr ""
 
-#: cps/helper.py:289
+#: cps/helper.py
 #, python-format
 msgid "Announcement Email to %(email)s"
 msgstr ""
 
-#: cps/helper.py:336
+#: cps/helper.py
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr ""
 
-#: cps/helper.py:342 cps/tasks/convert.py:88
+#: cps/helper.py cps/tasks/convert.py
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr ""
 
-#: cps/helper.py:347
+#: cps/helper.py
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr ""
 
-#: cps/helper.py:354 cps/helper.py:490 cps/templates/detail.html:669
-#: cps/templates/detail.html:673
+#: cps/helper.py cps/templates/detail.html
 msgid "Send to eReader"
 msgstr ""
 
-#: cps/helper.py:376
+#: cps/helper.py
 #, python-format
 msgid "Conversion timed out for book id: %(book)d"
 msgstr ""
 
-#: cps/helper.py:378
+#: cps/helper.py
 #, python-format
 msgid "Conversion failed for book id: %(book)d"
 msgstr ""
 
-#: cps/helper.py:386
+#: cps/helper.py
 msgid "Calibre-Web NextGen Test Email"
 msgstr ""
 
-#: cps/helper.py:387
+#: cps/helper.py
 msgid "Test Email"
 msgstr ""
 
-#: cps/helper.py:404
+#: cps/helper.py
 msgid "Get Started with Calibre-Web NextGen"
 msgstr ""
 
-#: cps/helper.py:409
+#: cps/helper.py
 #, python-format
 msgid "Registration Email for user: %(name)s"
 msgstr ""
 
-#: cps/helper.py:420 cps/helper.py:426
+#: cps/helper.py
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr ""
 
-#: cps/helper.py:445 cps/helper.py:449 cps/helper.py:453
+#: cps/helper.py
 #, python-format
 msgid "Send %(format)s to eReader"
 msgstr ""
 
-#: cps/helper.py:496
+#: cps/helper.py
 #, python-format
 msgid "%(book)s send to eReader"
 msgstr ""
 
-#: cps/helper.py:503
+#: cps/helper.py
 msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr ""
 
-#: cps/helper.py:899
+#: cps/helper.py
 #, python-brace-format
 msgid "Read status could not set: {}"
 msgstr ""
 
-#: cps/helper.py:934
+#: cps/helper.py
 #, python-format
 msgid "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
 msgstr ""
 
-#: cps/helper.py:946
+#: cps/helper.py
 #, python-format
 msgid "Deleting book %(id)s failed: %(message)s"
 msgstr ""
 
-#: cps/helper.py:957
+#: cps/helper.py
 #, python-format
 msgid ""
 "Deleting book %(id)s from database only, book path in database not valid:"
 " %(path)s"
 msgstr ""
 
-#: cps/helper.py:1047
+#: cps/helper.py
 #, python-format
 msgid "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 
-#: cps/helper.py:1116 cps/helper.py:1125
+#: cps/helper.py
 #, python-format
 msgid "File %(file)s not found on Google Drive"
 msgstr ""
 
-#: cps/helper.py:1215
+#: cps/helper.py
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
 
-#: cps/helper.py:1254
+#: cps/helper.py
 #, python-format
 msgid "Book path %(path)s not found on Google Drive"
 msgstr ""
 
-#: cps/helper.py:1315
+#: cps/helper.py
 msgid "Found an existing account for this Email address"
 msgstr ""
 
-#: cps/helper.py:1323
+#: cps/helper.py
 msgid "This username is already taken"
 msgstr ""
 
-#: cps/helper.py:1337
+#: cps/helper.py
 msgid "Invalid Email address format"
 msgstr ""
 
-#: cps/helper.py:1359
+#: cps/helper.py
 msgid "Password doesn't comply with password validation rules"
 msgstr ""
 
-#: cps/helper.py:1703
+#: cps/helper.py
 msgid "Python module 'advocate' is not installed but is needed for cover uploads"
 msgstr ""
 
-#: cps/helper.py:1711 cps/helper.py:1746
+#: cps/helper.py
 msgid "Error Downloading Cover"
 msgstr ""
 
-#: cps/helper.py:1715 cps/helper.py:1723
+#: cps/helper.py
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
 msgstr ""
 
-#: cps/helper.py:1732 cps/helper.py:1779 cps/helper.py:1792 cps/helper.py:1795
+#: cps/helper.py
 msgid "Cover-file is not a valid image file, or could not be stored"
 msgstr ""
 
-#: cps/helper.py:1749
+#: cps/helper.py
 msgid "Cover Format Error"
 msgstr ""
 
-#: cps/helper.py:1752
+#: cps/helper.py
 msgid ""
 "You are not allowed to access localhost or the local network for cover "
 "uploads"
 msgstr ""
 
-#: cps/helper.py:1768
+#: cps/helper.py
 msgid "Failed to create path for cover"
 msgstr ""
 
-#: cps/helper.py:1812
+#: cps/helper.py
 msgid "Only jpg/jpeg/png/webp/bmp files are supported as coverfile"
 msgstr ""
 
-#: cps/helper.py:1828 cps/helper.py:1833
+#: cps/helper.py
 msgid "Invalid cover file content"
 msgstr ""
 
-#: cps/helper.py:1837
+#: cps/helper.py
 msgid "Only jpg/jpeg files are supported as coverfile"
 msgstr ""
 
-#: cps/helper.py:2059 cps/helper.py:2329 cps/spa_strings.py:184
+#: cps/helper.py cps/spa_strings.py
 msgid "Cover"
 msgstr ""
 
-#: cps/helper.py:2082
+#: cps/helper.py
 msgid "UnRar binary file not found"
 msgstr ""
 
-#: cps/helper.py:2093
+#: cps/helper.py
 msgid "Error executing UnRar"
 msgstr ""
 
-#: cps/helper.py:2099
+#: cps/helper.py
 #, python-format
 msgid ""
 "Unsupported architecture detected: %(arch)s. Calibre-Web NextGen is "
 "optimized for x86_64 and aarch64."
 msgstr ""
 
-#: cps/helper.py:2108
+#: cps/helper.py
 msgid "Could not find the specified directory"
 msgstr ""
 
-#: cps/helper.py:2111
+#: cps/helper.py
 msgid "Please specify a directory, not a file"
 msgstr ""
 
-#: cps/helper.py:2125
+#: cps/helper.py
 msgid "Calibre binaries not viable"
 msgstr ""
 
-#: cps/helper.py:2134
+#: cps/helper.py
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2136
+#: cps/helper.py
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
 msgstr ""
 
-#: cps/helper.py:2141
+#: cps/helper.py
 msgid "Error executing Calibre"
 msgstr ""
 
-#: cps/helper.py:2331 cps/templates/admin.html:243
+#: cps/helper.py cps/templates/admin.html
 msgid "Queue all books for metadata backup"
 msgstr ""
 
-#: cps/kobo_auth.py:88
+#: cps/kobo_auth.py
 msgid ""
 "Please access Calibre-Web NextGen from non localhost to get valid "
 "api_endpoint for kobo device"
 msgstr ""
 
-#: cps/kobo_auth.py:107
+#: cps/kobo_auth.py
 msgid "Kobo Setup"
 msgstr ""
 
-#: cps/magic_shelf.py:327 cps/spa_strings.py:42
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recently Added"
 msgstr ""
 
-#: cps/magic_shelf.py:346 cps/spa_strings.py:43
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Highly Rated"
 msgstr ""
 
-#: cps/magic_shelf.py:383 cps/opds.py:200 cps/spa_strings.py:44
+#: cps/magic_shelf.py cps/opds.py cps/spa_strings.py
 msgid "Currently Reading"
 msgstr ""
 
-#: cps/magic_shelf.py:400 cps/spa_strings.py:45
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Yet to Read"
 msgstr ""
 
-#: cps/magic_shelf.py:417 cps/spa_strings.py:46
+#: cps/magic_shelf.py cps/spa_strings.py
 msgid "Recent Publications"
 msgstr ""
 
-#: cps/oauth_bb.py:294
+#: cps/oauth_bb.py
 #, python-format
 msgid "Register with %(provider)s"
 msgstr ""
 
-#: cps/oauth_bb.py:349
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: OAuth token validation error. This may be due to scope "
 "configuration mismatch. Please check your OAuth scopes configuration or "
 "contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:354
+#: cps/oauth_bb.py
 msgid "Login failed: OAuth token expired. Please try logging in again."
 msgstr ""
 
-#: cps/oauth_bb.py:358
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info "
 "endpoint. Please try again or contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:363
+#: cps/oauth_bb.py
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. "
 "Please contact your administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:385
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: OAuth provider response is missing required fields: "
@@ -1764,34 +1736,34 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:411 cps/oauth_bb.py:672
+#: cps/oauth_bb.py
 msgid "Failed to link OAuth account. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:444
+#: cps/oauth_bb.py
 msgid "Login failed: your account is not allowed to access this application."
 msgstr ""
 
-#: cps/oauth_bb.py:635
+#: cps/oauth_bb.py
 msgid "OAuth error: Provider returned invalid user information. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:649
+#: cps/oauth_bb.py
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
 msgstr ""
 
-#: cps/oauth_bb.py:656 cps/remotelogin.py:149
+#: cps/oauth_bb.py cps/remotelogin.py
 #, python-format
 msgid "Success! You are now logged in as: %(nickname)s"
 msgstr ""
 
-#: cps/oauth_bb.py:666
+#: cps/oauth_bb.py
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
 msgstr ""
 
-#: cps/oauth_bb.py:674
+#: cps/oauth_bb.py
 #, python-format
 msgid ""
 "Login failed: No user account is linked to your %(provider)s account. "
@@ -1799,5110 +1771,5010 @@ msgid ""
 "existing account."
 msgstr ""
 
-#: cps/oauth_bb.py:682
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed. Please try again or contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:686
+#: cps/oauth_bb.py
 msgid "OAuth system error. Please contact administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:719
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
 msgstr ""
 
-#: cps/oauth_bb.py:724
+#: cps/oauth_bb.py
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
 msgstr ""
 
-#: cps/oauth_bb.py:727
+#: cps/oauth_bb.py
 #, python-format
 msgid "Not Linked to %(oauth)s"
 msgstr ""
 
-#: cps/oauth_bb.py:1047
+#: cps/oauth_bb.py
 msgid "Failed to log in with GitHub."
 msgstr ""
 
-#: cps/oauth_bb.py:1053
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from GitHub."
 msgstr ""
 
-#: cps/oauth_bb.py:1074
+#: cps/oauth_bb.py
 msgid "Failed to log in with Google."
 msgstr ""
 
-#: cps/oauth_bb.py:1083
+#: cps/oauth_bb.py
 msgid "Failed to fetch user info from Google."
 msgstr ""
 
-#: cps/oauth_bb.py:1108
+#: cps/oauth_bb.py
 msgid "Failed to log in with Generic OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1124
+#: cps/oauth_bb.py
 msgid "OAuth authentication failed: Token validation error. Please try again."
 msgstr ""
 
-#: cps/oauth_bb.py:1128
+#: cps/oauth_bb.py
 msgid ""
 "OAuth authentication failed due to an unexpected error. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/oauth_bb.py:1136 cps/oauth_bb.py:1155 cps/oauth_bb.py:1174
+#: cps/oauth_bb.py
 msgid ""
 "OAuth error: Invalid redirect URI. If you're experiencing this error "
 "repeatedly, please configure the 'OAuth Redirect Host' setting in Admin >"
 " Basic Configuration > OAuth."
 msgstr ""
 
-#: cps/oauth_bb.py:1211
+#: cps/oauth_bb.py
 msgid "GitHub Oauth error, please retry later."
 msgstr ""
 
-#: cps/oauth_bb.py:1218
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr ""
 
-#: cps/oauth_bb.py:1268
+#: cps/oauth_bb.py
 msgid "Google Oauth error, please retry later."
 msgstr ""
 
-#: cps/oauth_bb.py:1275
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr ""
 
-#: cps/oauth_bb.py:1311 cps/oauth_bb.py:1319
+#: cps/oauth_bb.py
 #, python-brace-format
 msgid "OAuth error: {}"
 msgstr ""
 
-#: cps/opds.py:164
+#: cps/opds.py
 msgid "Alphabetical Books"
 msgstr ""
 
-#: cps/opds.py:165
+#: cps/opds.py
 msgid "Books sorted alphabetically"
 msgstr ""
 
-#: cps/opds.py:170 cps/render_template.py:151
+#: cps/opds.py cps/render_template.py
 msgid "Hot Books"
 msgstr ""
 
-#: cps/opds.py:171
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Downloads."
 msgstr ""
 
-#: cps/opds.py:176 cps/render_template.py:165 cps/web.py:687
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Top Rated Books"
 msgstr ""
 
-#: cps/opds.py:177
+#: cps/opds.py
 msgid "Popular publications from this catalog based on Rating."
 msgstr ""
 
-#: cps/opds.py:182
+#: cps/opds.py
 msgid "Recently added Books"
 msgstr ""
 
-#: cps/opds.py:183
+#: cps/opds.py
 msgid "The latest Books"
 msgstr ""
 
-#: cps/opds.py:188
+#: cps/opds.py
 msgid "Random Books"
 msgstr ""
 
-#: cps/opds.py:189 cps/render_template.py:177 cps/templates/user_table.html:161
-#: cps/templates/user_table.html:164
+#: cps/opds.py cps/render_template.py cps/templates/user_table.html
 msgid "Show Random Books"
 msgstr ""
 
-#: cps/opds.py:194 cps/opds.py:195 cps/render_template.py:168 cps/web.py:1052
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Read Books"
 msgstr ""
 
-#: cps/opds.py:201
+#: cps/opds.py
 msgid "Books currently being read"
 msgstr ""
 
-#: cps/opds.py:206 cps/opds.py:207 cps/render_template.py:172 cps/web.py:1055
+#: cps/opds.py cps/render_template.py cps/web.py
 msgid "Unread Books"
 msgstr ""
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:480
-#: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
-#: cps/templates/cwa_settings.html:336
-#: cps/templates/hardcover_review_matches.html:134
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/cwa_settings.html
+#: cps/templates/hardcover_review_matches.html
 msgid "Authors"
 msgstr ""
 
-#: cps/opds.py:213
+#: cps/opds.py
 msgid "Books ordered by Author"
 msgstr ""
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
-#: cps/templates/book_table.html:115 cps/web.py:2020
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Publishers"
 msgstr ""
 
-#: cps/opds.py:219
+#: cps/opds.py
 msgid "Books ordered by publisher"
 msgstr ""
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:504
-#: cps/templates/book_table.html:110 cps/web.py:2172
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/web.py
 msgid "Categories"
 msgstr ""
 
-#: cps/opds.py:225
+#: cps/opds.py
 msgid "Books ordered by category"
 msgstr ""
 
-#: cps/opds.py:230 cps/render_template.py:181 cps/spa_strings.py:279
-#: cps/templates/book_edit.html:143 cps/templates/book_table.html:111
-#: cps/templates/cwa_settings.html:362 cps/templates/cwa_settings.html:364
-#: cps/templates/cwa_settings.html:1134
-#: cps/templates/hardcover_review_matches.html:140
-#: cps/templates/search_form.html:70 cps/web.py:2052 cps/web.py:2064
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_edit.html cps/templates/book_table.html
+#: cps/templates/cwa_settings.html cps/templates/hardcover_review_matches.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Series"
 msgstr ""
 
-#: cps/opds.py:231
+#: cps/opds.py
 msgid "Books ordered by series"
 msgstr ""
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
-#: cps/templates/book_table.html:113 cps/templates/detail.html:930
-#: cps/templates/search_form.html:108 cps/web.py:2144
+#: cps/opds.py cps/render_template.py cps/spa_strings.py
+#: cps/templates/book_table.html cps/templates/detail.html
+#: cps/templates/search_form.html cps/web.py
 msgid "Languages"
 msgstr ""
 
-#: cps/opds.py:237
+#: cps/opds.py
 msgid "Books ordered by Languages"
 msgstr ""
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
-#: cps/web.py:2104
+#: cps/opds.py cps/render_template.py cps/spa_strings.py cps/web.py
 msgid "Ratings"
 msgstr ""
 
-#: cps/opds.py:243
+#: cps/opds.py
 msgid "Books ordered by Rating"
 msgstr ""
 
-#: cps/opds.py:248 cps/render_template.py:198
+#: cps/opds.py cps/render_template.py
 msgid "File formats"
 msgstr ""
 
-#: cps/opds.py:249
+#: cps/opds.py
 msgid "Books ordered by file formats"
 msgstr ""
 
-#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
-#: cps/templates/search_form.html:88
+#: cps/opds.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Shelves"
 msgstr ""
 
-#: cps/opds.py:255
+#: cps/opds.py
 msgid "Books organized in shelves"
 msgstr ""
 
-#: cps/opds.py:260
+#: cps/opds.py
 msgid "Magic Shelves"
 msgstr ""
 
-#: cps/opds.py:261
+#: cps/opds.py
 msgid "Books organized in magic shelves"
 msgstr ""
 
-#: cps/opds.py:317
+#: cps/opds.py
 msgid "description"
 msgstr ""
 
-#: cps/opds.py:827 cps/opds.py:1294
+#: cps/opds.py
 #, python-brace-format
 msgid "{} Stars"
 msgstr ""
 
-#: cps/opds.py:1169 cps/search.py:53 cps/search.py:454 cps/spa_strings.py:264
-#: cps/templates/book_edit.html:338 cps/templates/cwa_epub_fixer.html:25
-#: cps/templates/feed.xml:43 cps/templates/index.xml:12
-#: cps/templates/layout.html:326 cps/templates/layout.html:329
-#: cps/templates/search_form.html:247
+#: cps/opds.py cps/search.py cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/feed.xml
+#: cps/templates/index.xml cps/templates/layout.html
+#: cps/templates/search_form.html
 msgid "Search"
 msgstr ""
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
-#: cps/templates/layout.html:404 cps/templates/login.html:11
-#: cps/templates/login.html:39 cps/web.py:2643
+#: cps/remotelogin.py cps/spa_strings.py cps/templates/layout.html
+#: cps/templates/login.html cps/web.py
 msgid "Login"
 msgstr ""
 
-#: cps/remotelogin.py:93 cps/remotelogin.py:127
+#: cps/remotelogin.py
 msgid "Token not found"
 msgstr ""
 
-#: cps/remotelogin.py:102 cps/remotelogin.py:135
+#: cps/remotelogin.py
 msgid "Token has expired"
 msgstr ""
 
-#: cps/remotelogin.py:111
+#: cps/remotelogin.py
 msgid "Success! Please return to your device"
 msgstr ""
 
-#: cps/render_template.py:128
+#: cps/render_template.py
 msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate "
 "checks can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:492
+#: cps/render_template.py cps/spa_strings.py
 msgid "Books"
 msgstr ""
 
-#: cps/render_template.py:150
+#: cps/render_template.py
 msgid "Show recent books"
 msgstr ""
 
-#: cps/render_template.py:153
+#: cps/render_template.py
 msgid "Show Hot Books"
 msgstr ""
 
-#: cps/render_template.py:155 cps/render_template.py:160
+#: cps/render_template.py
 msgid "Downloaded Books"
 msgstr ""
 
-#: cps/render_template.py:157 cps/render_template.py:162
-#: cps/templates/user_table.html:169
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Downloaded Books"
 msgstr ""
 
-#: cps/render_template.py:167 cps/templates/user_table.html:163
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Top Rated Books"
 msgstr ""
 
-#: cps/render_template.py:170
+#: cps/render_template.py
 msgid "Show Read and Unread"
 msgstr ""
 
-#: cps/render_template.py:174
+#: cps/render_template.py
 msgid "Show unread"
 msgstr ""
 
-#: cps/render_template.py:175 cps/spa_strings.py:596
+#: cps/render_template.py cps/spa_strings.py
 msgid "Discover"
 msgstr ""
 
-#: cps/render_template.py:180 cps/templates/user_table.html:160
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Category Section"
 msgstr ""
 
-#: cps/render_template.py:183 cps/templates/user_table.html:159
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Series Section"
 msgstr ""
 
-#: cps/render_template.py:186 cps/templates/user_table.html:162
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Author Section"
 msgstr ""
 
-#: cps/render_template.py:190 cps/templates/user_table.html:165
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Publisher Section"
 msgstr ""
 
-#: cps/render_template.py:194 cps/templates/user_table.html:157
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Language Section"
 msgstr ""
 
-#: cps/render_template.py:197 cps/templates/user_table.html:166
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Ratings Section"
 msgstr ""
 
-#: cps/render_template.py:200 cps/templates/user_table.html:167
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show File Formats Section"
 msgstr ""
 
-#: cps/render_template.py:202 cps/web.py:1078
+#: cps/render_template.py cps/web.py
 msgid "Archived Books"
 msgstr ""
 
-#: cps/render_template.py:204 cps/templates/user_table.html:168
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Archived Books"
 msgstr ""
 
-#: cps/render_template.py:206 cps/spa_strings.py:632
+#: cps/render_template.py cps/spa_strings.py
 msgid "Favorites"
 msgstr ""
 
-#: cps/render_template.py:208
+#: cps/render_template.py
 msgid "Show Favorites"
 msgstr ""
 
-#: cps/render_template.py:211 cps/web.py:1826
+#: cps/render_template.py cps/web.py
 msgid "Books List"
 msgstr ""
 
-#: cps/render_template.py:213 cps/templates/user_table.html:170
+#: cps/render_template.py cps/templates/user_table.html
 msgid "Show Books List"
 msgstr ""
 
-#: cps/render_template.py:216 cps/spa_strings.py:609
+#: cps/render_template.py cps/spa_strings.py
 msgid "Duplicates"
 msgstr ""
 
-#: cps/render_template.py:218
+#: cps/render_template.py
 msgid "Show Duplicate Books"
 msgstr ""
 
-#: cps/render_template.py:334
+#: cps/render_template.py
 #, python-format
 msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
-#: cps/render_template.py:344
+#: cps/render_template.py
 #, python-format
 msgid ""
 "Help improve Calibre-Web NextGen's %(language)s translations — %(count)s "
 "strings in your language still need translating."
 msgstr ""
 
-#: cps/search.py:204
+#: cps/search.py
 msgid "Published after "
 msgstr ""
 
-#: cps/search.py:211
+#: cps/search.py
 msgid "Published before "
 msgstr ""
 
-#: cps/search.py:233
+#: cps/search.py
 #, python-format
 msgid "Rating <= %(rating)s"
 msgstr ""
 
-#: cps/search.py:235
+#: cps/search.py
 #, python-format
 msgid "Rating >= %(rating)s"
 msgstr ""
 
-#: cps/search.py:237
+#: cps/search.py
 #, python-format
 msgid "Read Status = '%(status)s'"
 msgstr ""
 
-#: cps/search.py:360
+#: cps/search.py
 msgid "Error on search for custom columns, please restart Calibre-Web"
 msgstr ""
 
-#: cps/search.py:398 cps/search.py:430 cps/templates/layout.html:337
+#: cps/search.py cps/templates/layout.html
 msgid "Advanced Search"
 msgstr ""
 
-#: cps/shelf.py:133 cps/shelf.py:186 cps/shelf.py:254
+#: cps/shelf.py
 msgid "Invalid shelf specified"
 msgstr ""
 
-#: cps/shelf.py:139 cps/shelf.py:259
+#: cps/shelf.py
 msgid "Sorry you are not allowed to add a book to that shelf"
 msgstr ""
 
-#: cps/shelf.py:157
+#: cps/shelf.py
 #, python-format
 msgid "Book is already part of the shelf: %(shelfname)s"
 msgstr ""
 
-#: cps/shelf.py:164
+#: cps/shelf.py
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
 msgstr ""
 
-#: cps/shelf.py:171
+#: cps/shelf.py
 #, python-format
 msgid "Book has been added to shelf: %(sname)s"
 msgstr ""
 
-#: cps/shelf.py:191
+#: cps/shelf.py
 msgid "You are not allowed to add a book to the shelf"
 msgstr ""
 
-#: cps/shelf.py:209
+#: cps/shelf.py
 #, python-format
 msgid "Books are already part of the shelf: %(name)s"
 msgstr ""
 
-#: cps/shelf.py:222
+#: cps/shelf.py
 #, python-format
 msgid "Books have been added to shelf: %(sname)s"
 msgstr ""
 
-#: cps/shelf.py:229
+#: cps/shelf.py
 #, python-format
 msgid "Could not add books to shelf: %(sname)s"
 msgstr ""
 
-#: cps/shelf.py:265
+#: cps/shelf.py
 msgid "Invalid series specified"
 msgstr ""
 
-#: cps/shelf.py:274
+#: cps/shelf.py
 #, python-format
 msgid "Series has no books you can see: %(name)s"
 msgstr ""
 
-#: cps/shelf.py:281
+#: cps/shelf.py
 #, python-format
 msgid "All books of series '%(name)s' are already on shelf: %(sname)s"
 msgstr ""
 
-#: cps/shelf.py:302
+#: cps/shelf.py
 #, python-format
 msgid "%(count)d books of series '%(name)s' added to shelf: %(sname)s"
 msgstr ""
 
-#: cps/shelf.py:345
+#: cps/shelf.py
 #, python-format
 msgid "Book has been removed from shelf: %(sname)s"
 msgstr ""
 
-#: cps/shelf.py:354
+#: cps/shelf.py
 msgid "Sorry you are not allowed to remove a book from this shelf"
 msgstr ""
 
-#: cps/shelf.py:364
+#: cps/shelf.py
 msgid "Create a Shelf"
 msgstr ""
 
-#: cps/shelf.py:372 cps/shelf.py:430
+#: cps/shelf.py
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr ""
 
-#: cps/shelf.py:374
+#: cps/shelf.py
 msgid "Edit a shelf"
 msgstr ""
 
-#: cps/shelf.py:383
+#: cps/shelf.py
 msgid "Error deleting Shelf"
 msgstr ""
 
-#: cps/shelf.py:385
+#: cps/shelf.py
 msgid "Shelf successfully deleted"
 msgstr ""
 
-#: cps/shelf.py:476
+#: cps/shelf.py
 #, python-format
 msgid "Change order of Shelf: '%(name)s'"
 msgstr ""
 
-#: cps/shelf.py:513
+#: cps/shelf.py
 msgid "Sorry you are not allowed to create a public shelf"
 msgstr ""
 
-#: cps/shelf.py:530
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s created"
 msgstr ""
 
-#: cps/shelf.py:533
+#: cps/shelf.py
 #, python-format
 msgid "Shelf %(title)s changed"
 msgstr ""
 
-#: cps/shelf.py:551
+#: cps/shelf.py
 msgid "There was an error"
 msgstr ""
 
-#: cps/shelf.py:575
+#: cps/shelf.py
 #, python-format
 msgid "A public shelf with the name '%(title)s' already exists."
 msgstr ""
 
-#: cps/shelf.py:586
+#: cps/shelf.py
 #, python-format
 msgid "A private shelf with the name '%(title)s' already exists."
 msgstr ""
 
-#: cps/shelf.py:677
+#: cps/shelf.py
 #, python-format
 msgid "Shelf: '%(name)s'"
 msgstr ""
 
-#: cps/shelf.py:683
+#: cps/shelf.py
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 
-#: cps/shelf.py:1016
+#: cps/shelf.py
 #, python-format
 msgid "Invalid order mode: %(mode)s"
 msgstr ""
 
-#: cps/shelf.py:1020
+#: cps/shelf.py
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:1044
+#: cps/shelf.py
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1052 cps/templates/layout.html:667
+#: cps/shelf.py cps/templates/layout.html
 msgid "Reorder Shelves"
 msgstr ""
 
-#: cps/shelf.py:1057
+#: cps/shelf.py
 msgid "Name (A → Z)"
 msgstr ""
 
-#: cps/shelf.py:1058
+#: cps/shelf.py
 msgid "Name (Z → A)"
 msgstr ""
 
-#: cps/shelf.py:1059
+#: cps/shelf.py
 msgid "Book count (most → fewest)"
 msgstr ""
 
-#: cps/shelf.py:1060
+#: cps/shelf.py
 msgid "Book count (fewest → most)"
 msgstr ""
 
-#: cps/shelf.py:1061
+#: cps/shelf.py
 msgid "Created (newest → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1062
+#: cps/shelf.py
 msgid "Created (oldest → newest)"
 msgstr ""
 
-#: cps/shelf.py:1063
+#: cps/shelf.py
 msgid "Modified (recent → oldest)"
 msgstr ""
 
-#: cps/shelf.py:1064
+#: cps/shelf.py
 msgid "Modified (oldest → recent)"
 msgstr ""
 
-#: cps/shelf.py:1065
+#: cps/shelf.py
 msgid "Manual (drag below)"
 msgstr ""
 
-#: cps/spa_strings.py:35 cps/templates/detail.html:634
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr ""
 
-#: cps/spa_strings.py:36
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Open details for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:37
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Read {title}"
 msgstr ""
 
-#: cps/spa_strings.py:51
+#: cps/spa_strings.py
 msgid "Standard (username / password)"
 msgstr ""
 
-#: cps/spa_strings.py:52
+#: cps/spa_strings.py
 msgid "LDAP"
 msgstr ""
 
-#: cps/spa_strings.py:53
+#: cps/spa_strings.py
 msgid "OAuth / OpenID Connect"
 msgstr ""
 
-#: cps/spa_strings.py:54 cps/templates/config_edit.html:402
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Anonymous"
 msgstr ""
 
-#: cps/spa_strings.py:55 cps/templates/config_edit.html:403
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Unauthenticated"
 msgstr ""
 
-#: cps/spa_strings.py:56
+#: cps/spa_strings.py
 msgid "Simple (service account)"
 msgstr ""
 
-#: cps/spa_strings.py:58 cps/templates/config_edit.html:372
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "TLS"
 msgstr ""
 
-#: cps/spa_strings.py:59 cps/templates/config_edit.html:373
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "SSL"
 msgstr ""
 
-#: cps/spa_strings.py:63
+#: cps/spa_strings.py
 msgid "Series order"
 msgstr ""
 
-#: cps/spa_strings.py:64
+#: cps/spa_strings.py
 msgid "Series order (reverse)"
 msgstr ""
 
-#: cps/spa_strings.py:68 cps/templates/detail.html:965
-#: cps/templates/detail.html:966 cps/templates/detail.html:1537
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add tag"
 msgstr ""
 
-#: cps/spa_strings.py:69
+#: cps/spa_strings.py
 msgid "New tag"
 msgstr ""
 
-#: cps/spa_strings.py:70 cps/templates/detail.html:957
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove tag"
 msgstr ""
 
-#: cps/spa_strings.py:74
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:75
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rename tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:76
+#: cps/spa_strings.py
 msgid "Tag name"
 msgstr ""
 
-#: cps/api/browse.py:89 cps/spa_strings.py:77
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot be empty"
 msgstr ""
 
-#: cps/spa_strings.py:78
+#: cps/spa_strings.py
 msgid "Save tag name"
 msgstr ""
 
-#: cps/spa_strings.py:79
+#: cps/spa_strings.py
 msgid "Select format"
 msgstr ""
 
-#: cps/spa_strings.py:80
+#: cps/spa_strings.py
 msgid "Could not rename tag"
 msgstr ""
 
-#: cps/spa_strings.py:81
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Tag renamed to {name}"
 msgstr ""
 
-#: cps/api/browse.py:61 cps/spa_strings.py:82
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You must be signed in"
 msgstr ""
 
-#: cps/api/browse.py:63 cps/spa_strings.py:83
+#: cps/api/browse.py cps/spa_strings.py
 msgid "You are not allowed to edit metadata"
 msgstr ""
 
-#: cps/api/browse.py:112 cps/api/browse.py:140 cps/spa_strings.py:85
+#: cps/api/browse.py cps/spa_strings.py
 msgid "A tag with that name already exists"
 msgstr ""
 
-#: cps/api/browse.py:86 cps/spa_strings.py:86
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name must be text"
 msgstr ""
 
-#: cps/api/browse.py:91 cps/spa_strings.py:87
+#: cps/api/browse.py cps/spa_strings.py
 msgid "Tag name cannot contain commas"
 msgstr ""
 
-#: cps/spa_strings.py:88
+#: cps/spa_strings.py
 msgid "Enter a valid tag name"
 msgstr ""
 
-#: cps/spa_strings.py:89
+#: cps/spa_strings.py
 msgid "Could not load this page"
 msgstr ""
 
-#: cps/spa_strings.py:90
+#: cps/spa_strings.py
 msgid "Page not found"
 msgstr ""
 
-#: cps/spa_strings.py:96
+#: cps/spa_strings.py
 msgid "Clear rating"
 msgstr ""
 
-#: cps/spa_strings.py:97
+#: cps/spa_strings.py
 msgid "Not rated"
 msgstr ""
 
-#: cps/spa_strings.py:98 cps/templates/book_edit.html:220
-#: cps/templates/search_form.html:46 cps/templates/search_form.html:167
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Yes"
 msgstr ""
 
-#: cps/spa_strings.py:99 cps/templates/book_edit.html:221
-#: cps/templates/search_form.html:47 cps/templates/search_form.html:168
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "No"
 msgstr ""
 
-#: cps/spa_strings.py:100 cps/templates/email_edit.html:60
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "Email Message Body"
 msgstr ""
 
-#: cps/spa_strings.py:102
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Rated {rating} out of 5"
 msgstr ""
 
-#: cps/spa_strings.py:103
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "More by {name}"
 msgstr ""
 
-#: cps/spa_strings.py:108
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Merge {n} books into the first selected? The others are removed after "
 "their formats are copied over."
 msgstr ""
 
-#: cps/spa_strings.py:109
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Apply to {n} books"
 msgstr ""
 
-#: cps/spa_strings.py:113
+#: cps/spa_strings.py
 msgid "Match condition"
 msgstr ""
 
-#: cps/spa_strings.py:114
+#: cps/spa_strings.py
 msgid "Rule field"
 msgstr ""
 
-#: cps/spa_strings.py:115
+#: cps/spa_strings.py
 msgid "Rule operator"
 msgstr ""
 
-#: cps/spa_strings.py:116
+#: cps/spa_strings.py
 msgid "Could not load smart-shelf rules."
 msgstr ""
 
-#: cps/spa_strings.py:117
+#: cps/spa_strings.py
 msgid "Has Cover"
 msgstr ""
 
-#: cps/spa_strings.py:118
+#: cps/spa_strings.py
 msgid "Series Index"
 msgstr ""
 
-#: cps/spa_strings.py:119 cps/templates/search_form.html:42
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Read Status"
 msgstr ""
 
-#: cps/spa_strings.py:120
+#: cps/spa_strings.py
 msgid "Has Hardcover ID"
 msgstr ""
 
-#: cps/spa_strings.py:121 cps/templates/magic_shelf_edit.html:584
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "In the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:122 cps/templates/magic_shelf_edit.html:585
+#: cps/spa_strings.py cps/templates/magic_shelf_edit.html
 msgid "Not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:123
+#: cps/spa_strings.py
 msgid "is before / less than"
 msgstr ""
 
-#: cps/spa_strings.py:124
+#: cps/spa_strings.py
 msgid "is on or before / at most"
 msgstr ""
 
-#: cps/spa_strings.py:125
+#: cps/spa_strings.py
 msgid "is after / greater than"
 msgstr ""
 
-#: cps/spa_strings.py:126
+#: cps/spa_strings.py
 msgid "is on or after / at least"
 msgstr ""
 
-#: cps/spa_strings.py:127
+#: cps/spa_strings.py
 msgid "is between"
 msgstr ""
 
-#: cps/spa_strings.py:128
+#: cps/spa_strings.py
 msgid "is not between"
 msgstr ""
 
-#: cps/spa_strings.py:129
+#: cps/spa_strings.py
 msgid "does not begin with"
 msgstr ""
 
-#: cps/spa_strings.py:130
+#: cps/spa_strings.py
 msgid "does not end with"
 msgstr ""
 
-#: cps/spa_strings.py:131
+#: cps/spa_strings.py
 msgid "is empty"
 msgstr ""
 
-#: cps/spa_strings.py:132
+#: cps/spa_strings.py
 msgid "is not empty"
 msgstr ""
 
-#: cps/spa_strings.py:135
+#: cps/spa_strings.py
 msgid "Appearance"
 msgstr ""
 
-#: cps/spa_strings.py:136 cps/templates/read.html:106
-#: cps/templates/readcbr.html:102 cps/templates/user_edit.html:279
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
+#: cps/templates/user_edit.html
 msgid "Theme"
 msgstr ""
 
-#: cps/spa_strings.py:137
+#: cps/spa_strings.py
 msgid "System"
 msgstr ""
 
-#: cps/spa_strings.py:138 cps/spa_strings.py:229 cps/templates/read.html:108
-#: cps/templates/readcbr.html:105
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Light"
 msgstr ""
 
-#: cps/spa_strings.py:139 cps/spa_strings.py:190 cps/templates/read.html:109
-#: cps/templates/readcbr.html:106
+#: cps/spa_strings.py cps/templates/read.html cps/templates/readcbr.html
 msgid "Dark"
 msgstr ""
 
-#: cps/spa_strings.py:140 cps/spa_strings.py:277 cps/templates/read.html:110
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Sepia"
 msgstr ""
 
-#: cps/spa_strings.py:141
+#: cps/spa_strings.py
 msgid "High contrast"
 msgstr ""
 
-#: cps/spa_strings.py:142
+#: cps/spa_strings.py
 msgid "Midnight (AMOLED)"
 msgstr ""
 
-#: cps/spa_strings.py:143
+#: cps/spa_strings.py
 msgid "Match your device’s light or dark setting"
 msgstr ""
 
-#: cps/spa_strings.py:144
+#: cps/spa_strings.py
 msgid "Theme saved."
 msgstr ""
 
-#: cps/spa_strings.py:145
+#: cps/spa_strings.py
 msgid "Could not save theme."
 msgstr ""
 
-#: cps/spa_strings.py:146
+#: cps/spa_strings.py
 msgid "Default theme for new accounts"
 msgstr ""
 
-#: cps/spa_strings.py:147
+#: cps/spa_strings.py
 msgid ""
 "Applies to accounts created from now on. Everyone picks their own under "
 "Account → Theme."
 msgstr ""
 
-#: cps/spa_strings.py:156
+#: cps/spa_strings.py
 msgid "Add a format"
 msgstr ""
 
-#: cps/spa_strings.py:157
+#: cps/spa_strings.py
 msgid "Add rule"
 msgstr ""
 
-#: cps/spa_strings.py:158 cps/templates/detail.html:786
-#: cps/templates/detail.html:997 cps/templates/detail.html:998
-#: cps/templates/detail.html:1659 cps/templates/listenmp3.html:190
-#: cps/templates/search.html:17
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
+#: cps/templates/search.html
 msgid "Add to shelf"
 msgstr ""
 
-#: cps/spa_strings.py:159
+#: cps/spa_strings.py
 msgid "Add your own"
 msgstr ""
 
-#: cps/spa_strings.py:160
+#: cps/spa_strings.py
 msgid "App password label"
 msgstr ""
 
-#: cps/spa_strings.py:161
+#: cps/spa_strings.py
 msgid "App passwords"
 msgstr ""
 
-#: cps/spa_strings.py:162 cps/templates/book_edit.html:135
-#: cps/templates/book_edit.html:459 cps/templates/cwa_settings.html:1122
-#: cps/templates/search_form.html:12
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Author"
 msgstr ""
 
-#: cps/spa_strings.py:163
+#: cps/spa_strings.py
 msgid "Authors (separate with &)"
 msgstr ""
 
-#: cps/spa_strings.py:165
+#: cps/spa_strings.py
 msgid "Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:166 cps/templates/read.html:197
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Blue"
 msgstr ""
 
-#: cps/spa_strings.py:167
+#: cps/spa_strings.py
 msgid "Book content"
 msgstr ""
 
-#: cps/spa_strings.py:168 cps/templates/layout.html:641
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Browse"
 msgstr ""
 
-#: cps/spa_strings.py:169
+#: cps/spa_strings.py
 msgid "Change password"
 msgstr ""
 
-#: cps/spa_strings.py:170 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:378 cps/templates/book_table.html:346
-#: cps/templates/cwng_feedback_popup.html:63
-#: cps/templates/cwng_feedback_popup.html:72 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:375 cps/templates/layout.html:751
-#: cps/templates/layout.html:894 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:69
-#: cps/templates/user_edit.html:673
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
+#: cps/templates/modal_dialogs.html cps/templates/shelf.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Close"
 msgstr ""
 
-#: cps/spa_strings.py:171
+#: cps/spa_strings.py
 msgid "Close menu"
 msgstr ""
 
-#: cps/spa_strings.py:172
+#: cps/spa_strings.py
 msgid "Contents"
 msgstr ""
 
-#: cps/spa_strings.py:173
+#: cps/spa_strings.py
 msgid "Convert failed."
 msgstr ""
 
-#: cps/spa_strings.py:174
+#: cps/spa_strings.py
 msgid "Convert to"
 msgstr ""
 
-#: cps/spa_strings.py:175
+#: cps/spa_strings.py
 msgid "Convert to format"
 msgstr ""
 
-#: cps/spa_strings.py:176 cps/templates/cwa_settings.html:770
-#: cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/spa_strings.py cps/templates/cwa_settings.html
+#: cps/templates/update_now_modal.html cps/templates/user_edit.html
 msgid "Copy"
 msgstr ""
 
-#: cps/spa_strings.py:177
+#: cps/spa_strings.py
 msgid "Could not change password."
 msgstr ""
 
-#: cps/spa_strings.py:178
+#: cps/spa_strings.py
 msgid "Could not create."
 msgstr ""
 
-#: cps/spa_strings.py:179
+#: cps/spa_strings.py
 msgid "Could not fetch cover."
 msgstr ""
 
-#: cps/spa_strings.py:180
+#: cps/spa_strings.py
 msgid "Could not load metadata."
 msgstr ""
 
-#: cps/spa_strings.py:181
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Could not load the book file ({status})"
 msgstr ""
 
-#: cps/spa_strings.py:182
+#: cps/spa_strings.py
 msgid "Could not load your account."
 msgstr ""
 
-#: cps/spa_strings.py:183
+#: cps/spa_strings.py
 msgid "Could not save."
 msgstr ""
 
-#: cps/spa_strings.py:185
+#: cps/spa_strings.py
 msgid "Cover image URL"
 msgstr ""
 
-#: cps/spa_strings.py:186
+#: cps/spa_strings.py
 msgid "Cover update failed."
 msgstr ""
 
-#: cps/spa_strings.py:187 cps/templates/cover_picker.html:227
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Cover updated."
 msgstr ""
 
-#: cps/spa_strings.py:188
+#: cps/spa_strings.py
 msgid "Create smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:189
+#: cps/spa_strings.py
 msgid "Create your account"
 msgstr ""
 
-#: cps/spa_strings.py:191
+#: cps/spa_strings.py
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/spa_strings.py:412
-#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
-#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
-#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
-#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
-#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
-#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/read.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete"
 msgstr ""
 
-#: cps/spa_strings.py:194
+#: cps/spa_strings.py
 msgid "Delete book"
 msgstr ""
 
-#: cps/spa_strings.py:195
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Delete \"{title}\"? This permanently removes the book and all its files "
 "from your library. This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:196
+#: cps/spa_strings.py
 msgid "Deleting…"
 msgstr ""
 
-#: cps/spa_strings.py:197
+#: cps/spa_strings.py
 msgid "Could not delete this book."
 msgstr ""
 
-#: cps/spa_strings.py:198
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete the {fmt} file? The book stays; only this format is removed."
 msgstr ""
 
-#: cps/spa_strings.py:199
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {fmt}"
 msgstr ""
 
-#: cps/spa_strings.py:200
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {n} book(s)? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:201
+#: cps/spa_strings.py
 msgid "Description contains"
 msgstr ""
 
-#: cps/spa_strings.py:202
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deselect {title}"
 msgstr ""
 
-#: cps/spa_strings.py:203
+#: cps/spa_strings.py
 msgid "Edit metadata"
 msgstr ""
 
-#: cps/spa_strings.py:204
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit {title}"
 msgstr ""
 
-#: cps/spa_strings.py:207
+#: cps/spa_strings.py
 msgid "Showing your default library view."
 msgstr ""
 
-#: cps/spa_strings.py:208
+#: cps/spa_strings.py
 msgid "Show all books"
 msgstr ""
 
-#: cps/spa_strings.py:209
+#: cps/spa_strings.py
 msgid "Edit default view"
 msgstr ""
 
-#: cps/spa_strings.py:210
+#: cps/spa_strings.py
 msgid "Failed to load books."
 msgstr ""
 
-#: cps/spa_strings.py:211
+#: cps/spa_strings.py
 msgid "Failed to open the book."
 msgstr ""
 
-#: cps/spa_strings.py:212
+#: cps/spa_strings.py
 msgid "Generate"
 msgstr ""
 
-#: cps/spa_strings.py:213 cps/templates/read.html:196
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Green"
 msgstr ""
 
-#: cps/spa_strings.py:214
+#: cps/spa_strings.py
 msgid "Help"
 msgstr ""
 
-#: cps/spa_strings.py:215
+#: cps/spa_strings.py
 msgid "Highlight color"
 msgstr ""
 
-#: cps/spa_strings.py:216 cps/templates/annotations_view.html:46
+#: cps/spa_strings.py cps/templates/annotations_view.html
 msgid "Import from Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:217
+#: cps/spa_strings.py
 msgid "Interface language"
 msgstr ""
 
-#: cps/spa_strings.py:218
+#: cps/spa_strings.py
 msgid "Invalid username or password."
 msgstr ""
 
-#: cps/spa_strings.py:220
+#: cps/spa_strings.py
 msgid "UI body font"
 msgstr ""
 
-#: cps/spa_strings.py:221
+#: cps/spa_strings.py
 msgid "UI display font"
 msgstr ""
 
-#: cps/spa_strings.py:222
+#: cps/spa_strings.py
 msgid "Default (Optima / Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:223
+#: cps/spa_strings.py
 msgid "Default (Bookish Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:224
+#: cps/spa_strings.py
 msgid "System Sans-Serif"
 msgstr ""
 
-#: cps/spa_strings.py:225
+#: cps/spa_strings.py
 msgid "Bookish Serif"
 msgstr ""
 
-#: cps/spa_strings.py:226
+#: cps/spa_strings.py
 msgid "Monospace"
 msgstr ""
 
-#: cps/spa_strings.py:227
+#: cps/spa_strings.py
 msgid "Label (e.g. KOReader on phone)"
 msgstr ""
 
-#: cps/spa_strings.py:228
+#: cps/spa_strings.py
 msgid "Languages (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:230
+#: cps/spa_strings.py
 msgid "Light theme"
 msgstr ""
 
-#: cps/spa_strings.py:231
+#: cps/spa_strings.py
 msgid "Login failed."
 msgstr ""
 
-#: cps/spa_strings.py:232
+#: cps/spa_strings.py
 msgid "Mark read"
 msgstr ""
 
-#: cps/spa_strings.py:233
+#: cps/spa_strings.py
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/spa_strings.py:415
-#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
-#: cps/templates/duplicates.html:745
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Merge"
 msgstr ""
 
-#: cps/spa_strings.py:235
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Metadata applied to {n} book(s)."
 msgstr ""
 
-#: cps/spa_strings.py:236
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "New password for “{label}” — copy it now, it won’t be shown again:"
 msgstr ""
 
-#: cps/spa_strings.py:237
+#: cps/spa_strings.py
 msgid "New passwords do not match."
 msgstr ""
 
-#: cps/spa_strings.py:238
+#: cps/spa_strings.py
 msgid "No books here."
 msgstr ""
 
-#: cps/spa_strings.py:239
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No results for \"{q}\"."
 msgstr ""
 
-#: cps/spa_strings.py:240
+#: cps/spa_strings.py
 msgid "No suggestions"
 msgstr ""
 
-#: cps/spa_strings.py:241
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {filter} books here."
 msgstr ""
 
-#: cps/spa_strings.py:242
+#: cps/spa_strings.py
 msgid "Password changed."
 msgstr ""
 
-#: cps/spa_strings.py:243
+#: cps/spa_strings.py
 msgid "Paste URL"
 msgstr ""
 
-#: cps/spa_strings.py:244
+#: cps/spa_strings.py
 msgid "Private shelf"
 msgstr ""
 
-#: cps/spa_strings.py:245
+#: cps/spa_strings.py
 msgid "Profile"
 msgstr ""
 
-#: cps/spa_strings.py:246
+#: cps/spa_strings.py
 msgid "Profile saved."
 msgstr ""
 
-#: cps/spa_strings.py:247
+#: cps/spa_strings.py
 msgid "Public shelf"
 msgstr ""
 
-#: cps/spa_strings.py:248 cps/templates/book_edit.html:159
-#: cps/templates/book_edit.html:460 cps/templates/cwa_settings.html:348
-#: cps/templates/cwa_settings.html:350 cps/templates/cwa_settings.html:1140
-#: cps/templates/detail.html:1005
-#: cps/templates/hardcover_review_matches.html:148
-#: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/detail.html
+#: cps/templates/hardcover_review_matches.html cps/templates/listenmp3.html
+#: cps/templates/search_form.html
 msgid "Publisher"
 msgstr ""
 
-#: cps/spa_strings.py:249
+#: cps/spa_strings.py
 msgid "Publishers (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:250 cps/templates/image.html:26
-#: cps/templates/listenmp3.html:159
+#: cps/spa_strings.py cps/templates/image.html cps/templates/listenmp3.html
 msgid "Read"
 msgstr ""
 
-#: cps/spa_strings.py:251
+#: cps/spa_strings.py
 msgid "Reading progress"
 msgstr ""
 
-#: cps/spa_strings.py:252 cps/templates/read.html:195
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Red"
 msgstr ""
 
-#: cps/spa_strings.py:253
+#: cps/spa_strings.py
 msgid "Registration failed."
 msgstr ""
 
-#: cps/spa_strings.py:254
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Remove {name}"
 msgstr ""
 
-#: cps/spa_strings.py:255
+#: cps/spa_strings.py
 msgid "Request failed."
 msgstr ""
 
-#: cps/spa_strings.py:256
+#: cps/spa_strings.py
 msgid "Reset"
 msgstr ""
 
-#: cps/spa_strings.py:257
+#: cps/spa_strings.py
 msgid "Reset your password"
 msgstr ""
 
-#: cps/spa_strings.py:258
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Revoke {label}"
 msgstr ""
 
-#: cps/spa_strings.py:259
+#: cps/spa_strings.py
 msgid "Save changes"
 msgstr ""
 
-#: cps/spa_strings.py:260
+#: cps/spa_strings.py
 msgid "Save failed."
 msgstr ""
 
-#: cps/spa_strings.py:261
+#: cps/spa_strings.py
 msgid "Save profile"
 msgstr ""
 
-#: cps/spa_strings.py:262
+#: cps/spa_strings.py
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/spa_strings.py:418
-#: cps/templates/shelf_order.html:33
+#: cps/spa_strings.py cps/templates/shelf_order.html
 msgid "Saving…"
 msgstr ""
 
-#: cps/spa_strings.py:265
+#: cps/spa_strings.py
 msgid "Search failed."
 msgstr ""
 
-#: cps/spa_strings.py:266
+#: cps/spa_strings.py
 msgid "Search for metadata"
 msgstr ""
 
-#: cps/spa_strings.py:267
+#: cps/spa_strings.py
 msgid "Metadata providers"
 msgstr ""
 
-#: cps/spa_strings.py:268
+#: cps/spa_strings.py
 msgid "Loading providers…"
 msgstr ""
 
-#: cps/spa_strings.py:269
+#: cps/spa_strings.py
 msgid "Could not load providers."
 msgstr ""
 
-#: cps/spa_strings.py:270
+#: cps/spa_strings.py
 msgid "Could not update provider."
 msgstr ""
 
-#: cps/spa_strings.py:271
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{provider}: {state}"
 msgstr ""
 
-#: cps/spa_strings.py:272
+#: cps/spa_strings.py
 msgid "On"
 msgstr ""
 
-#: cps/spa_strings.py:273
+#: cps/spa_strings.py
 msgid "Off"
 msgstr ""
 
-#: cps/spa_strings.py:274 cps/templates/shelf.html:119
+#: cps/spa_strings.py cps/templates/shelf.html
 msgid "Search results"
 msgstr ""
 
-#: cps/spa_strings.py:275
+#: cps/spa_strings.py
 msgid "Search the library"
 msgstr ""
 
-#: cps/spa_strings.py:276
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Select {title}"
 msgstr ""
 
-#: cps/spa_strings.py:278
+#: cps/spa_strings.py
 msgid "Sepia theme"
 msgstr ""
 
-#: cps/spa_strings.py:280
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Series position {n}"
 msgstr ""
 
-#: cps/spa_strings.py:282
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{series} #{n}"
 msgstr ""
 
-#: cps/spa_strings.py:283
+#: cps/spa_strings.py
 msgid "Sign in"
 msgstr ""
 
-#: cps/spa_strings.py:284
+#: cps/spa_strings.py
 msgid "Sign in failed. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:285
+#: cps/spa_strings.py
 msgid "Skip to content"
 msgstr ""
 
-#: cps/spa_strings.py:286
+#: cps/spa_strings.py
 msgid "Some fields could not be saved."
 msgstr ""
 
-#: cps/spa_strings.py:287
+#: cps/spa_strings.py
 msgid "Table of contents"
 msgstr ""
 
-#: cps/spa_strings.py:288
+#: cps/spa_strings.py
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:289 cps/templates/book_table.html:106
-#: cps/templates/config_view_edit.html:39 cps/templates/cwa_settings.html:327
-#: cps/templates/cwa_settings.html:329 cps/templates/cwa_settings.html:1116
-#: cps/templates/shelf_edit.html:8 cps/templates/tasks.html:41
-#: cps/templates/tasks.html:64
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/config_view_edit.html cps/templates/cwa_settings.html
+#: cps/templates/shelf_edit.html cps/templates/tasks.html
 msgid "Title"
 msgstr ""
 
-#: cps/spa_strings.py:290
+#: cps/spa_strings.py
 msgid "Unread"
 msgstr ""
 
-#: cps/spa_strings.py:291
+#: cps/spa_strings.py
 msgid "Update password"
 msgstr ""
 
-#: cps/spa_strings.py:292 cps/tasks/upload.py:28 cps/templates/admin.html:22
-#: cps/templates/layout.html:378 cps/templates/user_table.html:146
+#: cps/spa_strings.py cps/tasks/upload.py cps/templates/admin.html
+#: cps/templates/layout.html cps/templates/user_table.html
 msgid "Upload"
 msgstr ""
 
-#: cps/spa_strings.py:293
+#: cps/spa_strings.py
 msgid "Choose books to upload"
 msgstr ""
 
-#: cps/spa_strings.py:294
+#: cps/spa_strings.py
 msgid "Upload failed."
 msgstr ""
 
-#: cps/spa_strings.py:295
+#: cps/spa_strings.py
 msgid "Upload image"
 msgstr ""
 
-#: cps/spa_strings.py:296
+#: cps/spa_strings.py
 msgid "Uploading…"
 msgstr ""
 
-#: cps/spa_strings.py:297 cps/templates/read.html:194
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Yellow"
 msgstr ""
 
-#: cps/spa_strings.py:298
+#: cps/spa_strings.py
 msgid "e.g. MOBI"
 msgstr ""
 
-#: cps/spa_strings.py:299
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{format} reader"
 msgstr ""
 
-#: cps/spa_strings.py:300
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{name} API key"
 msgstr ""
 
-#: cps/spa_strings.py:301
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) added to the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:302
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} book(s) deleted."
 msgstr ""
 
-#: cps/spa_strings.py:303
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as read."
 msgstr ""
 
-#: cps/spa_strings.py:304
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} marked as unread."
 msgstr ""
 
-#: cps/spa_strings.py:305 cps/templates/_book_organizer.html:162
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 #, python-brace-format
 msgid "{n} selected"
 msgstr ""
 
-#: cps/spa_strings.py:306
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{pct}% read"
 msgstr ""
 
-#: cps/spa_strings.py:312
+#: cps/spa_strings.py
 msgid "What's new"
 msgstr ""
 
-#: cps/spa_strings.py:313
+#: cps/spa_strings.py
 msgid "Help — new updates available"
 msgstr ""
 
-#: cps/spa_strings.py:314
+#: cps/spa_strings.py
 msgid "The latest features and fixes in Calibre-Web NextGen — newest first."
 msgstr ""
 
-#: cps/spa_strings.py:315
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} update"
 msgstr ""
 
-#: cps/spa_strings.py:316
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} updates"
 msgstr ""
 
-#: cps/spa_strings.py:317
+#: cps/spa_strings.py
 msgid "No release notes yet — check back after the next update."
 msgstr ""
 
-#: cps/spa_strings.py:318
+#: cps/spa_strings.py
 msgid ""
 "The interface is translated into your language; these update notes are "
 "written in English."
 msgstr ""
 
-#: cps/spa_strings.py:320 cps/templates/image.html:27
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Reading"
 msgstr ""
 
-#: cps/spa_strings.py:321
+#: cps/spa_strings.py
 msgid "Grid view"
 msgstr ""
 
-#: cps/spa_strings.py:322
+#: cps/spa_strings.py
 msgid "Library"
 msgstr ""
 
-#: cps/spa_strings.py:323
+#: cps/spa_strings.py
 msgid "List view"
 msgstr ""
 
-#: cps/spa_strings.py:324
+#: cps/spa_strings.py
 msgid "Sync"
 msgstr ""
 
-#: cps/spa_strings.py:325 cps/templates/layout.html:355
-#: cps/templates/layout.html:393 cps/templates/user_edit.html:312
-#: cps/templates/user_edit.html:314
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/user_edit.html
 msgid "Account"
 msgstr ""
 
-#: cps/spa_strings.py:326 cps/templates/admin.html:19
-#: cps/templates/layout.html:389 cps/templates/user_table.html:144
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/layout.html
+#: cps/templates/user_table.html
 msgid "Admin"
 msgstr ""
 
-#: cps/spa_strings.py:327
+#: cps/spa_strings.py
 msgid "Under the hood"
 msgstr ""
 
-#: cps/spa_strings.py:330
+#: cps/spa_strings.py
 msgid "Open your library"
 msgstr ""
 
-#: cps/spa_strings.py:331
+#: cps/spa_strings.py
 msgid "Browse tags"
 msgstr ""
 
-#: cps/spa_strings.py:332
+#: cps/spa_strings.py
 msgid "Open the table view"
 msgstr ""
 
-#: cps/spa_strings.py:333
+#: cps/spa_strings.py
 msgid "Review duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:334
+#: cps/spa_strings.py
 msgid "Open your shelves"
 msgstr ""
 
-#: cps/spa_strings.py:335
+#: cps/spa_strings.py
 msgid "Manage sync & app passwords"
 msgstr ""
 
-#: cps/spa_strings.py:336
+#: cps/spa_strings.py
 msgid "Check your e-reader address"
 msgstr ""
 
-#: cps/spa_strings.py:337
+#: cps/spa_strings.py
 msgid "Create an app password"
 msgstr ""
 
-#: cps/spa_strings.py:338
+#: cps/spa_strings.py
 msgid "Browse series"
 msgstr ""
 
-#: cps/spa_strings.py:339
+#: cps/spa_strings.py
 msgid "Browse authors"
 msgstr ""
 
-#: cps/spa_strings.py:340
+#: cps/spa_strings.py
 msgid "Browse languages"
 msgstr ""
 
-#: cps/spa_strings.py:341
+#: cps/spa_strings.py
 msgid "Open Table view"
 msgstr ""
 
-#: cps/spa_strings.py:342
+#: cps/spa_strings.py
 msgid "Open Admin"
 msgstr ""
 
-#: cps/spa_strings.py:343
+#: cps/spa_strings.py
 msgid "Open account settings"
 msgstr ""
 
-#: cps/spa_strings.py:344
+#: cps/spa_strings.py
 msgid "Browse Discover"
 msgstr ""
 
-#: cps/spa_strings.py:345
+#: cps/spa_strings.py
 msgid "Explore your library"
 msgstr ""
 
-#: cps/spa_strings.py:346
+#: cps/spa_strings.py
 msgid "Go to Upload"
 msgstr ""
 
-#: cps/spa_strings.py:347
+#: cps/spa_strings.py
 msgid "Open search"
 msgstr ""
 
-#: cps/spa_strings.py:349
+#: cps/spa_strings.py
 msgid "Editions"
 msgstr ""
 
-#: cps/spa_strings.py:350 cps/templates/layout.html:348
+#: cps/spa_strings.py cps/templates/layout.html
 msgid "Back to New UI"
 msgstr ""
 
-#: cps/spa_strings.py:351
+#: cps/spa_strings.py
 msgid "Back to results"
 msgstr ""
 
-#: cps/spa_strings.py:352
+#: cps/spa_strings.py
 msgid "No editions found for this book."
 msgstr ""
 
-#: cps/spa_strings.py:354
+#: cps/spa_strings.py
 msgid "View all details"
 msgstr ""
 
-#: cps/spa_strings.py:355
+#: cps/spa_strings.py
 msgid "Result details"
 msgstr ""
 
-#: cps/spa_strings.py:356 cps/templates/detail.html:1011
-#: cps/templates/listenmp3.html:111
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Published"
 msgstr ""
 
-#: cps/spa_strings.py:357 cps/templates/cwa_settings.html:1146
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Format"
 msgstr ""
 
-#: cps/spa_strings.py:358 cps/templates/book_edit.html:462
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Source"
 msgstr ""
 
-#: cps/spa_strings.py:361
+#: cps/spa_strings.py
 msgid "Customize"
 msgstr ""
 
-#: cps/spa_strings.py:362
+#: cps/spa_strings.py
 msgid "Customize sidebar"
 msgstr ""
 
-#: cps/spa_strings.py:363
+#: cps/spa_strings.py
 msgid "Customize navigation"
 msgstr ""
 
-#: cps/spa_strings.py:364 cps/templates/_book_organizer.html:164
+#: cps/spa_strings.py cps/templates/_book_organizer.html
 msgid "Done"
 msgstr ""
 
-#: cps/spa_strings.py:365
+#: cps/spa_strings.py
 msgid "Reset to default"
 msgstr ""
 
-#: cps/spa_strings.py:366
+#: cps/spa_strings.py
 msgid "Always shown"
 msgstr ""
 
-#: cps/spa_strings.py:367
+#: cps/spa_strings.py
 msgid "Editing sidebar. Reorder or hide sections, then tap Done."
 msgstr ""
 
-#: cps/spa_strings.py:368
+#: cps/spa_strings.py
 msgid "Editing cancelled."
 msgstr ""
 
-#: cps/spa_strings.py:369
+#: cps/spa_strings.py
 msgid ""
 "Drag to reorder. Tap ✕ to hide a section. Arrow keys move the focused "
 "handle."
 msgstr ""
 
-#: cps/spa_strings.py:370
+#: cps/spa_strings.py
 msgid "Sidebar saved."
 msgstr ""
 
-#: cps/spa_strings.py:371
+#: cps/spa_strings.py
 msgid "Sidebar reset to default."
 msgstr ""
 
-#: cps/spa_strings.py:372
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} moved to position {pos} of {total}"
 msgstr ""
 
-#: cps/spa_strings.py:373
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reorder {label} (position {pos} of {total}). Use arrow keys to move."
 msgstr ""
 
-#: cps/spa_strings.py:374
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {label}"
 msgstr ""
 
-#: cps/spa_strings.py:375
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Restore {label}"
 msgstr ""
 
-#: cps/spa_strings.py:376
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} hidden"
 msgstr ""
 
-#: cps/spa_strings.py:377
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{label} restored"
 msgstr ""
 
-#: cps/spa_strings.py:378
+#: cps/spa_strings.py
 msgid "Could not save sidebar. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:385
+#: cps/spa_strings.py
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py
 msgid "<"
 msgstr ""
 
-#: cps/spa_strings.py:406
+#: cps/spa_strings.py
 msgid "="
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py
 msgid ">"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Run it from CWA settings, then "
 "return here."
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py
 msgid "Date Added"
 msgstr ""
 
-#: cps/spa_strings.py:410
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} book, which is kept."
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete “{name}”? It is removed from {count} books, which are kept."
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py
 msgid "Dismiss Ko-fi support message"
 msgstr ""
 
-#: cps/spa_strings.py:414
+#: cps/spa_strings.py
 msgid "Dismiss help announcement"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py
 msgid "Open Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
-#: cps/templates/cwa_settings.html:378
+#: cps/spa_strings.py cps/templates/cwa_settings.html
 msgid "Publication Date"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py
 msgid "Support us on Ko-fi!"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py
 msgid ""
 "These open the full configuration pages. Changes there apply to the whole"
 " server."
 msgstr ""
 
-#: cps/spa_strings.py:421
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} book. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:422
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "“{name}” already exists on {count} books. Merge this tag into it?"
 msgstr ""
 
-#: cps/spa_strings.py:423
+#: cps/spa_strings.py
 msgid "begins with"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py
 msgid "contains"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py
 msgid "does not contain"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py
 msgid "ends with"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py
 msgid "in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py
 msgid "is not"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py
 msgid "is"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py
 msgid "not in the past N days"
 msgstr ""
 
-#: cps/spa_strings.py:431
+#: cps/spa_strings.py
 msgid "on or after"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py
 msgid "on or before"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py
 msgid "≤"
 msgstr ""
 
-#: cps/spa_strings.py:434
+#: cps/spa_strings.py
 msgid "≥"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:446 cps/templates/config_edit.html:245
-#: cps/templates/cover_picker.html:108
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py
 msgid "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above"
 " to run it."
 msgstr ""
 
-#: cps/spa_strings.py:450 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/layout.html:681
-#: cps/templates/stats.html:3
+#: cps/spa_strings.py cps/templates/layout.html cps/templates/stats.html
 msgid "About"
 msgstr ""
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:455 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:703
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:458
+#: cps/spa_strings.py
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:463 cps/templates/search_form.html:44
-#: cps/templates/search_form.html:165
+#: cps/spa_strings.py cps/templates/search_form.html
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing "
 "values):"
 msgstr ""
 
-#: cps/spa_strings.py:470 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:471 cps/templates/book_table.html:54
-#: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
+#: cps/spa_strings.py cps/templates/book_table.html
+#: cps/templates/duplicates.html
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:472 cps/templates/detail.html:712
-#: cps/templates/listenmp3.html:167
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Archived"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:477
+#: cps/spa_strings.py
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:494
+#: cps/spa_strings.py
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device "
 "on its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:497
+#: cps/spa_strings.py
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:500 cps/templates/admin.html:305
-#: cps/templates/admin.html:319 cps/templates/book_edit.html:312
-#: cps/templates/book_table.html:176 cps/templates/book_table.html:195
-#: cps/templates/book_table.html:215 cps/templates/book_table.html:235
-#: cps/templates/book_table.html:255 cps/templates/book_table.html:275
-#: cps/templates/book_table.html:333 cps/templates/book_table.html:369
-#: cps/templates/config_db.html:115 cps/templates/config_edit.html:745
-#: cps/templates/config_view_edit.html:236 cps/templates/cover_picker.html:191
-#: cps/templates/cwa_convert_library.html:23
-#: cps/templates/cwa_cover_enforcer.html:31
-#: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1192
-#: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:857
-#: cps/templates/layout.html:1012 cps/templates/modal_dialogs.html:64
-#: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
-#: cps/templates/modal_dialogs.html:135 cps/templates/read.html:187
-#: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
-#: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
-#: cps/templates/tasks.html:166 cps/templates/tasks.html:173
-#: cps/templates/user_edit.html:587
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_edit.html
+#: cps/templates/book_table.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/cover_picker.html cps/templates/cwa_convert_library.html
+#: cps/templates/cwa_cover_enforcer.html cps/templates/cwa_epub_fixer.html
+#: cps/templates/detail.html cps/templates/duplicates.html
+#: cps/templates/layout.html cps/templates/modal_dialogs.html
+#: cps/templates/read.html cps/templates/schedule_edit.html
+#: cps/templates/shelf.html cps/templates/shelf_edit.html
+#: cps/templates/tasks.html cps/templates/user_edit.html
 msgid "Cancel"
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:507 cps/templates/book_edit.html:192
-#: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
-#: cps/templates/detail.html:622 cps/templates/detail.html:744
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cover_picker.html cps/templates/detail.html
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:509
+#: cps/spa_strings.py
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:519
+#: cps/spa_strings.py
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:520
+#: cps/spa_strings.py
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:521
+#: cps/spa_strings.py
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:523
+#: cps/spa_strings.py
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:526 cps/tasks/convert.py:391
+#: cps/spa_strings.py cps/tasks/convert.py
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:527
+#: cps/spa_strings.py
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:542
+#: cps/spa_strings.py
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:543 cps/templates/detail.html:738
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:546 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py cps/templates/shelf_reorder.html
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:547
+#: cps/spa_strings.py
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:549
+#: cps/spa_strings.py
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:552
+#: cps/spa_strings.py
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:556
+#: cps/spa_strings.py
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:562
+#: cps/spa_strings.py
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:563
+#: cps/spa_strings.py
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:565
+#: cps/spa_strings.py
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:566
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:567
+#: cps/spa_strings.py
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:568 cps/templates/config_edit.html:259
-#: cps/templates/cover_picker.html:123
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:569 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:570 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:571
+#: cps/spa_strings.py
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:572 cps/templates/detail.html:849
-#: cps/templates/image.html:27 cps/templates/index.html:45
+#: cps/spa_strings.py cps/templates/detail.html cps/templates/image.html
+#: cps/templates/index.html
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:576 cps/templates/detail.html:904
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:577
+#: cps/spa_strings.py
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:578
+#: cps/spa_strings.py
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:583
+#: cps/spa_strings.py
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:585
+#: cps/spa_strings.py
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:590
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:594 cps/templates/book_edit.html:171
-#: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
-#: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/search_form.html
 msgid "Description"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:599 cps/templates/cwng_feedback_popup.html:24
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:423
-#: cps/templates/layout.html:605
+#: cps/spa_strings.py cps/templates/cwng_feedback_popup.html
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:603 cps/templates/admin.html:24
-#: cps/templates/detail.html:647 cps/templates/shelf.html:9
-#: cps/templates/user_table.html:147
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/detail.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Download"
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:605
+#: cps/spa_strings.py
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates "
 "when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:610 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:612 cps/templates/config_edit.html:253
-#: cps/templates/cover_picker.html:117
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:613 cps/templates/config_edit.html:252
-#: cps/templates/cover_picker.html:116
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/admin.html:26
-#: cps/templates/book_table.html:51 cps/templates/book_table.html:332
-#: cps/templates/duplicates.html:657 cps/templates/index.html:131
-#: cps/templates/user_table.html:131 cps/templates/user_table.html:149
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/book_table.html
+#: cps/templates/duplicates.html cps/templates/index.html
+#: cps/templates/user_table.html
 msgid "Edit"
 msgstr ""
 
-#: cps/spa_strings.py:615
+#: cps/spa_strings.py
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:618 cps/templates/admin.html:15
-#: cps/templates/register.html:14 cps/templates/user_edit.html:200
-#: cps/templates/user_table.html:135
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/register.html
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Email"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:624 cps/templates/config_edit.html:208
+#: cps/spa_strings.py cps/templates/config_edit.html
 msgid "Enable Kobo sync"
 msgstr ""
 
-#: cps/spa_strings.py:625 cps/templates/admin.html:80
-#: cps/templates/email_edit.html:39
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/email_edit.html
 msgid "Encryption"
 msgstr ""
 
-#: cps/spa_strings.py:626
+#: cps/spa_strings.py
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:627
+#: cps/spa_strings.py
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:630 cps/templates/image.html:25
+#: cps/spa_strings.py cps/templates/image.html
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py
 msgid ""
 "Files are queued for the library's ingest process and appear once "
 "imported."
 msgstr ""
 
-#: cps/spa_strings.py:637 cps/templates/config_edit.html:250
-#: cps/templates/cover_picker.html:114
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:638
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:639
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:641
+#: cps/spa_strings.py
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:642
+#: cps/spa_strings.py
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:644
+#: cps/spa_strings.py
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:646
+#: cps/spa_strings.py
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:648
+#: cps/spa_strings.py
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:649
+#: cps/spa_strings.py
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:650
+#: cps/spa_strings.py
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:652 cps/templates/config_edit.html:254
-#: cps/templates/cover_picker.html:118
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:661 cps/templates/detail.html:770
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:662 cps/templates/readcbr.html:173
+#: cps/spa_strings.py cps/templates/readcbr.html
 msgid "Hide"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:664
+#: cps/spa_strings.py
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:665
+#: cps/spa_strings.py
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:673 cps/templates/book_edit.html:175
+#: cps/spa_strings.py cps/templates/book_edit.html
 msgid "Identifiers"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Image from {source}"
 msgstr ""
 
-#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
-#: cps/templates/detail.html:899
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/detail.html
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:680 cps/templates/detail.html:1017
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:683
+#: cps/spa_strings.py
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
-#: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html cps/templates/listenmp3.html
 msgid "Language"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:689 cps/templates/detail.html:908
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:690 cps/templates/detail.html:1029
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:692 cps/templates/read.html:132
+#: cps/spa_strings.py cps/templates/read.html
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:694 cps/templates/admin.html:301
-#: cps/templates/admin.html:333 cps/templates/config_db.html:4
-#: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
-#: cps/templates/read.html:74
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/cwa_settings.html
+#: cps/templates/read.html
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:695
+#: cps/spa_strings.py
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
-#: cps/templates/book_table.html:60 cps/templates/book_table.html:254
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
-#: cps/templates/book_table.html:63 cps/templates/book_table.html:274
+#: cps/spa_strings.py cps/templates/_book_organizer.html
+#: cps/templates/book_table.html
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:725
+#: cps/spa_strings.py
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:727
+#: cps/spa_strings.py
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:729
+#: cps/spa_strings.py
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:732
+#: cps/spa_strings.py
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:736
+#: cps/spa_strings.py
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:738
+#: cps/spa_strings.py
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:740
+#: cps/spa_strings.py
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:747
+#: cps/spa_strings.py
 msgid "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:750
+#: cps/spa_strings.py
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:753
+#: cps/spa_strings.py
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:754
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py
 msgid ""
 "On another device where you’re already signed in, scan this code or open "
 "the link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:771
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:772
+#: cps/spa_strings.py
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/admin.html:20
-#: cps/templates/login.html:22 cps/templates/login.html:23
-#: cps/templates/user_edit.html:211
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/user_edit.html
 msgid "Password"
 msgstr ""
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or "
 "use the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:777 cps/templates/admin.html:123
+#: cps/spa_strings.py cps/templates/admin.html
 msgid "Port"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
-#: cps/templates/tasks.html:17
+#: cps/spa_strings.py cps/templates/duplicates.html cps/templates/tasks.html
 msgid "Progress"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
-#: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/cwa_settings.html
 msgid "Rating"
 msgstr ""
 
-#: cps/spa_strings.py:787
+#: cps/spa_strings.py
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:789
+#: cps/spa_strings.py
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
-#: cps/templates/index.html:120
+#: cps/spa_strings.py cps/templates/cover_picker.html cps/templates/index.html
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:798 cps/templates/detail.html:739
-#: cps/templates/detail.html:740
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:801 cps/templates/detail.html:700
-#: cps/templates/detail.html:701 cps/templates/detail.html:702
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:802 cps/templates/detail.html:809
-#: cps/templates/detail.html:991
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:808
+#: cps/spa_strings.py
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a"
 " replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "SSL/TLS"
 msgstr ""
 
-#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
+#: cps/spa_strings.py cps/templates/email_edit.html
 msgid "STARTTLS"
 msgstr ""
 
-#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
-#: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
-#: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
-#: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
-#: cps/templates/shelf_edit.html:36 cps/templates/shelf_reorder.html:38
-#: cps/templates/user_edit.html:585
+#: cps/spa_strings.py cps/templates/book_edit.html cps/templates/config_db.html
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/email_edit.html cps/templates/read.html
+#: cps/templates/schedule_edit.html cps/templates/shelf_edit.html
+#: cps/templates/shelf_reorder.html cps/templates/user_edit.html
 msgid "Save"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:831
+#: cps/spa_strings.py
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
-#: cps/templates/cover_picker.html:224
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:834
+#: cps/spa_strings.py
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py cps/templates/modal_dialogs.html
 msgid "Select"
 msgstr ""
 
-#: cps/spa_strings.py:836
+#: cps/spa_strings.py
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:837 cps/templates/detail.html:1191
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:838
+#: cps/spa_strings.py
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:839
+#: cps/spa_strings.py
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:845
+#: cps/spa_strings.py
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:848
+#: cps/spa_strings.py
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:849
+#: cps/spa_strings.py
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:850
+#: cps/spa_strings.py
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them "
 "manually."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:865
+#: cps/spa_strings.py
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:871
+#: cps/spa_strings.py
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:875
+#: cps/spa_strings.py
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:876
+#: cps/spa_strings.py
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:880
+#: cps/spa_strings.py
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:882 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:883
+#: cps/spa_strings.py
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:886 cps/templates/tasks.html:16
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Status"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
-#: cps/templates/cover_picker.html:122
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:888
+#: cps/spa_strings.py
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
-#: cps/templates/search_form.html:52
+#: cps/spa_strings.py cps/templates/book_edit.html
+#: cps/templates/search_form.html
 msgid "Tags"
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
-#: cps/templates/cover_picker.html:104
+#: cps/spa_strings.py cps/templates/config_edit.html
+#: cps/templates/cover_picker.html
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:897 cps/templates/tasks.html:15
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Task"
 msgstr ""
 
-#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
-#: cps/templates/tasks.html:7
+#: cps/spa_strings.py cps/tasks_status.py cps/templates/layout.html
+#: cps/templates/tasks.html
 msgid "Tasks"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py
 msgid ""
 "This page ran into an error and could not be displayed. Your library is "
 "fine — reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:913 cps/templates/book_table.html:57
-#: cps/templates/book_table.html:234
+#: cps/spa_strings.py cps/templates/book_table.html
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:920
+#: cps/spa_strings.py
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
-#: cps/templates/cover_picker.html:193
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:924 cps/templates/tasks.html:13
-#: cps/templates/tasks.html:42 cps/templates/tasks.html:65
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "User"
 msgstr ""
 
-#: cps/spa_strings.py:925
+#: cps/spa_strings.py
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:926
+#: cps/spa_strings.py
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:927
+#: cps/spa_strings.py
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:928 cps/templates/admin.html:14
-#: cps/templates/login.html:17 cps/templates/login.html:19
-#: cps/templates/register.html:9 cps/templates/user_edit.html:192
-#: cps/templates/user_table.html:134
+#: cps/spa_strings.py cps/templates/admin.html cps/templates/login.html
+#: cps/templates/register.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Username"
 msgstr ""
 
-#: cps/spa_strings.py:929
+#: cps/spa_strings.py
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:930
+#: cps/spa_strings.py
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:931 cps/templates/user_table.html:148
+#: cps/spa_strings.py cps/templates/user_table.html
 msgid "View"
 msgstr ""
 
-#: cps/spa_strings.py:932
+#: cps/spa_strings.py
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:933
+#: cps/spa_strings.py
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:934
+#: cps/spa_strings.py
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py cps/templates/cover_picker.html
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:936 cps/templates/detail.html:1023
+#: cps/spa_strings.py cps/templates/detail.html
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:937
+#: cps/spa_strings.py
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to "
 "make it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:938
+#: cps/spa_strings.py
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:939
+#: cps/spa_strings.py
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:940
+#: cps/spa_strings.py
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:941
+#: cps/spa_strings.py
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:942
+#: cps/spa_strings.py
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:943
+#: cps/spa_strings.py
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:944
+#: cps/spa_strings.py
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:945
+#: cps/spa_strings.py
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:946
+#: cps/spa_strings.py
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:947
+#: cps/spa_strings.py
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:948
+#: cps/spa_strings.py
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:949
+#: cps/spa_strings.py
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:950
+#: cps/spa_strings.py
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:951
+#: cps/spa_strings.py
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:952
+#: cps/spa_strings.py
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:953
+#: cps/spa_strings.py
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:954
+#: cps/spa_strings.py
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:955
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:956
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:957
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:958
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:959
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:960
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:961
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:962
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:963
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:964
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:965
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:966
+#: cps/spa_strings.py
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:967
+#: cps/spa_strings.py
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:968
+#: cps/spa_strings.py
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:969
+#: cps/spa_strings.py
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:970
+#: cps/spa_strings.py
 msgid "← Library"
 msgstr ""
 
-#: cps/tasks_status.py:54
+#: cps/tasks_status.py
 msgid "Waiting"
 msgstr ""
 
-#: cps/tasks_status.py:56
+#: cps/tasks_status.py
 msgid "Failed"
 msgstr ""
 
-#: cps/tasks_status.py:58
+#: cps/tasks_status.py
 msgid "Started"
 msgstr ""
 
-#: cps/tasks_status.py:60
+#: cps/tasks_status.py
 msgid "Finished"
 msgstr ""
 
-#: cps/tasks_status.py:62
+#: cps/tasks_status.py
 msgid "Ended"
 msgstr ""
 
-#: cps/tasks_status.py:64
+#: cps/tasks_status.py
 msgid "Cancelled"
 msgstr ""
 
-#: cps/tasks_status.py:66
+#: cps/tasks_status.py
 msgid "Unknown Status"
 msgstr ""
 
-#: cps/updater.py:499 cps/updater.py:510 cps/updater.py:610 cps/updater.py:617
-#: cps/updater.py:632
+#: cps/updater.py
 msgid "Unexpected data while reading update information"
 msgstr ""
 
-#: cps/updater.py:506 cps/updater.py:624
+#: cps/updater.py
 msgid "No update available. You already have the latest version installed"
 msgstr ""
 
-#: cps/updater.py:525
+#: cps/updater.py
 msgid ""
 "A new update is available. Click on the button below to update to the "
 "latest version."
 msgstr ""
 
-#: cps/updater.py:542
+#: cps/updater.py
 msgid "Could not fetch update information"
 msgstr ""
 
-#: cps/updater.py:553
+#: cps/updater.py
 msgid "Click on the button below to update to the latest stable version."
 msgstr ""
 
-#: cps/updater.py:561 cps/updater.py:576 cps/updater.py:587
+#: cps/updater.py
 #, python-format
 msgid ""
 "A new update is available. Click on the button below to update to "
 "version: %(version)s"
 msgstr ""
 
-#: cps/updater.py:605
+#: cps/updater.py
 msgid "No release information available"
 msgstr ""
 
-#: cps/templates/index.html:33 cps/web.py:714
+#: cps/templates/index.html cps/web.py
 msgid "Discover (Random Books)"
 msgstr ""
 
-#: cps/web.py:764
+#: cps/web.py
 msgid "Hot Books (Most Downloaded)"
 msgstr ""
 
-#: cps/web.py:795
+#: cps/web.py
 #, python-format
 msgid "Downloaded books by %(user)s"
 msgstr ""
 
-#: cps/web.py:828
+#: cps/web.py
 #, python-format
 msgid "Author: %(name)s"
 msgstr ""
 
-#: cps/web.py:864
+#: cps/web.py
 #, python-format
 msgid "Publisher: %(name)s"
 msgstr ""
 
-#: cps/web.py:892
+#: cps/web.py
 #, python-format
 msgid "Series: %(serie)s"
 msgstr ""
 
-#: cps/web.py:906
+#: cps/web.py
 msgid "Rating: None"
 msgstr ""
 
-#: cps/web.py:915
+#: cps/web.py
 #, python-format
 msgid "Rating: %(rating)s stars"
 msgstr ""
 
-#: cps/web.py:946
+#: cps/web.py
 #, python-format
 msgid "File format: %(format)s"
 msgstr ""
 
-#: cps/web.py:983
+#: cps/web.py
 #, python-format
 msgid "Category: %(name)s"
 msgstr ""
 
-#: cps/web.py:1012
+#: cps/web.py
 #, python-format
 msgid "Language: %(name)s"
 msgstr ""
 
-#: cps/web.py:1103
+#: cps/web.py
 msgid "Favorite Books"
 msgstr ""
 
-#: cps/templates/user_edit.html:177 cps/web.py:1127
+#: cps/templates/user_edit.html cps/web.py
 msgid "Hidden Books"
 msgstr ""
 
-#: cps/web.py:1193
+#: cps/web.py
 msgid "Error loading magic shelf"
 msgstr ""
 
-#: cps/web.py:1218
+#: cps/web.py
 #, python-format
 msgid "Magic Shelf&nbsp&nbsp&nbsp—&nbsp&nbsp&nbsp%(icon)s %(name)s"
 msgstr ""
 
-#: cps/web.py:1394
+#: cps/web.py
 msgid "No rules provided"
 msgstr ""
 
-#: cps/web.py:1400
+#: cps/web.py
 msgid "Invalid rules format"
 msgstr ""
 
-#: cps/web.py:1422
+#: cps/web.py
 msgid "Error processing rules"
 msgstr ""
 
-#: cps/web.py:1426
+#: cps/web.py
 msgid "Invalid request"
 msgstr ""
 
-#: cps/web.py:1470
+#: cps/web.py
 msgid "Name and rules are required"
 msgstr ""
 
-#: cps/web.py:1473 cps/web.py:1590
+#: cps/web.py
 msgid "Shelf name too long (max 100 characters)"
 msgstr ""
 
-#: cps/api/magicshelves.py:178 cps/web.py:1513 cps/web.py:1639
+#: cps/api/magicshelves.py cps/web.py
 msgid ""
 "Kobo sync for Magic Shelves is disabled globally — this shelf won't reach"
 " your Kobo until 'Sync Magic Shelves to Kobo' is enabled in CWA Settings."
 msgstr ""
 
-#: cps/web.py:1521
+#: cps/web.py
 msgid "Error creating shelf"
 msgstr ""
 
-#: cps/templates/layout.html:677 cps/web.py:1524
+#: cps/templates/layout.html cps/web.py
 msgid "Create Magic Shelf"
 msgstr ""
 
-#: cps/web.py:1583
+#: cps/web.py
 msgid "Permission denied to change public status"
 msgstr ""
 
-#: cps/web.py:1587
+#: cps/web.py
 msgid "Shelf name is required"
 msgstr ""
 
-#: cps/web.py:1647
+#: cps/web.py
 msgid "Error updating shelf"
 msgstr ""
 
-#: cps/web.py:1652
+#: cps/web.py
 msgid "Edit Magic Shelf"
 msgstr ""
 
-#: cps/web.py:1668
+#: cps/web.py
 msgid "Shelf not found"
 msgstr ""
 
-#: cps/web.py:1673
+#: cps/web.py
 msgid "Permission denied"
 msgstr ""
 
-#: cps/web.py:1704
+#: cps/web.py
 msgid "Shelf duplicated successfully"
 msgstr ""
 
-#: cps/web.py:1710
+#: cps/web.py
 msgid "Error duplicating shelf"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:506 cps/web.py:1737
+#: cps/templates/magic_shelf_edit.html cps/web.py
 msgid ""
 "System shelves cannot be deleted. You can hide them in your user profile "
 "settings."
 msgstr ""
 
-#: cps/web.py:1755
+#: cps/web.py
 msgid "Error deleting shelf"
 msgstr ""
 
-#: cps/web.py:1771
+#: cps/web.py
 msgid ""
 "You cannot hide your own shelves. Delete them instead if you don't want "
 "them."
 msgstr ""
 
-#: cps/web.py:1781
+#: cps/web.py
 msgid "Shelf already hidden"
 msgstr ""
 
-#: cps/web.py:1795
+#: cps/web.py
 msgid "Error hiding shelf"
 msgstr ""
 
-#: cps/web.py:1809
+#: cps/web.py
 msgid "Shelf was not hidden"
 msgstr ""
 
-#: cps/web.py:1818
+#: cps/web.py
 msgid "Error unhiding shelf"
 msgstr ""
 
-#: cps/templates/admin.html:18 cps/web.py:1979
+#: cps/templates/admin.html cps/web.py
 msgid "Downloads"
 msgstr ""
 
-#: cps/web.py:2131
+#: cps/web.py
 msgid "File formats list"
 msgstr ""
 
-#: cps/web.py:2396 cps/web.py:2434
+#: cps/web.py
 msgid "Please configure the SMTP mail settings first..."
 msgstr ""
 
-#: cps/web.py:2400
+#: cps/web.py
 msgid "Oops! Please update your profile with a valid eReader Email."
 msgstr ""
 
-#: cps/web.py:2422
+#: cps/web.py
 #, python-format
 msgid "Success! Book queued for sending to %(eReadermail)s"
 msgstr ""
 
-#: cps/web.py:2425 cps/web.py:2502
+#: cps/web.py
 #, python-format
 msgid "Oops! There was an error sending book: %(res)s"
 msgstr ""
 
-#: cps/web.py:2442 cps/web.py:2452
+#: cps/web.py
 msgid "No email addresses selected"
 msgstr ""
 
-#: cps/web.py:2473
+#: cps/web.py
 msgid "Additional email addresses are disabled for your account."
 msgstr ""
 
-#: cps/web.py:2500
+#: cps/web.py
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr ""
 
-#: cps/web.py:2519
+#: cps/web.py
 msgid "Please wait one minute to register next user"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/templates/layout.html:405
-#: cps/templates/login.html:48 cps/templates/register.html:17 cps/web.py:2520
-#: cps/web.py:2524 cps/web.py:2529 cps/web.py:2533 cps/web.py:2539
-#: cps/web.py:2568 cps/web.py:2572 cps/web.py:2585 cps/web.py:2588
+#: cps/templates/layout.html cps/templates/login.html
+#: cps/templates/register.html cps/web.py
 msgid "Register"
 msgstr ""
 
-#: cps/web.py:2523 cps/web.py:2730
+#: cps/web.py
 msgid "Connection error to limiter backend, please contact your administrator"
 msgstr ""
 
-#: cps/web.py:2528 cps/web.py:2584
+#: cps/web.py
 msgid "Oops! Email server is not configured, please contact your administrator."
 msgstr ""
 
-#: cps/web.py:2570
+#: cps/web.py
 msgid "Oops! Your Email is not allowed."
 msgstr ""
 
-#: cps/web.py:2573
+#: cps/web.py
 msgid "Success! Confirmation Email has been sent."
 msgstr ""
 
-#: cps/web.py:2624
+#: cps/web.py
 msgid ""
 "Authentication loop detected. If you're experiencing login issues, please"
 " contact your administrator."
 msgstr ""
 
-#: cps/web.py:2704
+#: cps/web.py
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
 msgstr ""
 
-#: cps/web.py:2709 cps/web.py:2736
+#: cps/web.py
 msgid "Cannot activate LDAP authentication"
 msgstr ""
 
-#: cps/web.py:2718
+#: cps/web.py
 msgid "Standard login is disabled."
 msgstr ""
 
-#: cps/web.py:2726
+#: cps/web.py
 msgid "Please wait one minute before next login"
 msgstr ""
 
-#: cps/web.py:2744
+#: cps/web.py
 msgid "Username cannot be empty"
 msgstr ""
 
-#: cps/web.py:2756
+#: cps/web.py
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
 msgstr ""
 
-#: cps/web.py:2775
+#: cps/web.py
 #, python-format
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged "
 "in as: '%(nickname)s'"
 msgstr ""
 
-#: cps/web.py:2780 cps/web.py:2783
+#: cps/web.py
 msgid ""
 "Authentication successful, but account creation failed. Please contact "
 "your administrator."
 msgstr ""
 
-#: cps/web.py:2787
+#: cps/web.py
 msgid ""
 "Authentication successful, but no local account found. Please contact "
 "your administrator to create your account."
 msgstr ""
 
-#: cps/web.py:2795
+#: cps/web.py
 #, python-format
 msgid ""
 "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not"
 " known"
 msgstr ""
 
-#: cps/web.py:2801
+#: cps/web.py
 #, python-format
 msgid "Could not login: %(message)s"
 msgstr ""
 
-#: cps/web.py:2823 cps/web.py:2824 cps/web.py:2866
+#: cps/web.py
 msgid "Wrong Username or Password"
 msgstr ""
 
-#: cps/web.py:2832
+#: cps/web.py
 msgid "New Password was sent to your email address"
 msgstr ""
 
-#: cps/web.py:2836
+#: cps/web.py
 msgid "An unknown error occurred. Please try again later."
 msgstr ""
 
-#: cps/web.py:2838
+#: cps/web.py
 msgid "Please enter valid username to reset password"
 msgstr ""
 
-#: cps/web.py:2846
+#: cps/web.py
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
 msgstr ""
 
-#: cps/web.py:3158
+#: cps/web.py
 msgid "Success! Profile Updated"
 msgstr ""
 
-#: cps/web.py:3164
+#: cps/web.py
 msgid "Oops! An account already exists for this Email."
 msgstr ""
 
-#: cps/web.py:3298
+#: cps/web.py
 msgid "App-password label must be 1-64 characters."
 msgstr ""
 
-#: cps/web.py:3333
+#: cps/web.py
 #, python-format
 msgid "App password '%(label)s' revoked."
 msgstr ""
 
-#: cps/web.py:3544
+#: cps/web.py
 msgid "Invalid book ID."
 msgstr ""
 
-#: cps/api/browse.py:183
+#: cps/api/browse.py
 msgid "Tag could not be deleted"
 msgstr ""
 
-#: cps/progress_syncing/protocols/kosync.py:821
+#: cps/progress_syncing/protocols/kosync.py
 msgid "KOReader Sync Plugin"
 msgstr ""
 
-#: cps/services/gmail.py:48
+#: cps/services/gmail.py
 msgid "Found no valid gmail.json file with OAuth information"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:39
+#: cps/tasks/annotation_sync.py
 msgid "Syncing annotations to reading services"
 msgstr ""
 
-#: cps/tasks/annotation_sync.py:95
+#: cps/tasks/annotation_sync.py
 msgid "Annotation Sync"
 msgstr ""
 
-#: cps/tasks/auto_hardcover_id.py:45
+#: cps/tasks/auto_hardcover_id.py
 msgid "Auto-fetching Hardcover IDs"
 msgstr ""
 
-#: cps/tasks/auto_send.py:34
+#: cps/tasks/auto_send.py
 msgid "Preparing to send to eReader..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:56
+#: cps/tasks/auto_send.py
 msgid "Checking available formats..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:69
+#: cps/tasks/auto_send.py
 msgid "Sending to eReader..."
 msgstr ""
 
-#: cps/tasks/auto_send.py:86
+#: cps/tasks/auto_send.py
 msgid "Auto-send completed successfully"
 msgstr ""
 
-#: cps/tasks/auto_send.py:102
+#: cps/tasks/auto_send.py
 msgid "Auto-Send"
 msgstr ""
 
-#: cps/tasks/clean.py:18
+#: cps/tasks/clean.py
 msgid "Delete temp folder contents"
 msgstr ""
 
-#: cps/tasks/convert.py:109
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(book)s send to E-Reader"
 msgstr ""
 
-#: cps/tasks/convert.py:181
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre ebook-convert %(tool)s not found"
 msgstr ""
 
-#: cps/tasks/convert.py:213
+#: cps/tasks/convert.py
 #, python-format
 msgid "%(format)s format not found on disk"
 msgstr ""
 
-#: cps/tasks/convert.py:217
+#: cps/tasks/convert.py
 msgid "Ebook converter failed with unknown error"
 msgstr ""
 
-#: cps/tasks/convert.py:242
+#: cps/tasks/convert.py
 #, python-format
 msgid "Kepubify-converter failed: %(error)s"
 msgstr ""
 
-#: cps/tasks/convert.py:268
+#: cps/tasks/convert.py
 msgid "Kepubify produced an invalid KEPUB archive"
 msgstr ""
 
-#: cps/tasks/convert.py:283
+#: cps/tasks/convert.py
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
 
-#: cps/tasks/convert.py:324 cps/tasks/convert.py:386
+#: cps/tasks/convert.py
 #, python-format
 msgid "Calibre failed with error: %(error)s"
 msgstr ""
 
-#: cps/tasks/convert.py:363
+#: cps/tasks/convert.py
 #, python-format
 msgid "Ebook-converter failed: %(error)s"
 msgstr ""
 
-#: cps/tasks/database.py:15
+#: cps/tasks/database.py
 msgid "Reconnecting Calibre database"
 msgstr ""
 
-#: cps/tasks/database.py:37
+#: cps/tasks/database.py
 msgid "Clean archived book references"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:60 cps/tasks/duplicate_scan.py:76
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:106
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan skipped: import in progress"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:114
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:122
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:128
+#: cps/tasks/duplicate_scan.py
 msgid "Building duplicate index: no books"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:132
+#: cps/tasks/duplicate_scan.py
 msgid "Finding duplicate groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:148
+#: cps/tasks/duplicate_scan.py
 msgid "Updating duplicate cache"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:177 cps/tasks/duplicate_scan.py:187
-#: cps/tasks/duplicate_scan.py:227 cps/tasks/duplicate_scan.py:236
+#: cps/tasks/duplicate_scan.py
 msgid "Duplicate scan pending: manual scan required"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:255
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:257
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s new groups"
 msgstr ""
 
-#: cps/tasks/duplicate_scan.py:307
+#: cps/tasks/duplicate_scan.py
 #, python-format
 msgid "Duplicate scan completed: %(count)s groups auto-resolved"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:41
+#: cps/tasks/hardcover_sync.py
 msgid "Syncing shelf additions to Hardcover"
 msgstr ""
 
-#: cps/tasks/hardcover_sync.py:119
+#: cps/tasks/hardcover_sync.py
 msgid "Hardcover Sync"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:50
+#: cps/tasks/kepub_backfill.py
 msgid "Convert Kobo books missing KEPUB"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:63
+#: cps/tasks/kepub_backfill.py
 msgid "Kepubify is not configured"
 msgstr ""
 
-#: cps/tasks/kepub_backfill.py:124
+#: cps/tasks/kepub_backfill.py
 #, python-format
 msgid "%(count)d KEPUB conversion(s) failed"
 msgstr ""
 
-#: cps/tasks/mail.py:331
+#: cps/tasks/mail.py
 msgid "E-mail"
 msgstr ""
 
-#: cps/tasks/metadata_backup.py:23
+#: cps/tasks/metadata_backup.py
 msgid "Backing up Metadata"
 msgstr ""
 
-#: cps/tasks/ops.py:28
+#: cps/tasks/ops.py
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:84
+#: cps/tasks/ops.py
 msgid "Convert Library"
 msgstr ""
 
-#: cps/tasks/ops.py:95
+#: cps/tasks/ops.py
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py:142
+#: cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:102
+#: cps/tasks/thumbnail.py
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:322 cps/tasks/thumbnail.py:543
-#: cps/tasks/thumbnail.py:611
+#: cps/tasks/thumbnail.py
 msgid "Cover Thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:382
+#: cps/tasks/thumbnail.py
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr ""
 
-#: cps/tasks/thumbnail.py:554
+#: cps/tasks/thumbnail.py
 msgid "Clearing cover thumbnail cache"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:11
+#: cps/templates/_book_organizer.html
 msgid "Book organizer"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:21
+#: cps/templates/_book_organizer.html
 msgid "Change sort order"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:48 cps/templates/_book_organizer.html:49
+#: cps/templates/_book_organizer.html
 msgid "Select multiple books"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:62 cps/templates/_book_organizer.html:63
+#: cps/templates/_book_organizer.html
 msgid "Display settings"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:75
+#: cps/templates/_book_organizer.html
 msgid "Cover Settings"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:84
+#: cps/templates/_book_organizer.html
 msgid "Hide shelf badges on covers"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:93
+#: cps/templates/_book_organizer.html
 msgid "Selection actions"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:104 cps/templates/book_table.html:69
+#: cps/templates/_book_organizer.html cps/templates/book_table.html
 msgid "Add to Shelf"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:116 cps/templates/detail.html:797
-#: cps/templates/detail.html:819 cps/templates/detail.html:989
-#: cps/templates/detail.html:1622 cps/templates/feed.xml:109
-#: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:661 cps/templates/layout.html:674
-#: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
-#: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
+#: cps/templates/_book_organizer.html cps/templates/detail.html
+#: cps/templates/feed.xml cps/templates/index.html cps/templates/layout.html
+#: cps/templates/listenmp3.html cps/templates/search.html
+#: cps/templates/shelf_reorder.html
 msgid "(Public)"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:132
+#: cps/templates/_book_organizer.html
 msgid "Mark"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:180
+#: cps/templates/_book_organizer.html
 msgid "Downloads, fewest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:183
+#: cps/templates/_book_organizer.html
 msgid "Downloads, most first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:191
-#: cps/templates/_book_organizer.html:218
-#: cps/templates/_book_organizer.html:265
-#: cps/templates/_book_organizer.html:292
+#: cps/templates/_book_organizer.html
 msgid "Date added, newest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:194
-#: cps/templates/_book_organizer.html:221
-#: cps/templates/_book_organizer.html:268
-#: cps/templates/_book_organizer.html:295
+#: cps/templates/_book_organizer.html
 msgid "Date added, oldest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:197
-#: cps/templates/_book_organizer.html:224
-#: cps/templates/_book_organizer.html:271
-#: cps/templates/_book_organizer.html:298
+#: cps/templates/_book_organizer.html
 msgid "Title A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:200
-#: cps/templates/_book_organizer.html:227
-#: cps/templates/_book_organizer.html:274
-#: cps/templates/_book_organizer.html:301
+#: cps/templates/_book_organizer.html
 msgid "Title Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:203
-#: cps/templates/_book_organizer.html:230
-#: cps/templates/_book_organizer.html:304
+#: cps/templates/_book_organizer.html
 msgid "Author A → Z"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:206
-#: cps/templates/_book_organizer.html:233
-#: cps/templates/_book_organizer.html:307
+#: cps/templates/_book_organizer.html
 msgid "Author Z → A"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:209
-#: cps/templates/_book_organizer.html:236
-#: cps/templates/_book_organizer.html:277
-#: cps/templates/_book_organizer.html:310
+#: cps/templates/_book_organizer.html
 msgid "Published, newest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:212
-#: cps/templates/_book_organizer.html:239
-#: cps/templates/_book_organizer.html:280
-#: cps/templates/_book_organizer.html:313
+#: cps/templates/_book_organizer.html
 msgid "Published, oldest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:245
+#: cps/templates/_book_organizer.html
 msgid "Series number, ascending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:248
+#: cps/templates/_book_organizer.html
 msgid "Series number, descending"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:316
+#: cps/templates/_book_organizer.html
 msgid "Added to shelf, newest first"
 msgstr ""
 
-#: cps/templates/_book_organizer.html:319
+#: cps/templates/_book_organizer.html
 msgid "Added to shelf, oldest first"
 msgstr ""
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html
 msgid "Users&nbsp;&nbsp;👤"
 msgstr ""
 
-#: cps/templates/admin.html:16
+#: cps/templates/admin.html
 msgid "Send to eReader Email"
 msgstr ""
 
-#: cps/templates/admin.html:17 cps/templates/user_edit.html:228
+#: cps/templates/admin.html cps/templates/user_edit.html
 msgid "Send to eReader Subject"
 msgstr ""
 
-#: cps/templates/admin.html:25
+#: cps/templates/admin.html
 msgid "View Books"
 msgstr ""
 
-#: cps/templates/admin.html:28
+#: cps/templates/admin.html
 msgid "Public Shelf"
 msgstr ""
 
-#: cps/templates/admin.html:58
+#: cps/templates/admin.html
 msgid "Manage Profile Pictures"
 msgstr ""
 
-#: cps/templates/admin.html:60
+#: cps/templates/admin.html
 msgid "Import LDAP Users"
 msgstr ""
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html
 msgid "Email Server Settings&nbsp;&nbsp;📬"
 msgstr ""
 
-#: cps/templates/admin.html:72 cps/templates/email_edit.html:31
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Hostname"
 msgstr ""
 
-#: cps/templates/admin.html:76 cps/templates/email_edit.html:35
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Port"
 msgstr ""
 
-#: cps/templates/admin.html:84 cps/templates/email_edit.html:47
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "SMTP Login"
 msgstr ""
 
-#: cps/templates/admin.html:88 cps/templates/admin.html:99
-#: cps/templates/email_edit.html:55
+#: cps/templates/admin.html cps/templates/email_edit.html
 msgid "From Email"
 msgstr ""
 
-#: cps/templates/admin.html:95
+#: cps/templates/admin.html
 msgid "Email Service"
 msgstr ""
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html
 msgid "Gmail via Oauth2"
 msgstr ""
 
-#: cps/templates/admin.html:112
+#: cps/templates/admin.html
 msgid "Configuration&nbsp;&nbsp;⚙️"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html
 msgid "Calibre Database Directory"
 msgstr ""
 
-#: cps/templates/admin.html:119 cps/templates/config_edit.html:140
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Log Level"
 msgstr ""
 
-#: cps/templates/admin.html:128
+#: cps/templates/admin.html
 msgid "External Port"
 msgstr ""
 
-#: cps/templates/admin.html:135 cps/templates/config_view_edit.html:45
+#: cps/templates/admin.html cps/templates/config_view_edit.html
 msgid "Books per Page"
 msgstr ""
 
-#: cps/templates/admin.html:139
+#: cps/templates/admin.html
 msgid "Uploads"
 msgstr ""
 
-#: cps/templates/admin.html:143
+#: cps/templates/admin.html
 msgid "Anonymous Browsing"
 msgstr ""
 
-#: cps/templates/admin.html:147
+#: cps/templates/admin.html
 msgid "Public Registration"
 msgstr ""
 
-#: cps/templates/admin.html:151
+#: cps/templates/admin.html
 msgid "Magic Link Remote Login"
 msgstr ""
 
-#: cps/templates/admin.html:155
+#: cps/templates/admin.html
 msgid "Reverse Proxy Login"
 msgstr ""
 
-#: cps/templates/admin.html:160 cps/templates/config_edit.html:335
+#: cps/templates/admin.html cps/templates/config_edit.html
 msgid "Reverse Proxy Header Name"
 msgstr ""
 
-#: cps/templates/admin.html:165
+#: cps/templates/admin.html
 msgid "NextGen Settings"
 msgstr ""
 
-#: cps/templates/admin.html:166
+#: cps/templates/admin.html
 msgid "Edit Basic Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:167
+#: cps/templates/admin.html
 msgid "Edit UI Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:168
+#: cps/templates/admin.html
 msgid "Edit Calibre Database Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:174
+#: cps/templates/admin.html
 msgid "Scheduled Tasks&nbsp;&nbsp;⌛"
 msgstr ""
 
-#: cps/templates/admin.html:177 cps/templates/schedule_edit.html:12
-#: cps/templates/tasks.html:19
+#: cps/templates/admin.html cps/templates/schedule_edit.html
+#: cps/templates/tasks.html
 msgid "Start Time"
 msgstr ""
 
-#: cps/templates/admin.html:181 cps/templates/schedule_edit.html:20
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Maximum Duration"
 msgstr ""
 
-#: cps/templates/admin.html:185 cps/templates/schedule_edit.html:29
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Scheduled Thumbnail Refresh"
 msgstr ""
 
-#: cps/templates/admin.html:189
+#: cps/templates/admin.html
 msgid "Generate series cover thumbnails"
 msgstr ""
 
-#: cps/templates/admin.html:193 cps/templates/admin.html:235
-#: cps/templates/schedule_edit.html:38
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Reconnect Calibre Database"
 msgstr ""
 
-#: cps/templates/admin.html:197 cps/templates/schedule_edit.html:42
+#: cps/templates/admin.html cps/templates/schedule_edit.html
 msgid "Generate Metadata Backup Files"
 msgstr ""
 
-#: cps/templates/admin.html:203
+#: cps/templates/admin.html
 msgid "Refresh Thumbnail Cache"
 msgstr ""
 
-#: cps/templates/admin.html:209
+#: cps/templates/admin.html
 msgid "NextGen Admin Functions&nbsp;&nbsp;⚡"
 msgstr ""
 
-#: cps/templates/admin.html:210
+#: cps/templates/admin.html
 msgid "Show NextGen Stats"
 msgstr ""
 
-#: cps/templates/admin.html:211
+#: cps/templates/admin.html
 msgid "Check NextGen Status"
 msgstr ""
 
-#: cps/templates/admin.html:212
+#: cps/templates/admin.html
 msgid "Setup KOReader Sync"
 msgstr ""
 
-#: cps/templates/admin.html:215
+#: cps/templates/admin.html
 msgid "NextGen Library Conversion Service"
 msgstr ""
 
-#: cps/templates/admin.html:216
+#: cps/templates/admin.html
 msgid "NextGen EPUB Fixer Service"
 msgstr ""
 
-#: cps/templates/admin.html:217
+#: cps/templates/admin.html
 msgid "NextGen Cover & Metadata Enforcement"
 msgstr ""
 
-#: cps/templates/admin.html:220
+#: cps/templates/admin.html
 msgid "NextGen GitHub"
 msgstr ""
 
-#: cps/templates/admin.html:221
+#: cps/templates/admin.html
 msgid "NextGen Discord Server"
 msgstr ""
 
-#: cps/templates/admin.html:224
+#: cps/templates/admin.html
 msgid "Run Hardcover Auto-Fetch"
 msgstr ""
 
-#: cps/templates/admin.html:229
+#: cps/templates/admin.html
 msgid "Administration&nbsp;&nbsp;🚀"
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid ""
 "Sanitized: safe to attach to a public GitHub issue. Passwords, tokens, "
 "IPs, and install paths are scrubbed."
 msgstr ""
 
-#: cps/templates/admin.html:230
+#: cps/templates/admin.html
 msgid "Get Support Pack"
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Full unredacted pack. Admin/private use only — contains secrets and IPs."
 msgstr ""
 
-#: cps/templates/admin.html:231
+#: cps/templates/admin.html
 msgid "Download Debug Package"
 msgstr ""
 
-#: cps/templates/admin.html:232
+#: cps/templates/admin.html
 msgid "View Logs"
 msgstr ""
 
-#: cps/templates/admin.html:238
+#: cps/templates/admin.html
 msgid "Restart"
 msgstr ""
 
-#: cps/templates/admin.html:239
+#: cps/templates/admin.html
 msgid "Shutdown"
 msgstr ""
 
-#: cps/templates/admin.html:248
+#: cps/templates/admin.html
 msgid "Version Information&nbsp;&nbsp;📜"
 msgstr ""
 
-#: cps/templates/admin.html:253
+#: cps/templates/admin.html
 msgid "Version"
 msgstr ""
 
-#: cps/templates/admin.html:254
+#: cps/templates/admin.html
 msgid "Details"
 msgstr ""
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html
 msgid "Update available"
 msgstr ""
 
-#: cps/templates/admin.html:264 cps/templates/layout.html:514
+#: cps/templates/admin.html cps/templates/layout.html
 msgid "Update now"
 msgstr ""
 
-#: cps/templates/admin.html:266
+#: cps/templates/admin.html
 msgid "Current Version"
 msgstr ""
 
-#: cps/templates/admin.html:273 cps/templates/admin.html:278
+#: cps/templates/admin.html
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:285
+#: cps/templates/admin.html
 msgid "Check for Update"
 msgstr ""
 
-#: cps/templates/admin.html:286
+#: cps/templates/admin.html
 msgid "Perform Update"
 msgstr ""
 
-#: cps/templates/admin.html:299
+#: cps/templates/admin.html
 msgid "Are you sure you want to restart?"
 msgstr ""
 
-#: cps/templates/admin.html:304 cps/templates/admin.html:318
-#: cps/templates/admin.html:338 cps/templates/config_db.html:145
-#: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
+#: cps/templates/admin.html cps/templates/config_db.html
+#: cps/templates/duplicates.html
 msgid "OK"
 msgstr ""
 
-#: cps/templates/admin.html:317
+#: cps/templates/admin.html
 msgid "Are you sure you want to shutdown?"
 msgstr ""
 
-#: cps/templates/admin.html:329
+#: cps/templates/admin.html
 msgid "Updating, please do not reload this page"
 msgstr ""
 
-#: cps/templates/annotations_import.html:6
+#: cps/templates/annotations_import.html
 #, python-format
 msgid ""
 "Upload your Kobo device's %(filename)s file to import every highlight and"
@@ -6911,600 +6783,577 @@ msgid ""
 "skipped."
 msgstr ""
 
-#: cps/templates/annotations_import.html:9
+#: cps/templates/annotations_import.html
 msgid ""
 "The file is parsed in-memory and deleted after the import completes. It "
 "is never stored on the server."
 msgstr ""
 
-#: cps/templates/annotations_import.html:15
+#: cps/templates/annotations_import.html
 msgid "KoboReader.sqlite"
 msgstr ""
 
-#: cps/templates/annotations_import.html:18
+#: cps/templates/annotations_import.html
 msgid "Import"
 msgstr ""
 
-#: cps/templates/annotations_import.html:23
+#: cps/templates/annotations_import.html
 msgid "Import summary"
 msgstr ""
 
-#: cps/templates/annotations_import.html:25
+#: cps/templates/annotations_import.html
 msgid "new highlights imported"
 msgstr ""
 
-#: cps/templates/annotations_import.html:26
+#: cps/templates/annotations_import.html
 msgid "already imported (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:27
+#: cps/templates/annotations_import.html
 msgid "for books not in this library (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:28
+#: cps/templates/annotations_import.html
 msgid "hidden on device (skipped)"
 msgstr ""
 
-#: cps/templates/annotations_import.html:29
+#: cps/templates/annotations_import.html
 msgid "total entries seen"
 msgstr ""
 
-#: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
-#: cps/templates/book_edit.html:111 cps/templates/layout.html:375
-#: cps/templates/layout.html:580
+#: cps/templates/annotations_import.html cps/templates/book_edit.html
+#: cps/templates/layout.html
 msgid "Uploading..."
 msgstr ""
 
-#: cps/templates/annotations_import.html:69
+#: cps/templates/annotations_import.html
 msgid "Import failed."
 msgstr ""
 
-#: cps/templates/annotations_import.html:75
+#: cps/templates/annotations_import.html
 msgid "Network error."
 msgstr ""
 
-#: cps/templates/annotations_view.html:7
+#: cps/templates/annotations_view.html
 msgid "Export Markdown"
 msgstr ""
 
-#: cps/templates/annotations_view.html:8
+#: cps/templates/annotations_view.html
 msgid "Export CSV"
 msgstr ""
 
-#: cps/templates/annotations_view.html:9
+#: cps/templates/annotations_view.html
 msgid "Export JSON"
 msgstr ""
 
-#: cps/templates/annotations_view.html:10
+#: cps/templates/annotations_view.html
 msgid "Open book"
 msgstr ""
 
-#: cps/templates/annotations_view.html:15
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1153
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/annotations_view.html cps/templates/cwa_settings.html
 msgid "Note:"
 msgstr ""
 
-#: cps/templates/annotations_view.html:31
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Chapter progress: %(pct)d%%"
 msgstr ""
 
-#: cps/templates/annotations_view.html:34
+#: cps/templates/annotations_view.html
 #, python-format
 msgid "Source: %(s)s"
 msgstr ""
 
-#: cps/templates/annotations_view.html:45 cps/templates/read.html:192
+#: cps/templates/annotations_view.html cps/templates/read.html
 msgid "No annotations on this book yet."
 msgstr ""
 
-#: cps/templates/author.html:18
+#: cps/templates/author.html
 msgid "via"
 msgstr ""
 
-#: cps/templates/author.html:26
+#: cps/templates/author.html
 msgid "In Library"
 msgstr ""
 
-#: cps/templates/author.html:59 cps/templates/author.html:116
-#: cps/templates/index.html:61 cps/templates/index.html:204
-#: cps/templates/search.html:66 cps/templates/shelf.html:61
+#: cps/templates/author.html cps/templates/index.html cps/templates/search.html
+#: cps/templates/shelf.html
 msgid "reduce"
 msgstr ""
 
-#: cps/templates/author.html:100
+#: cps/templates/author.html
 msgid "More by"
 msgstr ""
 
-#: cps/templates/book_edit.html:53 cps/templates/detail.html:751
-#: cps/templates/detail.html:753
+#: cps/templates/book_edit.html cps/templates/detail.html
 msgid "Delete Book"
 msgstr ""
 
-#: cps/templates/book_edit.html:56
+#: cps/templates/book_edit.html
 msgid "Delete formats:"
 msgstr ""
 
-#: cps/templates/book_edit.html:67
+#: cps/templates/book_edit.html
 msgid "Convert book format:"
 msgstr ""
 
-#: cps/templates/book_edit.html:72
+#: cps/templates/book_edit.html
 msgid "Convert from:"
 msgstr ""
 
-#: cps/templates/book_edit.html:74 cps/templates/book_edit.html:81
+#: cps/templates/book_edit.html
 msgid "select an option"
 msgstr ""
 
-#: cps/templates/book_edit.html:79
+#: cps/templates/book_edit.html
 msgid "Convert to:"
 msgstr ""
 
-#: cps/templates/book_edit.html:88
+#: cps/templates/book_edit.html
 msgid "Convert book"
 msgstr ""
 
-#: cps/templates/book_edit.html:94 cps/templates/duplicates.html:799
-#: cps/templates/hardcover_review_matches.html:279
-#: cps/templates/hardcover_review_matches.html:288
-#: cps/templates/hardcover_review_matches.html:323
-#: cps/templates/hardcover_review_matches.html:332
-#: cps/templates/hardcover_review_matches.html:360
-#: cps/templates/hardcover_review_matches.html:369
-#: cps/templates/hardcover_review_matches.html:400
-#: cps/templates/hardcover_review_matches.html:409
-#: cps/templates/layout.html:375
+#: cps/templates/book_edit.html cps/templates/duplicates.html
+#: cps/templates/hardcover_review_matches.html cps/templates/layout.html
 msgid "Error"
 msgstr ""
 
-#: cps/templates/book_edit.html:99
+#: cps/templates/book_edit.html
 msgid "Upload Format"
 msgstr ""
 
-#: cps/templates/book_edit.html:147 cps/templates/book_table.html:112
+#: cps/templates/book_edit.html cps/templates/book_table.html
 msgid "Series ID"
 msgstr ""
 
-#: cps/templates/book_edit.html:150
+#: cps/templates/book_edit.html
 msgid "Published Date"
 msgstr ""
 
-#: cps/templates/book_edit.html:179 cps/templates/book_edit.html:470
+#: cps/templates/book_edit.html
 msgid "Identifier Type"
 msgstr ""
 
-#: cps/templates/book_edit.html:180 cps/templates/book_edit.html:471
+#: cps/templates/book_edit.html
 msgid "Identifier Value"
 msgstr ""
 
-#: cps/templates/book_edit.html:181 cps/templates/book_edit.html:472
-#: cps/templates/user_table.html:24
+#: cps/templates/book_edit.html cps/templates/user_table.html
 msgid "Remove"
 msgstr ""
 
-#: cps/templates/book_edit.html:186
+#: cps/templates/book_edit.html
 msgid "Add Identifier"
 msgstr ""
 
-#: cps/templates/book_edit.html:195
+#: cps/templates/book_edit.html
 msgid ""
 "Pick a cover from any source, paste a URL, upload a file, or use the "
 "embedded cover."
 msgstr ""
 
-#: cps/templates/book_edit.html:199
+#: cps/templates/book_edit.html
 msgid ""
 "Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
 "database)"
 msgstr ""
 
-#: cps/templates/book_edit.html:208
+#: cps/templates/book_edit.html
 msgid "Upload Cover from Local Disk"
 msgstr ""
 
-#: cps/templates/book_edit.html:286
+#: cps/templates/book_edit.html
 msgid "Hardcover Sync Blacklist"
 msgstr ""
 
-#: cps/templates/book_edit.html:290
+#: cps/templates/book_edit.html
 msgid "Blacklist annotations from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:297
+#: cps/templates/book_edit.html
 msgid "Blacklist reading progress from syncing to Hardcover"
 msgstr ""
 
-#: cps/templates/book_edit.html:306
+#: cps/templates/book_edit.html
 msgid "View Book on Save"
 msgstr ""
 
-#: cps/templates/book_edit.html:310 cps/templates/book_edit.html:332
+#: cps/templates/book_edit.html
 msgid "Fetch Metadata"
 msgstr ""
 
-#: cps/templates/book_edit.html:335
+#: cps/templates/book_edit.html
 msgid "Keyword"
 msgstr ""
 
-#: cps/templates/book_edit.html:336
+#: cps/templates/book_edit.html
 msgid "Search keyword"
 msgstr ""
 
-#: cps/templates/book_edit.html:345
+#: cps/templates/book_edit.html
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
 
-#: cps/templates/book_edit.html:352
+#: cps/templates/book_edit.html
 msgid "API Keys"
 msgstr ""
 
-#: cps/templates/book_edit.html:358
+#: cps/templates/book_edit.html
 msgid ""
 "Some metadata sources need an API key. Adding a key here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/book_edit.html:360 cps/templates/book_edit.html:374
-#: cps/templates/book_edit.html:456
+#: cps/templates/book_edit.html
 msgid "Loading..."
 msgstr ""
 
-#: cps/templates/book_edit.html:365
+#: cps/templates/book_edit.html
 msgid "Sort by:"
 msgstr ""
 
-#: cps/templates/book_edit.html:367
+#: cps/templates/book_edit.html
 msgid "Provider order (default)"
 msgstr ""
 
-#: cps/templates/book_edit.html:368
+#: cps/templates/book_edit.html
 msgid "Cover size — largest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:369
+#: cps/templates/book_edit.html
 msgid "Cover size — smallest first"
 msgstr ""
 
-#: cps/templates/book_edit.html:400
+#: cps/templates/book_edit.html
 msgid "Apply"
 msgstr ""
 
-#: cps/templates/book_edit.html:457
+#: cps/templates/book_edit.html
 msgid "Search error!"
 msgstr ""
 
-#: cps/templates/book_edit.html:458
+#: cps/templates/book_edit.html
 msgid "No Result(s) found! Please try another keyword."
 msgstr ""
 
-#: cps/templates/book_table.html:12 cps/templates/book_table.html:112
-#: cps/templates/user_table.html:14 cps/templates/user_table.html:77
-#: cps/templates/user_table.html:100
+#: cps/templates/book_table.html cps/templates/user_table.html
 msgid "This Field is Required"
 msgstr ""
 
-#: cps/templates/book_table.html:71
+#: cps/templates/book_table.html
 msgid " Exchange author & title"
 msgstr ""
 
-#: cps/templates/book_table.html:76
+#: cps/templates/book_table.html
 msgid "Select all"
 msgstr ""
 
-#: cps/templates/book_table.html:79
+#: cps/templates/book_table.html
 msgid "Clear all"
 msgstr ""
 
-#: cps/templates/book_table.html:88
+#: cps/templates/book_table.html
 msgid "Update Title Sort automatically  "
 msgstr ""
 
-#: cps/templates/book_table.html:92
+#: cps/templates/book_table.html
 msgid "Update Author Sort automatically"
 msgstr ""
 
-#: cps/templates/book_table.html:106 cps/templates/book_table.html:112
+#: cps/templates/book_table.html
 msgid "Enter Title"
 msgstr ""
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Enter Title Sort"
 msgstr ""
 
-#: cps/templates/book_table.html:107
+#: cps/templates/book_table.html
 msgid "Title Sort"
 msgstr ""
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Enter Author Sort"
 msgstr ""
 
-#: cps/templates/book_table.html:108
+#: cps/templates/book_table.html
 msgid "Author Sort"
 msgstr ""
 
-#: cps/templates/book_table.html:109
+#: cps/templates/book_table.html
 msgid "Enter Authors"
 msgstr ""
 
-#: cps/templates/book_table.html:110
+#: cps/templates/book_table.html
 msgid "Enter Categories"
 msgstr ""
 
-#: cps/templates/book_table.html:111
+#: cps/templates/book_table.html
 msgid "Enter Series"
 msgstr ""
 
-#: cps/templates/book_table.html:113
+#: cps/templates/book_table.html
 msgid "Enter Languages"
 msgstr ""
 
-#: cps/templates/book_table.html:114
+#: cps/templates/book_table.html
 msgid "Publishing Date"
 msgstr ""
 
-#: cps/templates/book_table.html:115
+#: cps/templates/book_table.html
 msgid "Enter Publishers"
 msgstr ""
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Enter comments"
 msgstr ""
 
-#: cps/templates/book_table.html:116
+#: cps/templates/book_table.html
 msgid "Comments"
 msgstr ""
 
-#: cps/templates/book_table.html:118
+#: cps/templates/book_table.html
 msgid "Archived?"
 msgstr ""
 
-#: cps/templates/book_table.html:120
+#: cps/templates/book_table.html
 msgid "Read?"
 msgstr ""
 
-#: cps/templates/book_table.html:123 cps/templates/book_table.html:125
-#: cps/templates/book_table.html:127 cps/templates/book_table.html:129
-#: cps/templates/book_table.html:133 cps/templates/book_table.html:135
-#: cps/templates/book_table.html:139
+#: cps/templates/book_table.html
 msgid "Enter "
 msgstr ""
 
-#: cps/templates/book_table.html:162 cps/templates/book_table.html:186
-#: cps/templates/book_table.html:206 cps/templates/book_table.html:226
-#: cps/templates/book_table.html:246 cps/templates/book_table.html:266
-#: cps/templates/duplicates.html:707 cps/templates/modal_dialogs.html:46
-#: cps/templates/tasks.html:84
+#: cps/templates/book_table.html cps/templates/duplicates.html
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Are you really sure?"
 msgstr ""
 
-#: cps/templates/book_table.html:166
+#: cps/templates/book_table.html
 msgid "Books with Title will be merged from:"
 msgstr ""
 
-#: cps/templates/book_table.html:170
+#: cps/templates/book_table.html
 msgid "Into Book with Title:"
 msgstr ""
 
-#: cps/templates/book_table.html:190
+#: cps/templates/book_table.html
 msgid "The following books will be deleted:"
 msgstr ""
 
-#: cps/templates/book_table.html:210
+#: cps/templates/book_table.html
 msgid "The following books will be archived:"
 msgstr ""
 
-#: cps/templates/book_table.html:230
+#: cps/templates/book_table.html
 msgid "The following books will be unarchived:"
 msgstr ""
 
-#: cps/templates/book_table.html:250
+#: cps/templates/book_table.html
 msgid "The following books will be marked read:"
 msgstr ""
 
-#: cps/templates/book_table.html:270
+#: cps/templates/book_table.html
 msgid "The following books will be marked unread:"
 msgstr ""
 
-#: cps/templates/book_table.html:286 cps/templates/detail.html:721
+#: cps/templates/book_table.html cps/templates/detail.html
 msgid "Edit Metadata"
 msgstr ""
 
-#: cps/templates/book_table.html:289
+#: cps/templates/book_table.html
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
 msgstr ""
 
-#: cps/templates/book_table.html:291
+#: cps/templates/book_table.html
 msgid ""
 "Multiple values are supported for Authors, Tags/Categories, Languages, "
 "and Publishers. Use comma-separated values (e.g., \"Name1, Name2\")."
 msgstr ""
 
-#: cps/templates/book_table.html:347
+#: cps/templates/book_table.html
 msgid "Select a Shelf"
 msgstr ""
 
-#: cps/templates/book_table.html:350
+#: cps/templates/book_table.html
 msgid "Please select a shelf to add the selected books to:"
 msgstr ""
 
-#: cps/templates/book_table.html:352
+#: cps/templates/book_table.html
 msgid "-- Select a Shelf --"
 msgstr ""
 
-#: cps/templates/book_table.html:370 cps/templates/email_edit.html:87
-#: cps/templates/email_edit.html:114 cps/templates/shelf.html:102
-#: cps/templates/shelf.html:126 cps/templates/user_table.html:27
+#: cps/templates/book_table.html cps/templates/email_edit.html
+#: cps/templates/shelf.html cps/templates/user_table.html
 msgid "Add"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:8
+#: cps/templates/broadcast_email.html
 msgid "The email server is not configured yet, so announcements cannot be sent."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:13
+#: cps/templates/broadcast_email.html
 msgid ""
 "Compose a message and send it by email to your users. Messages are queued"
 " and sent in the background — check Tasks for delivery status."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:19
+#: cps/templates/broadcast_email.html
 msgid "Subject"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:25 cps/templates/tasks.html:20
+#: cps/templates/broadcast_email.html cps/templates/tasks.html
 msgid "Message"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:27
+#: cps/templates/broadcast_email.html
 msgid "Write your announcement here. HTML is allowed (links, bold, lists)."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:29
+#: cps/templates/broadcast_email.html
 msgid ""
 "HTML is allowed for formatting (e.g. links and bold). Recipients on "
 "plain-text mail clients automatically get a text-only version."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:31
+#: cps/templates/broadcast_email.html
 msgid "Use current announcement banner text"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:37
+#: cps/templates/broadcast_email.html
 msgid "Recipients"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:40
+#: cps/templates/broadcast_email.html
 msgid "Select all users with an email address"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:50
+#: cps/templates/broadcast_email.html
 msgid "No users have an email address set, so there is no one to send to yet."
 msgstr ""
 
-#: cps/templates/broadcast_email.html:55
+#: cps/templates/broadcast_email.html
 msgid "Send announcement"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:57
+#: cps/templates/broadcast_email.html
 msgid "Send test to me"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:58
-#: cps/templates/cwng_feedback_popup.html:50 cps/templates/email_edit.html:76
-#: cps/templates/layout.html:146 cps/templates/shelf_order.html:71
-#: cps/templates/shelf_reorder.html:39 cps/templates/user_table.html:176
+#: cps/templates/broadcast_email.html cps/templates/cwng_feedback_popup.html
+#: cps/templates/email_edit.html cps/templates/layout.html
+#: cps/templates/shelf_order.html cps/templates/shelf_reorder.html
+#: cps/templates/user_table.html
 msgid "Back"
 msgstr ""
 
-#: cps/templates/broadcast_email.html:69
+#: cps/templates/broadcast_email.html
 msgid "Send this announcement to __NUM__ recipient(s)?"
 msgstr ""
 
-#: cps/templates/config_db.html:18
+#: cps/templates/config_db.html
 msgid "Troubleshooting your DB"
 msgstr ""
 
-#: cps/templates/config_db.html:19
+#: cps/templates/config_db.html
 msgid ""
 "If you have been sent to this page after updating or migrating, there was"
 " a problem mounting your Calibre Database (metadata.db), or less likely, "
 "a problem with your app.db."
 msgstr ""
 
-#: cps/templates/config_db.html:20
+#: cps/templates/config_db.html
 msgid "Common causes include:"
 msgstr ""
 
-#: cps/templates/config_db.html:22
+#: cps/templates/config_db.html
 msgid ""
 "NextGen and Calibre are using the same database or library at the same "
 "time."
 msgstr ""
 
-#: cps/templates/config_db.html:23
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen, or part of it, is running over a network share without "
 "%(network_share_mode)s enabled in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:24
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "NextGen is running on %(unionfs)s or %(mergerfs)s without "
 "%(network_share_mode)s enabled."
 msgstr ""
 
-#: cps/templates/config_db.html:25
+#: cps/templates/config_db.html
 msgid "The path to your Calibre Database changed or is incorrect."
 msgstr ""
 
-#: cps/templates/config_db.html:26
+#: cps/templates/config_db.html
 msgid "The Calibre Database file (metadata.db) is missing or corrupted."
 msgstr ""
 
-#: cps/templates/config_db.html:27
+#: cps/templates/config_db.html
 msgid "File permissions prevent access to the Calibre Database."
 msgstr ""
 
-#: cps/templates/config_db.html:29
+#: cps/templates/config_db.html
 msgid "To resolve these issues, make sure that:"
 msgstr ""
 
-#: cps/templates/config_db.html:31
+#: cps/templates/config_db.html
 msgid ""
 "No other application, including Calibre, accesses the same Calibre "
 "Database while NextGen is running."
 msgstr ""
 
-#: cps/templates/config_db.html:32
+#: cps/templates/config_db.html
 #, python-format
 msgid ""
 "If you use a network share, unionfs, or mergerfs, enable "
 "%(network_share_mode)s in your Docker Compose configuration."
 msgstr ""
 
-#: cps/templates/config_db.html:33
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database path (metadata.db) is correct and accessible to "
 "NextGen."
 msgstr ""
 
-#: cps/templates/config_db.html:34
+#: cps/templates/config_db.html
 msgid ""
 "The Calibre Database file (metadata.db) exists and is not corrupted. Try "
 "opening it with Calibre to verify its integrity."
 msgstr ""
 
-#: cps/templates/config_db.html:35
+#: cps/templates/config_db.html
 msgid "NextGen has permission to access the Calibre Database file."
 msgstr ""
 
-#: cps/templates/config_db.html:37
+#: cps/templates/config_db.html
 msgid ""
 "If the problem remains after checking all of the above, restore your "
 "Calibre Database from a backup or create a new one."
 msgstr ""
 
-#: cps/templates/config_db.html:38
+#: cps/templates/config_db.html
 msgid ""
 "You can also use Last Resort Restore at the bottom of this page to try "
 "rebuilding your Calibre Database from the OPF files in your library."
 msgstr ""
 
-#: cps/templates/config_db.html:43
+#: cps/templates/config_db.html
 msgid "Location of Calibre Database (metadata.db file)"
 msgstr ""
 
-#: cps/templates/config_db.html:53
+#: cps/templates/config_db.html
 msgid ""
 "NextGen is configured so that your Calibre Database "
 "(<code>metadata.db</code> file) should always be somewhere in <code"
@@ -7522,14 +7371,14 @@ msgid ""
 "Automated/wiki/Configuration#database-configuration\">see here</a>!"
 msgstr ""
 
-#: cps/templates/config_db.html:59
+#: cps/templates/config_db.html
 msgid ""
 "Therefore, when configuring your docker-compose file for NextGen, <b>DO "
 "NOT CHANGE THE PATHS IN THE VOLUMES SECTION ON THE RIGHT SIDE OF THE "
 "COLONS!</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:60
+#: cps/templates/config_db.html
 msgid ""
 "These paths are internal to NextGen only, you can change what they're "
 "bind to to your heart's content on the left-hand side but there's no "
@@ -7541,7 +7390,7 @@ msgid ""
 " and there, enter the path to the rest of the library</b>"
 msgstr ""
 
-#: cps/templates/config_db.html:64
+#: cps/templates/config_db.html
 msgid ""
 "E.g. As long as your library's <code>metadata.db</code> file is bound "
 "somewhere within <code>/calibre-library</code>, you could bind the dir\n"
@@ -7552,42 +7401,42 @@ msgid ""
 "option."
 msgstr ""
 
-#: cps/templates/config_db.html:68
+#: cps/templates/config_db.html
 msgid "Split Library Functionality"
 msgstr ""
 
-#: cps/templates/config_db.html:71
+#: cps/templates/config_db.html
 msgid ""
 "<b>Separate Book Files from Library</b> - <code>metadata.db</code> file "
 "should remain in <code>/calibre-library</code>, however your library "
 "files can be wherever you desire"
 msgstr ""
 
-#: cps/templates/config_db.html:84
+#: cps/templates/config_db.html
 msgid "Use Google Drive?"
 msgstr ""
 
-#: cps/templates/config_db.html:89
+#: cps/templates/config_db.html
 msgid "Authenticate Google Drive"
 msgstr ""
 
-#: cps/templates/config_db.html:94
+#: cps/templates/config_db.html
 msgid "Google Drive Calibre folder"
 msgstr ""
 
-#: cps/templates/config_db.html:102
+#: cps/templates/config_db.html
 msgid "Metadata Watch Channel ID"
 msgstr ""
 
-#: cps/templates/config_db.html:105 cps/templates/user_edit.html:651
+#: cps/templates/config_db.html cps/templates/user_edit.html
 msgid "Revoke"
 msgstr ""
 
-#: cps/templates/config_db.html:123
+#: cps/templates/config_db.html
 msgid "Last Resort: Restore Calibre Database (experimental)"
 msgstr ""
 
-#: cps/templates/config_db.html:124
+#: cps/templates/config_db.html
 msgid ""
 "If your Calibre library is corrupted and cannot be opened, you can "
 "attempt to restore it from the OPF files in your library. This will "
@@ -7598,125 +7447,125 @@ msgid ""
 "saved alongside the backups."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 msgid "Are you sure? This cannot be undone."
 msgstr ""
 
-#: cps/templates/config_db.html:127
+#: cps/templates/config_db.html
 msgid "Restore Calibre Database (Last Resort)"
 msgstr ""
 
-#: cps/templates/config_db.html:143
+#: cps/templates/config_db.html
 msgid "New db location is invalid, please enter valid path"
 msgstr ""
 
-#: cps/templates/config_edit.html:6 cps/templates/config_edit.html:349
+#: cps/templates/config_edit.html
 msgid "Use Standard Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:8 cps/templates/config_edit.html:351
+#: cps/templates/config_edit.html
 msgid "Use LDAP Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:11
+#: cps/templates/config_edit.html
 msgid "Use OAuth"
 msgstr ""
 
-#: cps/templates/config_edit.html:105
+#: cps/templates/config_edit.html
 msgid "Server Configuration"
 msgstr ""
 
-#: cps/templates/config_edit.html:107
+#: cps/templates/config_edit.html
 msgid "Server Port"
 msgstr ""
 
-#: cps/templates/config_edit.html:110
+#: cps/templates/config_edit.html
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:117
+#: cps/templates/config_edit.html
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:125
+#: cps/templates/config_edit.html
 msgid "Update Channel"
 msgstr ""
 
-#: cps/templates/config_edit.html:127
+#: cps/templates/config_edit.html
 msgid "Stable"
 msgstr ""
 
-#: cps/templates/config_edit.html:128
+#: cps/templates/config_edit.html
 msgid "Nightly"
 msgstr ""
 
-#: cps/templates/config_edit.html:132
+#: cps/templates/config_edit.html
 msgid "Trusted Hosts (Comma Separated)"
 msgstr ""
 
-#: cps/templates/config_edit.html:138
+#: cps/templates/config_edit.html
 msgid "Logfile Configuration"
 msgstr ""
 
-#: cps/templates/config_edit.html:149
+#: cps/templates/config_edit.html
 msgid "Location and name of logfile (/dev/stdout for no entry)"
 msgstr ""
 
-#: cps/templates/config_edit.html:154
+#: cps/templates/config_edit.html
 msgid "Enable Access Log"
 msgstr ""
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html
 msgid "Location and name of access logfile (access.log for no entry)"
 msgstr ""
 
-#: cps/templates/config_edit.html:163
+#: cps/templates/config_edit.html
 msgid "Feature Configuration"
 msgstr ""
 
-#: cps/templates/config_edit.html:166
+#: cps/templates/config_edit.html
 msgid "Convert non-English characters in title and author while saving to disk"
 msgstr ""
 
-#: cps/templates/config_edit.html:170
+#: cps/templates/config_edit.html
 msgid ""
 "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs "
 "Calibre/Kepubify binaries)"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "Enable Uploads"
 msgstr ""
 
-#: cps/templates/config_edit.html:174
+#: cps/templates/config_edit.html
 msgid "(Please ensure that users also have upload permissions)"
 msgstr ""
 
-#: cps/templates/config_edit.html:178
+#: cps/templates/config_edit.html
 msgid "Allowed Upload Fileformats"
 msgstr ""
 
-#: cps/templates/config_edit.html:184
+#: cps/templates/config_edit.html
 msgid "Enable Anonymous Browsing"
 msgstr ""
 
-#: cps/templates/config_edit.html:188
+#: cps/templates/config_edit.html
 msgid "Enable Public Registration"
 msgstr ""
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html
 msgid "Use Email as Username"
 msgstr ""
 
-#: cps/templates/config_edit.html:198
+#: cps/templates/config_edit.html
 msgid "Enable Magic Link Remote Login"
 msgstr ""
 
-#: cps/templates/config_edit.html:202
+#: cps/templates/config_edit.html
 msgid "Allow users to hide books from their personal library"
 msgstr ""
 
-#: cps/templates/config_edit.html:203
+#: cps/templates/config_edit.html
 msgid ""
 "On by default for new installations; an existing saved choice is "
 "preserved during upgrades. When enabled, each user gets a hide button on "
@@ -7725,151 +7574,151 @@ msgid ""
 "profile page (Hidden Books link)."
 msgstr ""
 
-#: cps/templates/config_edit.html:213
+#: cps/templates/config_edit.html
 msgid "Proxy unknown requests to Kobo Store"
 msgstr ""
 
-#: cps/templates/config_edit.html:217
+#: cps/templates/config_edit.html
 msgid "Produce and prefer KEPUB for Kobo delivery"
 msgstr ""
 
-#: cps/templates/config_edit.html:219
+#: cps/templates/config_edit.html
 msgid ""
 "Kepubify was not found. Set its path under External binaries before this "
 "preference can convert books."
 msgstr ""
 
-#: cps/templates/config_edit.html:221
+#: cps/templates/config_edit.html
 msgid ""
 "Missing KEPUB files are created for books already delivered to a Kobo. "
 "EPUB remains the source format."
 msgstr ""
 
-#: cps/templates/config_edit.html:222
+#: cps/templates/config_edit.html
 msgid "Convert missing KEPUBs now"
 msgstr ""
 
-#: cps/templates/config_edit.html:226
+#: cps/templates/config_edit.html
 msgid "Server External Port (for port forwarded API calls)"
 msgstr ""
 
-#: cps/templates/config_edit.html:231
+#: cps/templates/config_edit.html
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html
 msgid "Pad book covers to Kobo screen aspect ratio"
 msgstr ""
 
-#: cps/templates/config_edit.html:237
+#: cps/templates/config_edit.html
 msgid ""
 "Eliminates the white letterbox bars that Kobo devices show on covers "
 "whose aspect ratio does not match the screen. Padding is applied server-"
 "side; original cover files on disk are unchanged."
 msgstr ""
 
-#: cps/templates/config_edit.html:243 cps/templates/cover_picker.html:106
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Libra Color / Libra 2 (1264x1680)"
 msgstr ""
 
-#: cps/templates/config_edit.html:244 cps/templates/cover_picker.html:107
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Kobo Clara HD / 2E / BW / Colour (1072x1448)"
 msgstr ""
 
-#: cps/templates/config_edit.html:246 cps/templates/cover_picker.html:109
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "2:3 (publisher cover, no padding for typical covers)"
 msgstr ""
 
-#: cps/templates/config_edit.html:255 cps/templates/cover_picker.html:119
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: most-common color in the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:256 cps/templates/cover_picker.html:120
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: average color of the cover"
 msgstr ""
 
-#: cps/templates/config_edit.html:257 cps/templates/cover_picker.html:121
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Solid: custom color"
 msgstr ""
 
-#: cps/templates/config_edit.html:263 cps/templates/cover_picker.html:128
+#: cps/templates/config_edit.html cps/templates/cover_picker.html
 msgid "Custom border color (hex)"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html
 msgid "Only used when fill style is 'Solid: custom color'. Format: #RRGGBB."
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html
 msgid "Use Goodreads"
 msgstr ""
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html
 msgid "Goodreads API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:284
+#: cps/templates/config_edit.html
 msgid "Enable Hardcover Sync"
 msgstr ""
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html
 msgid "Controls Hardcover auto-fetch and reading-progress sync from one setting."
 msgstr ""
 
-#: cps/templates/config_edit.html:287
+#: cps/templates/config_edit.html
 msgid ""
 "Managed by HARDCOVER_SYNC_ENABLED; change the environment variable to "
 "enable or disable Hardcover sync."
 msgstr ""
 
-#: cps/templates/config_edit.html:291
+#: cps/templates/config_edit.html
 msgid "Hardcover API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:293
+#: cps/templates/config_edit.html
 msgid ""
 "Free key from https://hardcover.app/account/api — required for Hardcover "
 "metadata results."
 msgstr ""
 
-#: cps/templates/config_edit.html:295
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the HARDCOVER_TOKEN environment variable is currently "
 "active. It is not shown here; a key entered in this field would override "
 "it."
 msgstr ""
 
-#: cps/templates/config_edit.html:297
+#: cps/templates/config_edit.html
 msgid ""
 "A token from the file named by HARDCOVER_TOKEN_FILE is currently active. "
 "It is not shown here; a key entered in this field would override it."
 msgstr ""
 
-#: cps/templates/config_edit.html:302
+#: cps/templates/config_edit.html
 msgid "Token status: not configured."
 msgstr ""
 
-#: cps/templates/config_edit.html:304
+#: cps/templates/config_edit.html
 msgid "Token status: valid."
 msgstr ""
 
-#: cps/templates/config_edit.html:306
+#: cps/templates/config_edit.html
 msgid "Token status: rejected or expired."
 msgstr ""
 
-#: cps/templates/config_edit.html:308
+#: cps/templates/config_edit.html
 msgid "Token status: present; validation is temporarily unavailable."
 msgstr ""
 
-#: cps/templates/config_edit.html:313
+#: cps/templates/config_edit.html
 msgid "Expiry: not provided by this token."
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html
 msgid "Google Books API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:321
+#: cps/templates/config_edit.html
 msgid ""
 "Optional. Without a key, Google Books is rate-limited to ~1,000 requests "
 "/ IP / day, which is easily exhausted on shared servers (HTTP 429). Free "
@@ -7877,401 +7726,401 @@ msgid ""
 "create an API key."
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html
 msgid "Allow Reverse Proxy Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:326
+#: cps/templates/config_edit.html
 msgid ""
 "Trusts the \"Remote-User\" header from a reverse proxy for "
 "authentication. This is an authentication method, distinct from the HTTPS"
 " security setting below."
 msgstr ""
 
-#: cps/templates/config_edit.html:330
+#: cps/templates/config_edit.html
 msgid "Use via HTTPS"
 msgstr ""
 
-#: cps/templates/config_edit.html:331
+#: cps/templates/config_edit.html
 msgid ""
 "Enables secure cookie settings (Secure, SameSite=Lax). Enable this ONLY "
 "if you are accessing the server via HTTPS, otherwise you will be locked "
 "out."
 msgstr ""
 
-#: cps/templates/config_edit.html:340
+#: cps/templates/config_edit.html
 msgid "Auto-create users from reverse proxy"
 msgstr ""
 
-#: cps/templates/config_edit.html:341
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when valid reverse proxy headers are "
 "received. Only enable if your reverse proxy authentication is properly "
 "secured."
 msgstr ""
 
-#: cps/templates/config_edit.html:347
+#: cps/templates/config_edit.html
 msgid "Login type"
 msgstr ""
 
-#: cps/templates/config_edit.html:354
+#: cps/templates/config_edit.html
 msgid "Use OAuth (requires HTTPS)"
 msgstr ""
 
-#: cps/templates/config_edit.html:361
+#: cps/templates/config_edit.html
 msgid "LDAP Server Host Name or IP Address"
 msgstr ""
 
-#: cps/templates/config_edit.html:365
+#: cps/templates/config_edit.html
 msgid "LDAP Server Port"
 msgstr ""
 
-#: cps/templates/config_edit.html:369
+#: cps/templates/config_edit.html
 msgid "LDAP Encryption"
 msgstr ""
 
-#: cps/templates/config_edit.html:377
+#: cps/templates/config_edit.html
 msgid ""
 "LDAP CACertificate Path (Only needed for Client Certificate "
 "Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:384
+#: cps/templates/config_edit.html
 msgid "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:391
+#: cps/templates/config_edit.html
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:400
+#: cps/templates/config_edit.html
 msgid "LDAP Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:404
+#: cps/templates/config_edit.html
 msgid "Simple"
 msgstr ""
 
-#: cps/templates/config_edit.html:409
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Username"
 msgstr ""
 
-#: cps/templates/config_edit.html:415
+#: cps/templates/config_edit.html
 msgid "LDAP Administrator Password"
 msgstr ""
 
-#: cps/templates/config_edit.html:420
+#: cps/templates/config_edit.html
 msgid "LDAP Distinguished Name (DN)"
 msgstr ""
 
-#: cps/templates/config_edit.html:424
+#: cps/templates/config_edit.html
 msgid "LDAP User Object Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:429
+#: cps/templates/config_edit.html
 msgid "LDAP Server is OpenLDAP?"
 msgstr ""
 
-#: cps/templates/config_edit.html:433
+#: cps/templates/config_edit.html
 msgid "Auto-create users from LDAP"
 msgstr ""
 
-#: cps/templates/config_edit.html:434
+#: cps/templates/config_edit.html
 msgid ""
 "Automatically create user accounts when LDAP authentication succeeds for "
 "new users. Recommended for enterprise environments."
 msgstr ""
 
-#: cps/templates/config_edit.html:436
+#: cps/templates/config_edit.html
 msgid "Following Settings are Needed For User Import"
 msgstr ""
 
-#: cps/templates/config_edit.html:438
+#: cps/templates/config_edit.html
 msgid "LDAP Group Object Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:442
+#: cps/templates/config_edit.html
 msgid "LDAP Group Name"
 msgstr ""
 
-#: cps/templates/config_edit.html:446
+#: cps/templates/config_edit.html
 msgid "LDAP Group Members Field"
 msgstr ""
 
-#: cps/templates/config_edit.html:450
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter Detection"
 msgstr ""
 
-#: cps/templates/config_edit.html:452
+#: cps/templates/config_edit.html
 msgid "Autodetect"
 msgstr ""
 
-#: cps/templates/config_edit.html:453
+#: cps/templates/config_edit.html
 msgid "Custom Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:458
+#: cps/templates/config_edit.html
 msgid "LDAP Member User Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid "Important:"
 msgstr ""
 
-#: cps/templates/config_edit.html:468
+#: cps/templates/config_edit.html
 msgid ""
 "OAuth authentication requires this server to be accessed via HTTPS. If "
 "you are using HTTP, login will fail."
 msgstr ""
 
-#: cps/templates/config_edit.html:471
+#: cps/templates/config_edit.html
 msgid "Generic OAuth Provider"
 msgstr ""
 
-#: cps/templates/config_edit.html:475
+#: cps/templates/config_edit.html
 msgid "OAuth Metadata URL (for auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:479
+#: cps/templates/config_edit.html
 msgid "Test Metadata"
 msgstr ""
 
-#: cps/templates/config_edit.html:482
+#: cps/templates/config_edit.html
 msgid "Leave empty to use manual configuration below"
 msgstr ""
 
-#: cps/templates/config_edit.html:488
+#: cps/templates/config_edit.html
 msgid "Use Manual Endpoint URLs (override auto-discovery)"
 msgstr ""
 
-#: cps/templates/config_edit.html:489
+#: cps/templates/config_edit.html
 msgid ""
 "Check this to manually configure individual OAuth endpoints instead of "
 "using auto-discovery"
 msgstr ""
 
-#: cps/templates/config_edit.html:494
+#: cps/templates/config_edit.html
 msgid "Manual Endpoint Configuration"
 msgstr ""
 
-#: cps/templates/config_edit.html:497
+#: cps/templates/config_edit.html
 msgid "OAuth Base URL"
 msgstr ""
 
-#: cps/templates/config_edit.html:502
+#: cps/templates/config_edit.html
 msgid "Authorization Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:507
+#: cps/templates/config_edit.html
 msgid "Token Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:512
+#: cps/templates/config_edit.html
 msgid "UserInfo Endpoint"
 msgstr ""
 
-#: cps/templates/config_edit.html:520
+#: cps/templates/config_edit.html
 msgid "Test Connection"
 msgstr ""
 
-#: cps/templates/config_edit.html:529
+#: cps/templates/config_edit.html
 msgid "OAuth Scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:531
+#: cps/templates/config_edit.html
 msgid "Space-separated list of OAuth scopes"
 msgstr ""
 
-#: cps/templates/config_edit.html:536
+#: cps/templates/config_edit.html
 msgid "OAuth Redirect Host"
 msgstr ""
 
-#: cps/templates/config_edit.html:539
+#: cps/templates/config_edit.html
 msgid ""
 "Set a consistent hostname for OAuth redirects to prevent \"invalid "
 "redirect URI\" errors. Include protocol (https://). Leave empty to use "
 "automatic detection."
 msgstr ""
 
-#: cps/templates/config_edit.html:541
+#: cps/templates/config_edit.html
 msgid ""
 "Required if: accessing via multiple hostnames, behind reverse proxy, or "
 "getting \"invalid redirect URI\" errors."
 msgstr ""
 
-#: cps/templates/config_edit.html:546
+#: cps/templates/config_edit.html
 msgid "OAuth Client Id"
 msgstr ""
 
-#: cps/templates/config_edit.html:550
+#: cps/templates/config_edit.html
 msgid "OAuth Client Secret"
 msgstr ""
 
-#: cps/templates/config_edit.html:555
+#: cps/templates/config_edit.html
 msgid "Field Mapping Configuration"
 msgstr ""
 
-#: cps/templates/config_edit.html:557
+#: cps/templates/config_edit.html
 msgid "Username Field"
 msgstr ""
 
-#: cps/templates/config_edit.html:559
+#: cps/templates/config_edit.html
 msgid "JWT field to extract username from"
 msgstr ""
 
-#: cps/templates/config_edit.html:562
+#: cps/templates/config_edit.html
 msgid "Email Field"
 msgstr ""
 
-#: cps/templates/config_edit.html:564
+#: cps/templates/config_edit.html
 msgid "JWT field to extract email from"
 msgstr ""
 
-#: cps/templates/config_edit.html:567
+#: cps/templates/config_edit.html
 msgid "OAuth Group Claim"
 msgstr ""
 
-#: cps/templates/config_edit.html:569
+#: cps/templates/config_edit.html
 msgid ""
 "OIDC claim containing group names. The claim may be a list, or a comma- "
 "or space-separated string."
 msgstr ""
 
-#: cps/templates/config_edit.html:573
+#: cps/templates/config_edit.html
 msgid "Require OAuth Group Membership"
 msgstr ""
 
-#: cps/templates/config_edit.html:574
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, Generic OAuth users must be a member of at least one "
 "allowed group before a user account is created or logged in."
 msgstr ""
 
-#: cps/templates/config_edit.html:577
+#: cps/templates/config_edit.html
 msgid "OAuth Allowed Groups"
 msgstr ""
 
-#: cps/templates/config_edit.html:579
+#: cps/templates/config_edit.html
 msgid ""
 "Comma- or space-separated OAuth groups allowed to log in via Generic "
 "OAuth. Leave empty only if group membership is not required."
 msgstr ""
 
-#: cps/templates/config_edit.html:582
+#: cps/templates/config_edit.html
 msgid "OAuth group for Admin"
 msgstr ""
 
-#: cps/templates/config_edit.html:584
+#: cps/templates/config_edit.html
 msgid ""
 "Name of the OAuth group that grants admin privileges. Leave empty to "
 "disable group-based admin management, or use the global setting in "
 "Security Settings for more control."
 msgstr ""
 
-#: cps/templates/config_edit.html:586
+#: cps/templates/config_edit.html
 msgid "Default Permissions for New Generic OAuth Users"
 msgstr ""
 
-#: cps/templates/config_edit.html:590 cps/templates/config_view_edit.html:136
-#: cps/templates/user_edit.html:443
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Downloads"
 msgstr ""
 
-#: cps/templates/config_edit.html:594 cps/templates/config_view_edit.html:141
-#: cps/templates/user_edit.html:448
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow eBook Viewer"
 msgstr ""
 
-#: cps/templates/config_edit.html:599 cps/templates/config_view_edit.html:147
-#: cps/templates/user_edit.html:454
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Uploads"
 msgstr ""
 
-#: cps/templates/config_edit.html:604 cps/templates/config_view_edit.html:153
-#: cps/templates/user_edit.html:460
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Edit"
 msgstr ""
 
-#: cps/templates/config_edit.html:608 cps/templates/config_view_edit.html:158
-#: cps/templates/user_edit.html:465
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Delete Books"
 msgstr ""
 
-#: cps/templates/config_edit.html:612 cps/templates/config_view_edit.html:163
-#: cps/templates/user_edit.html:471
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Changing Password"
 msgstr ""
 
-#: cps/templates/config_edit.html:616 cps/templates/config_view_edit.html:168
-#: cps/templates/user_edit.html:476
+#: cps/templates/config_edit.html cps/templates/config_view_edit.html
+#: cps/templates/user_edit.html
 msgid "Allow Editing Public Shelves"
 msgstr ""
 
-#: cps/templates/config_edit.html:619
+#: cps/templates/config_edit.html
 msgid ""
 "These permissions are applied only when a new user is created via Generic"
 " OAuth. Admin group membership still grants admin privileges when OAuth "
 "group-based admin management is enabled. Existing users are not changed."
 msgstr ""
 
-#: cps/templates/config_edit.html:621
+#: cps/templates/config_edit.html
 msgid "Login Button Text"
 msgstr ""
 
-#: cps/templates/config_edit.html:627
+#: cps/templates/config_edit.html
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr ""
 
-#: cps/templates/config_edit.html:630
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr ""
 
-#: cps/templates/config_edit.html:634
+#: cps/templates/config_edit.html
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr ""
 
-#: cps/templates/config_edit.html:645
+#: cps/templates/config_edit.html
 msgid "External binaries"
 msgstr ""
 
-#: cps/templates/config_edit.html:646
+#: cps/templates/config_edit.html
 msgid "Path to Calibre Binaries"
 msgstr ""
 
-#: cps/templates/config_edit.html:654
+#: cps/templates/config_edit.html
 msgid "Calibre E-Book Converter Settings"
 msgstr ""
 
-#: cps/templates/config_edit.html:657
+#: cps/templates/config_edit.html
 msgid "Path to Kepubify E-Book Converter"
 msgstr ""
 
-#: cps/templates/config_edit.html:665
+#: cps/templates/config_edit.html
 msgid "Location of Unrar binary"
 msgstr ""
 
-#: cps/templates/config_edit.html:676
+#: cps/templates/config_edit.html
 msgid "Security Settings"
 msgstr ""
 
-#: cps/templates/config_edit.html:679
+#: cps/templates/config_edit.html
 msgid "Disable Standard Login (Username/Password)"
 msgstr ""
 
-#: cps/templates/config_edit.html:680
+#: cps/templates/config_edit.html
 msgid ""
 "Hides the standard login form. Users must log in via OAuth or LDAP. "
 "Ensure you have a working alternative login method before enabling."
 msgstr ""
 
-#: cps/templates/config_edit.html:684
+#: cps/templates/config_edit.html
 msgid "Enable OAuth Group-Based Admin Role Management"
 msgstr ""
 
-#: cps/templates/config_edit.html:685
+#: cps/templates/config_edit.html
 msgid ""
 "When enabled, admin privileges are automatically granted or revoked based"
 " on OAuth group membership. Disable this to manually manage admin roles "
@@ -8279,325 +8128,320 @@ msgid ""
 "local role assignments."
 msgstr ""
 
-#: cps/templates/config_edit.html:689
+#: cps/templates/config_edit.html
 msgid "Limit failed login attempts"
 msgstr ""
 
-#: cps/templates/config_edit.html:693
+#: cps/templates/config_edit.html
 msgid "Configure Backend for Limiter"
 msgstr ""
 
-#: cps/templates/config_edit.html:697
+#: cps/templates/config_edit.html
 msgid "Options for Limiter Backend"
 msgstr ""
 
-#: cps/templates/config_edit.html:703
+#: cps/templates/config_edit.html
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 
-#: cps/templates/config_edit.html:706
+#: cps/templates/config_edit.html
 msgid "Session protection"
 msgstr ""
 
-#: cps/templates/config_edit.html:708
+#: cps/templates/config_edit.html
 msgid "Basic"
 msgstr ""
 
-#: cps/templates/config_edit.html:709
+#: cps/templates/config_edit.html
 msgid "Strong"
 msgstr ""
 
-#: cps/templates/config_edit.html:714
+#: cps/templates/config_edit.html
 msgid "User Password policy"
 msgstr ""
 
-#: cps/templates/config_edit.html:718
+#: cps/templates/config_edit.html
 msgid "Minimum password length"
 msgstr ""
 
-#: cps/templates/config_edit.html:723
+#: cps/templates/config_edit.html
 msgid "Enforce number"
 msgstr ""
 
-#: cps/templates/config_edit.html:727
+#: cps/templates/config_edit.html
 msgid "Enforce lowercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:731
+#: cps/templates/config_edit.html
 msgid "Enforce uppercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:735
+#: cps/templates/config_edit.html
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 
-#: cps/templates/config_edit.html:739
+#: cps/templates/config_edit.html
 msgid "Enforce special characters"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:36
+#: cps/templates/config_view_edit.html
 msgid "View Configuration"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:41
+#: cps/templates/config_view_edit.html
 msgid "The title displayed in the browser tab and navbar."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:47
+#: cps/templates/config_view_edit.html
 msgid "Number of books to display per page in list views (1-200)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:51
+#: cps/templates/config_view_edit.html
 msgid "No. of Random Books to Display"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:53
+#: cps/templates/config_view_edit.html
 msgid "Number of random books shown on the home page (1-30)."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:57
+#: cps/templates/config_view_edit.html
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:59
+#: cps/templates/config_view_edit.html
 msgid ""
 "Maximum number of authors to show in book details before truncating. Set "
 "to 0 to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:63
+#: cps/templates/config_view_edit.html
 msgid "Default Theme"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:65
+#: cps/templates/config_view_edit.html
 msgid "caliBlur! Dark Theme"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:67
+#: cps/templates/config_view_edit.html
 msgid ""
 "Default theme for new users and anonymous browsing. Users can select "
 "their own preferred theme in their profile."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:71
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Ignoring Columns"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:73
+#: cps/templates/config_view_edit.html
 msgid "Regex pattern to hide custom columns from being displayed in the UI."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:77
+#: cps/templates/config_view_edit.html
 msgid "Link Read/Unread Status to Calibre Column"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:84
+#: cps/templates/config_view_edit.html
 msgid "Sync read/unread status with a Calibre boolean custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:88
+#: cps/templates/config_view_edit.html
 msgid "View Restrictions based on Calibre column"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:95
+#: cps/templates/config_view_edit.html
 msgid "Restrict book visibility based on values in a Calibre text custom column."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:99
+#: cps/templates/config_view_edit.html
 msgid "Regular Expression for Title Sorting"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:101
+#: cps/templates/config_view_edit.html
 msgid ""
 "Regex to strip prefixes from titles for proper sorting (e.g., \"The\", "
 "\"A\", \"An\")."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:107
+#: cps/templates/config_view_edit.html
 msgid "Site Customization"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:110
+#: cps/templates/config_view_edit.html
 msgid "Server announcement banner"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:111
+#: cps/templates/config_view_edit.html
 msgid ""
 "Leave blank to hide the banner. Shown at the top of every page until each"
 " user dismisses it."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:112
+#: cps/templates/config_view_edit.html
 msgid ""
 "Up to 500 characters. HTML is escaped. Each user dismisses the banner "
 "independently; editing the text re-shows it for everyone."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:116
+#: cps/templates/config_view_edit.html
 msgid "Custom CSS"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:117
+#: cps/templates/config_view_edit.html
 #, python-brace-format
 msgid "e.g. .navbar { background: #2b2b2b; }"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:118
+#: cps/templates/config_view_edit.html
 msgid ""
 "Injected into every page as the last stylesheet, so it overrides the "
 "built-in themes. Applies to all users. Leave blank to disable."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:124
+#: cps/templates/config_view_edit.html
 msgid "Default Settings for New Users"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:125
+#: cps/templates/config_view_edit.html
 msgid "These settings will be applied to all newly created user accounts."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:127
+#: cps/templates/config_view_edit.html
 msgid "Permissions"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:131 cps/templates/user_edit.html:437
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Admin User"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:172
+#: cps/templates/config_view_edit.html
 msgid "Language & Display"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:174
+#: cps/templates/config_view_edit.html
 msgid "Default Language"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:180
+#: cps/templates/config_view_edit.html
 msgid "Default interface language for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:184
+#: cps/templates/config_view_edit.html
 msgid "Default Visible Language of Books"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:191
+#: cps/templates/config_view_edit.html
 msgid "Default book language filter for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:195
+#: cps/templates/config_view_edit.html
 msgid "OPDS Default Locale for Anonymous Clients"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:197
+#: cps/templates/config_view_edit.html
 msgid "(none — fall back to English)"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:202
+#: cps/templates/config_view_edit.html
 msgid ""
 "Used for anonymous OPDS feed responses when the client does not send an "
 "Accept-Language header and the request does not include a ?lang= "
 "override. Authenticated users keep their own selected locale."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:208
+#: cps/templates/config_view_edit.html
 msgid "Default Visibilities for New Users"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:209
+#: cps/templates/config_view_edit.html
 msgid "Choose which sidebar sections are visible by default for new users."
 msgstr ""
 
-#: cps/templates/config_view_edit.html:222 cps/templates/user_edit.html:395
-#: cps/templates/user_table.html:156
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
+#: cps/templates/user_table.html
 msgid "Show Random Books in Detail View"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:228 cps/templates/user_edit.html:401
+#: cps/templates/config_view_edit.html cps/templates/user_edit.html
 msgid "Add Allowed/Denied Tags"
 msgstr ""
 
-#: cps/templates/config_view_edit.html:229
+#: cps/templates/config_view_edit.html
 msgid "Add Allowed/Denied custom column values"
 msgstr ""
 
-#: cps/templates/cover_picker.html:51
+#: cps/templates/cover_picker.html
 msgid "Use a URL"
 msgstr ""
 
-#: cps/templates/cover_picker.html:69
+#: cps/templates/cover_picker.html
 msgid "Upload a file"
 msgstr ""
 
-#: cps/templates/cover_picker.html:84
+#: cps/templates/cover_picker.html
 msgid ""
 "Some metadata sources need an API key. Adding one here improves cover "
 "quality and unblocks rate-limited services. Keys are stored once for the "
 "whole instance — admins only."
 msgstr ""
 
-#: cps/templates/cover_picker.html:98
+#: cps/templates/cover_picker.html
 msgid "Show how each cover would look on your e-reader"
 msgstr ""
 
-#: cps/templates/cover_picker.html:136
+#: cps/templates/cover_picker.html
 msgid ""
 "Adjust how covers preview here. Defaults live in Admin → Configuration → "
 "Kobo sync."
 msgstr ""
 
-#: cps/templates/cover_picker.html:146
+#: cps/templates/cover_picker.html
 msgid "Candidates"
 msgstr ""
 
-#: cps/templates/cover_picker.html:159
+#: cps/templates/cover_picker.html
 msgid "Loading candidates…"
 msgstr ""
 
-#: cps/templates/cover_picker.html:175
+#: cps/templates/cover_picker.html
 msgid "Replace cover with this candidate?"
 msgstr ""
 
-#: cps/templates/cover_picker.html:229
+#: cps/templates/cover_picker.html
 msgid "Rendering e-reader previews:"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:10
-#: cps/templates/cwa_cover_enforcer.html:24
-#: cps/templates/cwa_epub_fixer.html:34
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run Archive"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:11
-#: cps/templates/cwa_cover_enforcer.html:25
-#: cps/templates/cwa_epub_fixer.html:35 cps/templates/cwa_read_log.html:9
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/cwa_read_log.html
 msgid "Download Log"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:24
-#: cps/templates/cwa_cover_enforcer.html:30
-#: cps/templates/cwa_epub_fixer.html:39 cps/templates/index.xml:7
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_cover_enforcer.html
+#: cps/templates/cwa_epub_fixer.html cps/templates/index.xml
 msgid "Start"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:27
-#: cps/templates/cwa_epub_fixer.html:44
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 5m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:28
-#: cps/templates/cwa_epub_fixer.html:45
+#: cps/templates/cwa_convert_library.html cps/templates/cwa_epub_fixer.html
 msgid "Schedule 15m"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:100
+#: cps/templates/cwa_convert_library.html
 msgid "Convert Library scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_convert_library.html:103
+#: cps/templates/cwa_convert_library.html
 msgid "Error scheduling Convert Library"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:17
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "This service rewrites the covers and metadata stored inside the ebook "
 "files themselves for every book in your library, so the files on disk "
@@ -8606,7 +8450,7 @@ msgid ""
 "toggled in CWA Settings."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:18
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Upon loading this page, if you have previously started a run of the "
 "NextGen Cover & Metadata Enforcement service either here in the Web UI or"
@@ -8614,7 +8458,7 @@ msgid ""
 " below."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:19
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "Once you start a run, you are free to leave the page and return whenever "
 "you want to check on the run's progress. If you wish to cancel a run that"
@@ -8622,86 +8466,85 @@ msgid ""
 "will terminate ASAP."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:27
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Bulk Processing"
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:52
+#: cps/templates/cwa_cover_enforcer.html
 msgid ""
 "No current or previous run to display. Press the Start button above to "
 "initiate a run."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:101
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Lost contact with the server, retrying..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:163
-#: cps/templates/cwa_cover_enforcer.html:170
+#: cps/templates/cwa_cover_enforcer.html
 msgid "The request failed."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:177
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Starting..."
 msgstr ""
 
-#: cps/templates/cwa_cover_enforcer.html:190
+#: cps/templates/cwa_cover_enforcer.html
 msgid "Cancelling..."
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:22
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on a single book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:24
+#: cps/templates/cwa_epub_fixer.html
 msgid "Search by title/author"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:29
+#: cps/templates/cwa_epub_fixer.html
 msgid "Run on selected book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:120
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer scheduled successfully"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:123
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error scheduling EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:132
+#: cps/templates/cwa_epub_fixer.html
 msgid "No matches found"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:167
+#: cps/templates/cwa_epub_fixer.html
 msgid "Enter a search term"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:175
+#: cps/templates/cwa_epub_fixer.html
 msgid "Failed to search library"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:182
+#: cps/templates/cwa_epub_fixer.html
 msgid "Select a book first"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:195
+#: cps/templates/cwa_epub_fixer.html
 msgid "EPUB Fixer started for selected book"
 msgstr ""
 
-#: cps/templates/cwa_epub_fixer.html:200
+#: cps/templates/cwa_epub_fixer.html
 msgid "Error starting EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:136
+#: cps/templates/cwa_settings.html
 msgid "Enable/Disable Calibre-Web NextGen Services"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:143
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Convert"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:145
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active all ingested books will automatically be "
 "converted to the target format specified below (epub by default) \n"
@@ -8709,11 +8552,11 @@ msgid ""
 "ignore below."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:154
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Automatic Cover & Metadata Enforcement Service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:156
+#: cps/templates/cwa_settings.html
 msgid ""
 "On by default, when active, whenever the Metadata and/or Cover Image is "
 "edited in the Web UI, the NextGen Metadata Enforcement service \n"
@@ -8725,11 +8568,11 @@ msgid ""
 "        or AZW3 format."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:167
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Kindle EPUB Fixer"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:169
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the encoding among other attributes of all EPUB files "
 "processed by NextGen will be checked and fixed to ensure maximum \n"
@@ -8739,162 +8582,162 @@ msgid ""
 "        file rejections or formatting problems."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:174
+#: cps/templates/cwa_settings.html
 msgid ""
 "This tool was adapted from the <a href=\"https://kindle-epub-"
 "fix.netlify.app/\">kindle-epub-fix.netlify.app</a> tool made by <a "
 "href=\"https://github.com/innocenat\">innocenat</a>."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:181
+#: cps/templates/cwa_settings.html
 msgid "Enable KOReader Sync (NextGen Plugin)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:183
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, NextGen exposes the /kosync endpoints and stores KOReader-"
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:185
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: Enabling this starts a checksum backfill service at startup which "
 "can temporarily lock metadata.db. To stop a running backfill, restart the"
 " container after disabling."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:192
+#: cps/templates/cwa_settings.html
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:194
+#: cps/templates/cwa_settings.html
 msgid ""
 "Aggressive mode applies more invasive fixes and will attempt lower-"
 "confidence encoding conversions. Safe mode is recommended for most "
 "libraries."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:202
+#: cps/templates/cwa_settings.html
 msgid "Enable Archived Book Cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:204
+#: cps/templates/cwa_settings.html
 msgid ""
 "Removes stale archived book references in app.db when the book no longer "
 "exists in the Calibre library. Helps keep archived counts accurate."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:208
+#: cps/templates/cwa_settings.html
 msgid "Cleanup Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:213 cps/templates/cwa_settings.html:582
+#: cps/templates/cwa_settings.html
 msgid "Frequent Intervals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:214 cps/templates/cwa_settings.html:583
+#: cps/templates/cwa_settings.html
 msgid "Every 15 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:215 cps/templates/cwa_settings.html:584
+#: cps/templates/cwa_settings.html
 msgid "Every 30 Minutes"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:216 cps/templates/cwa_settings.html:585
+#: cps/templates/cwa_settings.html
 msgid "Every Hour"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:217 cps/templates/cwa_settings.html:586
+#: cps/templates/cwa_settings.html
 msgid "Every 2 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:218 cps/templates/cwa_settings.html:587
+#: cps/templates/cwa_settings.html
 msgid "Every 4 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:219 cps/templates/cwa_settings.html:588
+#: cps/templates/cwa_settings.html
 msgid "Every 6 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:220 cps/templates/cwa_settings.html:589
+#: cps/templates/cwa_settings.html
 msgid "Every 12 Hours"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:222 cps/templates/cwa_settings.html:591
+#: cps/templates/cwa_settings.html
 msgid "Daily/Weekly/Monthly"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:223 cps/templates/cwa_settings.html:592
+#: cps/templates/cwa_settings.html
 msgid "Daily at Specific Time"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:224 cps/templates/cwa_settings.html:593
+#: cps/templates/cwa_settings.html
 msgid "Weekly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:225 cps/templates/cwa_settings.html:594
+#: cps/templates/cwa_settings.html
 msgid "Monthly on Specific Day"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:228
+#: cps/templates/cwa_settings.html
 msgid "Default: daily at 03:00"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:231 cps/templates/cwa_settings.html:601
+#: cps/templates/cwa_settings.html
 msgid "Day of Week:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:235 cps/templates/cwa_settings.html:606
+#: cps/templates/cwa_settings.html
 msgid "Monday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:236 cps/templates/cwa_settings.html:607
+#: cps/templates/cwa_settings.html
 msgid "Tuesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:237 cps/templates/cwa_settings.html:608
+#: cps/templates/cwa_settings.html
 msgid "Wednesday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:238 cps/templates/cwa_settings.html:609
+#: cps/templates/cwa_settings.html
 msgid "Thursday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:239 cps/templates/cwa_settings.html:610
+#: cps/templates/cwa_settings.html
 msgid "Friday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:240 cps/templates/cwa_settings.html:611
+#: cps/templates/cwa_settings.html
 msgid "Saturday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:241 cps/templates/cwa_settings.html:612
+#: cps/templates/cwa_settings.html
 msgid "Sunday"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:246 cps/templates/cwa_settings.html:618
+#: cps/templates/cwa_settings.html
 msgid "Day of Month:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:254 cps/templates/cwa_settings.html:627
+#: cps/templates/cwa_settings.html
 msgid "(1-28)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:258 cps/templates/cwa_settings.html:632
+#: cps/templates/cwa_settings.html
 msgid "Time of Day:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:266 cps/templates/cwa_settings.html:641
+#: cps/templates/cwa_settings.html
 #, python-format
 msgid "(Server timezone: %(tz)s)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:302
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Metadata Fetching for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:304
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, NextGen will automatically attempt to fetch and apply "
 "metadata (title, author, description, cover, etc.) for newly ingested "
@@ -8903,11 +8746,11 @@ msgid ""
 "or missing metadata."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:312
+#: cps/templates/cwa_settings.html
 msgid "Enable Smart Metadata Application"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:314
+#: cps/templates/cwa_settings.html
 msgid ""
 "When enabled, fetched metadata will only replace existing data if it "
 "appears to be better quality (e.g., longer descriptions, higher "
@@ -8915,107 +8758,105 @@ msgid ""
 " data as-is from the preferred provider."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:319
+#: cps/templates/cwa_settings.html
 msgid "Metadata Fields to Update"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:321
+#: cps/templates/cwa_settings.html
 msgid ""
 "Select which metadata fields should be updated when auto-fetching. "
 "Unchecked fields will never be modified during automatic metadata "
 "fetching, preserving your existing data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
+#: cps/templates/cwa_settings.html
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
+#: cps/templates/cwa_settings.html
 msgid "Identifiers (ISBN, etc.)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:390 cps/templates/cwa_settings.html:392
+#: cps/templates/cwa_settings.html
 msgid "Cover Image"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398 cps/templates/cwa_settings.html:419
-#: cps/templates/cwa_settings.html:526 cps/templates/cwa_settings.html:731
-#: cps/templates/user_edit.html:421 cps/templates/user_edit.html:512
+#: cps/templates/cwa_settings.html cps/templates/user_edit.html
 msgid "Tip"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:398
+#: cps/templates/cwa_settings.html
 msgid ""
 "These field selections apply to both Smart and Direct replacement modes. "
 "Smart mode will additionally apply quality criteria to selected fields, "
 "while Direct mode will replace all selected fields with provider data."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:403
+#: cps/templates/cwa_settings.html
 msgid "Cover File Max Size (MB):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:416
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-200 MB (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:419
+#: cps/templates/cwa_settings.html
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata "
 "providers or URLs to prevent slow or stalled saves."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:428
+#: cps/templates/cwa_settings.html
 msgid "Ingest Processing Timeout"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:430
+#: cps/templates/cwa_settings.html
 msgid ""
 "Maximum time (in minutes) to allow for processing a single book before "
 "timing out. Files that timeout are moved to the failed backup folder for "
 "investigation."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:432
+#: cps/templates/cwa_settings.html
 msgid "Timeout (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:444
+#: cps/templates/cwa_settings.html
 msgid "Range: 5-120 minutes (default: 15)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:448
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:449
+#: cps/templates/cwa_settings.html
 msgid ""
 "Ignored temporary upload files (.uploading, .part, etc.) can be cleaned "
 "after a set age. Setting either value to 0 disables cleanup. Changes "
 "apply on the next cleanup cycle."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:454
+#: cps/templates/cwa_settings.html
 msgid "Stale temp age (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:467
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-10080 minutes (default: 120)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:471
+#: cps/templates/cwa_settings.html
 msgid "Stale temp cleanup interval (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:484
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-86400 seconds (default: 600)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:490
+#: cps/templates/cwa_settings.html
 msgid "Auto-Send Delay for New Books"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:492
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay (in minutes) before automatically sending newly ingested books to "
 "eReaders. This allows time for metadata fetching and other processing to "
@@ -9023,53 +8864,53 @@ msgid ""
 " in their profile."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:494
+#: cps/templates/cwa_settings.html
 msgid "Delay (minutes):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:506
+#: cps/templates/cwa_settings.html
 msgid "Range: 1-60 minutes (default: 5)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:511
+#: cps/templates/cwa_settings.html
 msgid "Auto Metadata Fetch Provider Hierarchy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:513
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure the order in which metadata providers are searched when "
 "automatically fetching metadata for new books. Drag and drop to reorder "
 "providers. Only enabled providers will be used."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:526
+#: cps/templates/cwa_settings.html
 msgid "Providers are tried in order from top to bottom. Drag to reorder."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:535
+#: cps/templates/cwa_settings.html
 msgid "Enabled Metadata Providers"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:537
+#: cps/templates/cwa_settings.html
 msgid "Unchecked providers are disabled globally."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:550
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Auto-Fetch Settings"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:552
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically fetch and assign Hardcover IDs to books in your library. "
 "Hardcover IDs enable reading progress sync and annotation sync with "
 "Hardcover.app when using compatible eReaders."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:557
+#: cps/templates/cwa_settings.html
 msgid "Hardcover Token Required"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:558
+#: cps/templates/cwa_settings.html
 msgid ""
 "To enable Hardcover auto-fetch, you must set a valid HARDCOVER_TOKEN in "
 "your docker-compose environment variables or configure a global token in "
@@ -9077,102 +8918,102 @@ msgid ""
 "disabled."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:565
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is enabled. The schedule below controls automatic ID "
 "fetching."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:567
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hardcover sync is disabled. Enable it once in Basic Configuration or set "
 "HARDCOVER_SYNC_ENABLED=true."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:571
+#: cps/templates/cwa_settings.html
 msgid ""
 "Automatically search Hardcover for books without Hardcover IDs. High-"
 "confidence matches are applied automatically; low-confidence matches are "
 "queued for manual review."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:576
+#: cps/templates/cwa_settings.html
 msgid "Run Schedule:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:597
+#: cps/templates/cwa_settings.html
 msgid "How often to automatically run the Hardcover ID fetch task"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:677
+#: cps/templates/cwa_settings.html
 msgid "Minimum Confidence Threshold:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:687
+#: cps/templates/cwa_settings.html
 msgid "Range: 0.50-1.00 (default: 0.85)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:689
+#: cps/templates/cwa_settings.html
 msgid ""
 "Matches with confidence scores above this threshold are automatically "
 "applied. Lower scores are queued for manual review. Higher values = fewer"
 " auto-matches but higher accuracy."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:695
+#: cps/templates/cwa_settings.html
 msgid "Batch Size:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:705
+#: cps/templates/cwa_settings.html
 msgid "Range: 10-200 books per run (default: 50)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:707
+#: cps/templates/cwa_settings.html
 msgid ""
 "Number of books to process in each scheduled run. Smaller batches reduce "
 "API load; larger batches process your library faster."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:713
+#: cps/templates/cwa_settings.html
 msgid "Rate Limit Delay (seconds):"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:723
+#: cps/templates/cwa_settings.html
 msgid "Range: 0-60 seconds (default: 5.0)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:725
+#: cps/templates/cwa_settings.html
 msgid ""
 "Delay between API requests to Hardcover. Prevents rate limiting and "
 "protects your API key. Uses exponential backoff on errors."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:731
+#: cps/templates/cwa_settings.html
 msgid ""
 "You can manually trigger the Hardcover auto-fetch task from the Admin "
 "panel at any time. Check the NextGen Stats page to see progress and "
 "review queued matches that need manual approval."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:738
+#: cps/templates/cwa_settings.html
 msgid "Web UI Settings"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:745
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Update Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:747
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, you will receive notifications in the Web UI when a new "
 "version of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:751
+#: cps/templates/cwa_settings.html
 msgid "Automatic updates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:753
+#: cps/templates/cwa_settings.html
 msgid ""
 "New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
 "update itself from inside its container (nothing running inside a "
@@ -9181,102 +9022,101 @@ msgid ""
 "other containers alone."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:756
+#: cps/templates/cwa_settings.html
 msgid ""
 "Add these two services to your docker-compose file and run \"docker "
 "compose up -d\". After that you stay up to date automatically — no button"
 " to press."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
-#: cps/templates/update_now_modal.html:45
-#: cps/templates/update_now_modal.html:63 cps/templates/user_edit.html:618
+#: cps/templates/cwa_settings.html cps/templates/update_now_modal.html
+#: cps/templates/user_edit.html
 msgid "Copied!"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:773
+#: cps/templates/cwa_settings.html
 msgid ""
 "The label means Watchtower only ever touches Calibre-Web NextGen. The "
 "86400 interval checks once a day; \"cleanup\" removes the old image after"
 " each update."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:776
+#: cps/templates/cwa_settings.html
 msgid ""
 "Running under Podman instead? Native \"podman auto-update\" works too — a"
 " setup guide is coming once we have verified it against this image."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:785
+#: cps/templates/cwa_settings.html
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:787
+#: cps/templates/cwa_settings.html
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI "
 "when using a language other than English if the translations for your "
 "chosen language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:795
+#: cps/templates/cwa_settings.html
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:797
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:805
+#: cps/templates/cwa_settings.html
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:807
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the blurred cover background effect is also rendered on "
 "small screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:812
+#: cps/templates/cwa_settings.html
 msgid "Automatic Backup Settings"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:819
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, a copy of all imported files will be stored in "
 "<i>/config/processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:829
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of ingested files that undergo conversion will"
 " be stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:839
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:841
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service "
 "will make zip archives of all the backed up converted, imported and "
@@ -9284,43 +9124,43 @@ msgid ""
 "/config/processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:858
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:861
+#: cps/templates/cwa_settings.html
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:863
+#: cps/templates/cwa_settings.html
 msgid "Choose a target format:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:875
+#: cps/templates/cwa_settings.html
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support "
 "file in either EPUB and AZW3 format. Files in other formats will simply "
 "be ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:881
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:883
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:908
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will always be added to the library, even after"
 " they have been converted to the target format. However, if the format is"
@@ -9328,869 +9168,857 @@ msgid ""
 "imported. Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:940
+#: cps/templates/cwa_settings.html
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:941
+#: cps/templates/cwa_settings.html
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:959
+#: cps/templates/cwa_settings.html
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:963
+#: cps/templates/cwa_settings.html
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:967
+#: cps/templates/cwa_settings.html
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:975
+#: cps/templates/cwa_settings.html
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest "
 "feature, meaning files in these formats won't be added to the library by "
 "NextGen during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1001
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1004
+#: cps/templates/cwa_settings.html
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, "
 "duplicate scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1009
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Detection"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1013
+#: cps/templates/cwa_settings.html
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1021
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1024
+#: cps/templates/cwa_settings.html
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1027
+#: cps/templates/cwa_settings.html
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1030
+#: cps/templates/cwa_settings.html
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1036
+#: cps/templates/cwa_settings.html
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies"
 " the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1045
+#: cps/templates/cwa_settings.html
 msgid "Automatic Duplicate Scanning"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1048
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1053
+#: cps/templates/cwa_settings.html
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1060
+#: cps/templates/cwa_settings.html
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1063
+#: cps/templates/cwa_settings.html
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069
+#: cps/templates/cwa_settings.html
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1077
+#: cps/templates/cwa_settings.html
 msgid ""
 "Wait this many seconds after the last import before starting a background"
 " scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1082
+#: cps/templates/cwa_settings.html
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1088
+#: cps/templates/cwa_settings.html
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1093
+#: cps/templates/cwa_settings.html
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1100 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1107
+#: cps/templates/cwa_settings.html
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1117
+#: cps/templates/cwa_settings.html
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1123
+#: cps/templates/cwa_settings.html
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1129
+#: cps/templates/cwa_settings.html
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1135
+#: cps/templates/cwa_settings.html
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1141
+#: cps/templates/cwa_settings.html
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1147
+#: cps/templates/cwa_settings.html
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1153
+#: cps/templates/cwa_settings.html
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended"
 " as core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1159
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure which file formats are preferred when using the \"Highest "
 "Quality Format\" auto-resolution strategy. Drag and drop to reorder "
 "formats by priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1175
+#: cps/templates/cwa_settings.html
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books"
 " with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1183
+#: cps/templates/cwa_settings.html
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1186
+#: cps/templates/cwa_settings.html
 msgid ""
 "Configure how you are notified about duplicate books and optionally "
 "enable automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html
 msgid "Enable Duplicate Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1193
+#: cps/templates/cwa_settings.html
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins "
 "and users with edit rights will see a badge on the Duplicates sidebar "
 "button and a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1197
+#: cps/templates/cwa_settings.html
 msgid "Enable Automatic Duplicate Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html cps/templates/duplicates.html
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1200
+#: cps/templates/cwa_settings.html
 msgid ""
 "This will automatically delete books based on the strategy below. "
 "Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1204
+#: cps/templates/cwa_settings.html
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1207
+#: cps/templates/cwa_settings.html
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1210
+#: cps/templates/cwa_settings.html
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1213
+#: cps/templates/cwa_settings.html
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1216
+#: cps/templates/cwa_settings.html
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep Most Metadata"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1219
+#: cps/templates/cwa_settings.html
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1222
+#: cps/templates/cwa_settings.html
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1225
+#: cps/templates/cwa_settings.html
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1229
+#: cps/templates/cwa_settings.html
 msgid "Rate Limiting"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1230
+#: cps/templates/cwa_settings.html
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1234
+#: cps/templates/cwa_settings.html
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents "
 "rapid-fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1239
+#: cps/templates/cwa_settings.html
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. "
 "Dismissed duplicate groups are never auto-resolved."
 msgstr ""
 
-#: cps/templates/cwa_stats.html:66 cps/templates/cwa_stats_system.html:58
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 #, python-format
 msgid "Review %(count)s Pending Match(es)"
 msgstr ""
 
-#: cps/templates/cwa_stats.html:78 cps/templates/cwa_stats.html:100
-#: cps/templates/cwa_stats.html:122 cps/templates/cwa_stats.html:141
-#: cps/templates/cwa_stats.html:165 cps/templates/cwa_stats.html:184
-#: cps/templates/cwa_stats_system.html:70
-#: cps/templates/cwa_stats_system.html:92
-#: cps/templates/cwa_stats_system.html:114
-#: cps/templates/cwa_stats_system.html:133
-#: cps/templates/cwa_stats_system.html:157
-#: cps/templates/cwa_stats_system.html:176
+#: cps/templates/cwa_stats.html cps/templates/cwa_stats_system.html
 msgid "Click to See More"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:28
+#: cps/templates/cwng_feedback_popup.html
 msgid "Before you go — what made you switch back?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:29
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Optional, and completely anonymous. It helps us make the new interface "
 "better."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:31
+#: cps/templates/cwng_feedback_popup.html
 msgid "Something was broken or glitchy"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:32
+#: cps/templates/cwng_feedback_popup.html
 msgid "I prefer the classic look"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:33
+#: cps/templates/cwng_feedback_popup.html
 msgid "A feature I use was missing"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:34
+#: cps/templates/cwng_feedback_popup.html
 msgid "Too different / hard to find things"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:35
+#: cps/templates/cwng_feedback_popup.html
 msgid "It felt slow"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:38
+#: cps/templates/cwng_feedback_popup.html
 msgid "No thanks"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:39 cps/templates/feed.xml:31
-#: cps/templates/layout.html:709 cps/templates/layout.html:735
+#: cps/templates/cwng_feedback_popup.html cps/templates/feed.xml
+#: cps/templates/layout.html
 msgid "Next"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:45
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anything you’d like to add?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:46
+#: cps/templates/cwng_feedback_popup.html
 msgid "Optional — a sentence or two is plenty."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:48
+#: cps/templates/cwng_feedback_popup.html
 msgid "What would have kept you on the new interface?"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:51
+#: cps/templates/cwng_feedback_popup.html
 msgid "Send feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:60
+#: cps/templates/cwng_feedback_popup.html
 msgid "Thank you"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:61
+#: cps/templates/cwng_feedback_popup.html
 msgid "Your feedback was sent anonymously. We read every note."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:69
+#: cps/templates/cwng_feedback_popup.html
 msgid "Couldn’t send just now"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:70
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "No problem — your feedback wasn’t saved anywhere. You can close this or "
 "try again."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:73
+#: cps/templates/cwng_feedback_popup.html
 msgid "Try again"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:81
+#: cps/templates/cwng_feedback_popup.html
 msgid "Anonymize my feedback"
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:83
+#: cps/templates/cwng_feedback_popup.html
 msgid "No account, name, IP address, version or device info is sent or stored."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:84
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Sent over HTTPS to a server we run and saved as just your feedback — like"
 " unmarked mail. The network edge briefly sees your IP to stop spam; we "
 "only use a one-way hash of it for about a minute and never store it."
 msgstr ""
 
-#: cps/templates/cwng_feedback_popup.html:85
+#: cps/templates/cwng_feedback_popup.html
 msgid ""
 "Because you turned off anonymizing, your app version will be included to "
 "help us reproduce issues."
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1077 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Unread"
 msgstr ""
 
-#: cps/templates/detail.html:691 cps/templates/detail.html:692
-#: cps/templates/detail.html:1078 cps/templates/listenmp3.html:158
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Mark As Read"
 msgstr ""
 
-#: cps/templates/detail.html:693
+#: cps/templates/detail.html
 msgid "Marked as read"
 msgstr ""
 
-#: cps/templates/detail.html:694
+#: cps/templates/detail.html
 msgid "Marked as unread"
 msgstr ""
 
-#: cps/templates/detail.html:704
+#: cps/templates/detail.html
 msgid "Added to favorites"
 msgstr ""
 
-#: cps/templates/detail.html:705
+#: cps/templates/detail.html
 msgid "Removed from favorites"
 msgstr ""
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1088 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Restore from archive"
 msgstr ""
 
-#: cps/templates/detail.html:710 cps/templates/detail.html:711
-#: cps/templates/detail.html:1089 cps/templates/listenmp3.html:166
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Add to archive"
 msgstr ""
 
-#: cps/templates/detail.html:713
+#: cps/templates/detail.html
 msgid "Restored from archive"
 msgstr ""
 
-#: cps/templates/detail.html:736
+#: cps/templates/detail.html
 msgid "Reloaded metadata from disk"
 msgstr ""
 
-#: cps/templates/detail.html:737
+#: cps/templates/detail.html
 msgid "On-disk metadata matches — nothing to update"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Unhide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:768 cps/templates/detail.html:769
+#: cps/templates/detail.html
 msgid "Hide from your library"
 msgstr ""
 
-#: cps/templates/detail.html:771
+#: cps/templates/detail.html
 msgid "Unhidden"
 msgstr ""
 
-#: cps/templates/detail.html:858
+#: cps/templates/detail.html
 msgid "Rating updated"
 msgstr ""
 
-#: cps/templates/detail.html:859
+#: cps/templates/detail.html
 msgid "Rating cleared"
 msgstr ""
 
-#: cps/templates/detail.html:877 cps/templates/listenmp3.html:62
+#: cps/templates/detail.html cps/templates/listenmp3.html
 #, python-format
 msgid "Book %(index)s of %(range)s"
 msgstr ""
 
-#: cps/templates/detail.html:882
+#: cps/templates/detail.html
 msgid "ID"
 msgstr ""
 
-#: cps/templates/detail.html:887
+#: cps/templates/detail.html
 msgid "UUID"
 msgstr ""
 
-#: cps/templates/detail.html:890
+#: cps/templates/detail.html
 msgid "UUID copied to clipboard"
 msgstr ""
 
-#: cps/templates/detail.html:891
+#: cps/templates/detail.html
 msgid "Unable to copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:892 cps/templates/detail.html:893
+#: cps/templates/detail.html
 msgid "Copy UUID"
 msgstr ""
 
-#: cps/templates/detail.html:913
+#: cps/templates/detail.html
 msgid "File sizes"
 msgstr ""
 
-#: cps/templates/detail.html:1100 cps/templates/listenmp3.html:177
+#: cps/templates/detail.html cps/templates/listenmp3.html
 msgid "Description:"
 msgstr ""
 
-#: cps/templates/detail.html:1117
+#: cps/templates/detail.html
 msgid "Select eReader Email Addresses"
 msgstr ""
 
-#: cps/templates/detail.html:1130
+#: cps/templates/detail.html
 msgid "Choose email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1135
+#: cps/templates/detail.html
 msgid "Select All"
 msgstr ""
 
-#: cps/templates/detail.html:1156
+#: cps/templates/detail.html
 msgid "Other users' eReaders:"
 msgstr ""
 
-#: cps/templates/detail.html:1171
+#: cps/templates/detail.html
 msgid "Additional email addresses:"
 msgstr ""
 
-#: cps/templates/detail.html:1172
+#: cps/templates/detail.html
 msgid "Enter additional email addresses (separated by commas):"
 msgstr ""
 
-#: cps/templates/detail.html:1173
+#: cps/templates/detail.html
 msgid "example@domain.com, another@domain.com"
 msgstr ""
 
-#: cps/templates/detail.html:1174
+#: cps/templates/detail.html
 msgid "Enter one or more email addresses separated by commas"
 msgstr ""
 
-#: cps/templates/detail.html:1179
+#: cps/templates/detail.html
 msgid "Select format:"
 msgstr ""
 
-#: cps/templates/detail.html:1515
+#: cps/templates/detail.html
 msgid "Failed to update tags"
 msgstr ""
 
-#: cps/templates/detail.html:1623
+#: cps/templates/detail.html
 msgid "Failed to update shelves"
 msgstr ""
 
-#: cps/templates/duplicates.html:497
+#: cps/templates/duplicates.html
 msgid "NextGen Duplicates Manager"
 msgstr ""
 
-#: cps/templates/duplicates.html:499
+#: cps/templates/duplicates.html
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
 msgstr ""
 
-#: cps/templates/duplicates.html:507
+#: cps/templates/duplicates.html
 msgid "Run Full Duplicate Scan"
 msgstr ""
 
-#: cps/templates/duplicates.html:509
+#: cps/templates/duplicates.html
 msgid "Scan for Duplicates Now"
 msgstr ""
 
-#: cps/templates/duplicates.html:513
+#: cps/templates/duplicates.html
 msgid "Select Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:514
+#: cps/templates/duplicates.html
 msgid "Select None"
 msgstr ""
 
-#: cps/templates/duplicates.html:515
+#: cps/templates/duplicates.html
 msgid "Delete Selected"
 msgstr ""
 
-#: cps/templates/duplicates.html:529
+#: cps/templates/duplicates.html
 msgid "Duplicate scanning needs a one-time full scan."
 msgstr ""
 
-#: cps/templates/duplicates.html:531
+#: cps/templates/duplicates.html
 msgid ""
 "CWA now uses a duplicate index to keep duplicate checks fast during "
 "imports and metadata changes. Before incremental scans can run, the index"
 " needs an initial baseline."
 msgstr ""
 
-#: cps/templates/duplicates.html:534
+#: cps/templates/duplicates.html
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several "
 "minutes on large libraries, and you can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:541
+#: cps/templates/duplicates.html
 msgid "Duplicate scan is running."
 msgstr ""
 
-#: cps/templates/duplicates.html:542
+#: cps/templates/duplicates.html
 msgid "You can keep using CWA while it runs."
 msgstr ""
 
-#: cps/templates/duplicates.html:554
+#: cps/templates/duplicates.html
 msgid "View Background Tasks"
 msgstr ""
 
-#: cps/templates/duplicates.html:565
+#: cps/templates/duplicates.html
 msgid "Auto-Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/duplicates.html:569
+#: cps/templates/duplicates.html
 msgid ""
 "Automatically resolve all duplicate groups by keeping one book and "
 "deleting others based on a strategy."
 msgstr ""
 
-#: cps/templates/duplicates.html:573
+#: cps/templates/duplicates.html
 msgid "Strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:575
+#: cps/templates/duplicates.html
 msgid "Keep Newest - Delete older copies, keep the most recently added"
 msgstr ""
 
-#: cps/templates/duplicates.html:576
+#: cps/templates/duplicates.html
 msgid "Keep Oldest - Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/duplicates.html:577
+#: cps/templates/duplicates.html
 msgid "Merge Formats - Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/duplicates.html:578
+#: cps/templates/duplicates.html
 msgid ""
 "Keep Highest Quality Format - Prefer formats based on your Duplicate "
 "Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/duplicates.html:579
+#: cps/templates/duplicates.html
 msgid "Keep Most Metadata - Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/duplicates.html:580
+#: cps/templates/duplicates.html
 msgid "Keep Largest File Size - Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/duplicates.html:584
+#: cps/templates/duplicates.html
 msgid "Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:588 cps/templates/duplicates.html:695
+#: cps/templates/duplicates.html
 msgid "Execute Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:594
+#: cps/templates/duplicates.html
 msgid "This will permanently delete books. Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/duplicates.html:612
+#: cps/templates/duplicates.html
 msgid "Merge Selected"
 msgstr ""
 
-#: cps/templates/duplicates.html:616
+#: cps/templates/duplicates.html
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:629
+#: cps/templates/duplicates.html
 msgid "View book details"
 msgstr ""
 
-#: cps/templates/duplicates.html:656
+#: cps/templates/duplicates.html
 msgid "Edit book metadata"
 msgstr ""
 
-#: cps/templates/duplicates.html:659
+#: cps/templates/duplicates.html
 msgid "Archive/delete book"
 msgstr ""
 
-#: cps/templates/duplicates.html:673
+#: cps/templates/duplicates.html
 msgid "No Duplicate Books Found"
 msgstr ""
 
-#: cps/templates/duplicates.html:674
+#: cps/templates/duplicates.html
 msgid "Your library has no books with duplicate title and author combinations."
 msgstr ""
 
-#: cps/templates/duplicates.html:675
+#: cps/templates/duplicates.html
 msgid ""
 "This search looks for books with identical titles AND authors to avoid "
 "false positives."
 msgstr ""
 
-#: cps/templates/duplicates.html:685
+#: cps/templates/duplicates.html
 msgid "Execute Auto-Resolution"
 msgstr ""
 
-#: cps/templates/duplicates.html:688
+#: cps/templates/duplicates.html
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
 
-#: cps/templates/duplicates.html:690
+#: cps/templates/duplicates.html
 msgid "Selected strategy:"
 msgstr ""
 
-#: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
+#: cps/templates/duplicates.html
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: cps/templates/duplicates.html:711
+#: cps/templates/duplicates.html
 msgid "The following books will be permanently deleted:"
 msgstr ""
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:809
+#: cps/templates/duplicates.html cps/templates/layout.html
 msgid "Merge Books"
 msgstr ""
 
-#: cps/templates/duplicates.html:734
+#: cps/templates/duplicates.html
 msgid "The following book will be kept:"
 msgstr ""
 
-#: cps/templates/duplicates.html:738
+#: cps/templates/duplicates.html
 msgid "The following books will be merged into it (and then deleted):"
 msgstr ""
 
-#: cps/templates/duplicates.html:742
+#: cps/templates/duplicates.html
 msgid "Note: File formats from source books will be added to the target book."
 msgstr ""
 
-#: cps/templates/duplicates.html:759
+#: cps/templates/duplicates.html
 msgid "Resolution Preview"
 msgstr ""
 
-#: cps/templates/duplicates.html:777
+#: cps/templates/duplicates.html
 msgid "Success"
 msgstr ""
 
-#: cps/templates/duplicates.html:784
+#: cps/templates/duplicates.html
 msgid "Selected duplicate books have been deleted successfully!"
 msgstr ""
 
-#: cps/templates/duplicates.html:806
+#: cps/templates/duplicates.html
 msgid "An error occurred while processing your request."
 msgstr ""
 
-#: cps/templates/email_edit.html:13
+#: cps/templates/email_edit.html
 msgid "Email Account Type"
 msgstr ""
 
-#: cps/templates/email_edit.html:15
+#: cps/templates/email_edit.html
 msgid "Standard Email Account"
 msgstr ""
 
-#: cps/templates/email_edit.html:16
+#: cps/templates/email_edit.html
 msgid "Gmail Account"
 msgstr ""
 
-#: cps/templates/email_edit.html:22
+#: cps/templates/email_edit.html
 msgid "Setup Gmail Account"
 msgstr ""
 
-#: cps/templates/email_edit.html:24
+#: cps/templates/email_edit.html
 msgid "Revoke Gmail Access"
 msgstr ""
 
-#: cps/templates/email_edit.html:51
+#: cps/templates/email_edit.html
 msgid "SMTP Password"
 msgstr ""
 
-#: cps/templates/email_edit.html:62
+#: cps/templates/email_edit.html
 msgid ""
 "Message included with books sent to an eReader and in test emails. Sent "
 "as plain text, in any language. Leave blank to use the default."
 msgstr ""
 
-#: cps/templates/email_edit.html:64
+#: cps/templates/email_edit.html
 msgid "Attachment Size Limit"
 msgstr ""
 
-#: cps/templates/email_edit.html:72
+#: cps/templates/email_edit.html
 msgid "Save and Send Test Email"
 msgstr ""
 
-#: cps/templates/email_edit.html:80
+#: cps/templates/email_edit.html
 msgid "Allowed Domains (Whitelist)"
 msgstr ""
 
-#: cps/templates/email_edit.html:84 cps/templates/email_edit.html:111
+#: cps/templates/email_edit.html
 msgid "Add Domain"
 msgstr ""
 
-#: cps/templates/email_edit.html:92 cps/templates/email_edit.html:102
+#: cps/templates/email_edit.html
 msgid "Enter domainname"
 msgstr ""
 
-#: cps/templates/email_edit.html:98
+#: cps/templates/email_edit.html
 msgid "Denied Domains (Blacklist)"
 msgstr ""
 
-#: cps/templates/feed.xml:109
+#: cps/templates/feed.xml
 msgid "(Magic)"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:6
+#: cps/templates/generate_kobo_auth_url.html
 msgid ""
 "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
 "edit):"
 msgstr ""
 
-#: cps/templates/generate_kobo_auth_url.html:11
+#: cps/templates/generate_kobo_auth_url.html
 msgid "Kobo Token:"
 msgstr ""
 
-#: cps/templates/grid.html:21
+#: cps/templates/grid.html
 msgid "List"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:51
+#: cps/templates/hardcover_review_matches.html
 msgid "Hardcover Match Review 🔖"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:58
+#: cps/templates/hardcover_review_matches.html
 msgid "All Caught Up!"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:59
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "There are no pending Hardcover matches requiring review. New matches will"
 " appear here when the auto-fetch task runs."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:61
+#: cps/templates/hardcover_review_matches.html
 msgid "Back to Admin Panel"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:68
+#: cps/templates/hardcover_review_matches.html
 msgid "Review Required"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:69
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid ""
 "%(count)s book(s) have ambiguous Hardcover matches. Please review each "
@@ -10198,1437 +10026,1423 @@ msgid ""
 "exists."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:73
+#: cps/templates/hardcover_review_matches.html
 msgid "Pending Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:76
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Review and approve ambiguous Hardcover ID matches for your books. High-"
 "confidence matches are applied automatically; these require manual "
 "verification."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:81
+#: cps/templates/hardcover_review_matches.html
 msgid "Reject All Pending"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:94
+#: cps/templates/hardcover_review_matches.html
 msgid "Search Query"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 msgid "Candidate Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:98
+#: cps/templates/hardcover_review_matches.html
 #, python-format
 msgid "Top %(count)s"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:108
-#: cps/templates/hardcover_review_matches.html:110
-#: cps/templates/hardcover_review_matches.html:112
+#: cps/templates/hardcover_review_matches.html
 msgid "Confidence"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:155
+#: cps/templates/hardcover_review_matches.html
 msgid "Match Reason"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:160
+#: cps/templates/hardcover_review_matches.html
 msgid "View on Hardcover"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:168
+#: cps/templates/hardcover_review_matches.html
 msgid "Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:180
+#: cps/templates/hardcover_review_matches.html
 msgid "Reject All"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:185
+#: cps/templates/hardcover_review_matches.html
 msgid "Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:258
-#: cps/templates/hardcover_review_matches.html:303
-#: cps/templates/hardcover_review_matches.html:346
-#: cps/templates/hardcover_review_matches.html:380
+#: cps/templates/hardcover_review_matches.html
 msgid "Processing..."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:280
-#: cps/templates/hardcover_review_matches.html:289
+#: cps/templates/hardcover_review_matches.html
 msgid "✓ Select This Match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:284
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to apply match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:299
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be"
 " undone."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:324
-#: cps/templates/hardcover_review_matches.html:333
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:328
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject match"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:342
+#: cps/templates/hardcover_review_matches.html
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:361
-#: cps/templates/hardcover_review_matches.html:370
+#: cps/templates/hardcover_review_matches.html
 msgid "✗ Reject All Pending"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:365
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to reject all pending matches"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:401
-#: cps/templates/hardcover_review_matches.html:410
+#: cps/templates/hardcover_review_matches.html
 msgid "→ Skip for Now"
 msgstr ""
 
-#: cps/templates/hardcover_review_matches.html:405
+#: cps/templates/hardcover_review_matches.html
 msgid "Failed to skip match"
 msgstr ""
 
-#: cps/templates/http_error.html:37
+#: cps/templates/http_error.html
 msgid ""
 "Calibre-Web NextGen Instance is unconfigured, please contact your "
 "administrator"
 msgstr ""
 
-#: cps/templates/http_error.html:47
+#: cps/templates/http_error.html
 msgid "Create Issue"
 msgstr ""
 
-#: cps/templates/http_error.html:54
+#: cps/templates/http_error.html
 msgid "Return to Home"
 msgstr ""
 
-#: cps/templates/http_error.html:56
+#: cps/templates/http_error.html
 msgid "Logout User"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Mobile Notice"
 msgstr ""
 
-#: cps/templates/index.html:104
+#: cps/templates/index.html
 msgid "Magic shelf editing works best on desktop or tablet devices."
 msgstr ""
 
-#: cps/templates/index.html:119
+#: cps/templates/index.html
 msgid "Refresh shelf to update with latest changes"
 msgstr ""
 
-#: cps/templates/index.html:130
+#: cps/templates/index.html
 msgid "Edit shelf rules"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Hide this shelf from your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:144
+#: cps/templates/index.html
 msgid "Show this shelf in your sidebar"
 msgstr ""
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 msgid "Show Shelf"
 msgstr ""
 
-#: cps/templates/index.html:146
+#: cps/templates/index.html
 msgid "Hide Shelf"
 msgstr ""
 
-#: cps/templates/index.html:156
+#: cps/templates/index.html
 msgid "Add Series to Shelf"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:129
+#: cps/templates/kosync_plugin.html
 msgid "KOReader Sync is disabled."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:130
+#: cps/templates/kosync_plugin.html
 msgid ""
 "Enable it in NextGen Settings to activate the /kosync endpoints and "
 "checksum generation."
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:132
+#: cps/templates/kosync_plugin.html
 msgid "Open NextGen Settings"
 msgstr ""
 
-#: cps/templates/kosync_plugin.html:156
+#: cps/templates/kosync_plugin.html
 msgid "Download is available after enabling KOReader Sync in NextGen Settings."
 msgstr ""
 
-#: cps/templates/layout.html:146 cps/templates/login.html:51
+#: cps/templates/layout.html cps/templates/login.html
 msgid "Home"
 msgstr ""
 
-#: cps/templates/layout.html:312
+#: cps/templates/layout.html
 msgid "Toggle Navigation"
 msgstr ""
 
-#: cps/templates/layout.html:327
+#: cps/templates/layout.html
 msgid "Search Library"
 msgstr ""
 
-#: cps/templates/layout.html:344
+#: cps/templates/layout.html
 msgid "Switch to the new Calibre-Web NextGen interface"
 msgstr ""
 
-#: cps/templates/layout.html:348
+#: cps/templates/layout.html
 msgid "Switch to New UI"
 msgstr ""
 
-#: cps/templates/layout.html:361 cps/templates/layout.html:399
+#: cps/templates/layout.html
 msgid "Logout"
 msgstr ""
 
-#: cps/templates/layout.html:364 cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/layout.html:389 cps/templates/read.html:103
-#: cps/templates/readcbr.html:71 cps/templates/readcbr.html:97
+#: cps/templates/layout.html cps/templates/read.html cps/templates/readcbr.html
 msgid "Settings"
 msgstr ""
 
-#: cps/templates/layout.html:391
+#: cps/templates/layout.html
 msgid "Refresh Library"
 msgstr ""
 
-#: cps/templates/layout.html:397
+#: cps/templates/layout.html
 msgid "Support"
 msgstr ""
 
-#: cps/templates/layout.html:416
+#: cps/templates/layout.html
 msgid "New interface available"
 msgstr ""
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "A faster, redesigned Calibre-Web NextGen interface is ready."
 msgstr ""
 
-#: cps/templates/layout.html:418
+#: cps/templates/layout.html
 msgid "Your classic view stays the default until you switch."
 msgstr ""
 
-#: cps/templates/layout.html:421
+#: cps/templates/layout.html
 msgid "Try the new UI"
 msgstr ""
 
-#: cps/templates/layout.html:515
+#: cps/templates/layout.html
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:525
+#: cps/templates/layout.html
 msgid "Open Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:547
+#: cps/templates/layout.html
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:581
+#: cps/templates/layout.html
 msgid "Please do not refresh the page"
 msgstr ""
 
-#: cps/templates/layout.html:664
+#: cps/templates/layout.html
 msgid "Create Shelf"
 msgstr ""
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:694 cps/templates/layout.html:720
+#: cps/templates/layout.html
 msgid "Previous"
 msgstr ""
 
-#: cps/templates/layout.html:747
+#: cps/templates/layout.html
 msgid "Book Details"
 msgstr ""
 
-#: cps/templates/layout.html:815
+#: cps/templates/layout.html
 msgid "This cannot be undone."
 msgstr ""
 
-#: cps/templates/layout.html:821
+#: cps/templates/layout.html
 msgid "Will be deleted"
 msgstr ""
 
-#: cps/templates/layout.html:825 cps/templates/layout.html:838
+#: cps/templates/layout.html
 msgid "Formats:"
 msgstr ""
 
-#: cps/templates/layout.html:834
+#: cps/templates/layout.html
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:846
+#: cps/templates/layout.html
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:852
+#: cps/templates/layout.html
 msgid "Result will have formats:"
 msgstr ""
 
-#: cps/templates/layout.html:861
+#: cps/templates/layout.html
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:895
+#: cps/templates/layout.html
 msgid "Duplicate Books Detected"
 msgstr ""
 
-#: cps/templates/layout.html:896
+#: cps/templates/layout.html
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:901
+#: cps/templates/layout.html
 msgid "Duplicate Groups Found"
 msgstr ""
 
-#: cps/templates/layout.html:909
+#: cps/templates/layout.html
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:912
+#: cps/templates/layout.html
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:921
+#: cps/templates/layout.html
 msgid "Scroll to top"
 msgstr ""
 
-#: cps/templates/layout.html:923
+#: cps/templates/layout.html
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:1013
+#: cps/templates/layout.html
 msgid "Confirm"
 msgstr ""
 
-#: cps/templates/layout.html:1019
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr ""
 
-#: cps/templates/layout.html:1020
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:1021
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:1022
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Marked {n} books as read"
 msgstr ""
 
-#: cps/templates/layout.html:1023
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr ""
 
-#: cps/templates/layout.html:1024
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Deleted {n} books"
 msgstr ""
 
-#: cps/templates/layout.html:1025
+#: cps/templates/layout.html
 msgid "Delete books?"
 msgstr ""
 
-#: cps/templates/layout.html:1026
+#: cps/templates/layout.html
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot "
 "be undone."
 msgstr ""
 
-#: cps/templates/layout.html:1027
+#: cps/templates/layout.html
 msgid "Select at least one book first."
 msgstr ""
 
-#: cps/templates/layout.html:1028
+#: cps/templates/layout.html
 #, python-brace-format
 msgid "Request failed: {err}"
 msgstr ""
 
-#: cps/templates/list.html:25 cps/templates/list.html:27
+#: cps/templates/list.html
 msgid "Filter by initial"
 msgstr ""
 
-#: cps/templates/list.html:43
+#: cps/templates/list.html
 msgid "Grid"
 msgstr ""
 
-#: cps/templates/login.html:30
+#: cps/templates/login.html
 msgid "Show Password"
 msgstr ""
 
-#: cps/templates/login.html:35
+#: cps/templates/login.html
 msgid "Remember Me"
 msgstr ""
 
-#: cps/templates/login.html:41
+#: cps/templates/login.html
 msgid "Forgot Password?"
 msgstr ""
 
-#: cps/templates/login.html:55
+#: cps/templates/login.html
 msgid ""
 "Log in with Magic\n"
 "      Link"
 msgstr ""
 
-#: cps/templates/login.html:95
+#: cps/templates/login.html
 msgid "Log in with SSO"
 msgstr ""
 
-#: cps/templates/login.html:102
+#: cps/templates/login.html
 msgid ""
 "Standard login is disabled. Please use one of the alternative login "
 "methods."
 msgstr ""
 
-#: cps/templates/logviewer.html:6
+#: cps/templates/logviewer.html
 msgid "Show Calibre-Web Log: "
 msgstr ""
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Calibre-Web Log: "
 msgstr ""
 
-#: cps/templates/logviewer.html:8
+#: cps/templates/logviewer.html
 msgid "Stream output, can't be displayed"
 msgstr ""
 
-#: cps/templates/logviewer.html:12
+#: cps/templates/logviewer.html
 msgid "Show Access Log: "
 msgstr ""
 
-#: cps/templates/logviewer.html:18
+#: cps/templates/logviewer.html
 msgid "Download Calibre-Web Log"
 msgstr ""
 
-#: cps/templates/logviewer.html:21
+#: cps/templates/logviewer.html
 msgid "Download Access Log"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "System Template"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:376
+#: cps/templates/magic_shelf_edit.html
 msgid "This is a pre-configured template shelf. You can edit it freely."
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:457
+#: cps/templates/magic_shelf_edit.html
 msgid "Share with Everyone (Public)"
 msgstr ""
 
-#: cps/templates/magic_shelf_edit.html:460
+#: cps/templates/magic_shelf_edit.html
 msgid ""
 "Other users can view this shelf. Users with \"Edit Public Shelves\" "
 "permission can edit/delete it."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:6
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:7
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:8
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Tags of User"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:9
+#: cps/templates/modal_dialogs.html
 msgid "Select Allowed/Denied Custom Column Values of User"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:15
+#: cps/templates/modal_dialogs.html
 msgid "Enter Tag"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:24
+#: cps/templates/modal_dialogs.html
 msgid "Add View Restriction"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:50
+#: cps/templates/modal_dialogs.html
 msgid "This book format will be permanently erased from database"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:51
+#: cps/templates/modal_dialogs.html
 msgid "This book will be permanently erased from database"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:52
+#: cps/templates/modal_dialogs.html
 msgid "and hard disk"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:56
+#: cps/templates/modal_dialogs.html
 msgid "Important Kobo Note: deleted books will remain on any paired Kobo device."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:57
+#: cps/templates/modal_dialogs.html
 msgid ""
 "Books must first be archived and the device synced before a book can "
 "safely be deleted."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:76
+#: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:82
+#: cps/templates/modal_dialogs.html
 msgid "type"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:83
+#: cps/templates/modal_dialogs.html
 msgid "name"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:84
+#: cps/templates/modal_dialogs.html
 msgid "size"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:90
+#: cps/templates/modal_dialogs.html
 msgid "Parent Directory"
 msgstr ""
 
-#: cps/templates/modal_dialogs.html:134 cps/templates/tasks.html:93
+#: cps/templates/modal_dialogs.html cps/templates/tasks.html
 msgid "Ok"
 msgstr ""
 
-#: cps/templates/osd.xml:5
+#: cps/templates/osd.xml
 msgid "Calibre-Web NextGen eBook Catalog"
 msgstr ""
 
-#: cps/templates/read.html:7
+#: cps/templates/read.html
 msgid "epub Reader"
 msgstr ""
 
-#: cps/templates/read.html:33
+#: cps/templates/read.html
 msgid "Annotations"
 msgstr ""
 
-#: cps/templates/read.html:47
+#: cps/templates/read.html
 msgid "Open annotations page"
 msgstr ""
 
-#: cps/templates/read.html:111
+#: cps/templates/read.html
 msgid "Black"
 msgstr ""
 
-#: cps/templates/read.html:116
+#: cps/templates/read.html
 msgid "Font Sizes"
 msgstr ""
 
-#: cps/templates/read.html:124
+#: cps/templates/read.html
 msgid "Text margin"
 msgstr ""
 
-#: cps/templates/read.html:140
+#: cps/templates/read.html
 msgid "Font"
 msgstr ""
 
-#: cps/templates/read.html:142
+#: cps/templates/read.html
 msgid "Default"
 msgstr ""
 
-#: cps/templates/read.html:143
+#: cps/templates/read.html
 msgid "Yahei"
 msgstr ""
 
-#: cps/templates/read.html:144
+#: cps/templates/read.html
 msgid "SimSun"
 msgstr ""
 
-#: cps/templates/read.html:145
+#: cps/templates/read.html
 msgid "KaiTi"
 msgstr ""
 
-#: cps/templates/read.html:146
+#: cps/templates/read.html
 msgid "Arial"
 msgstr ""
 
-#: cps/templates/read.html:151
+#: cps/templates/read.html
 msgid "Spread"
 msgstr ""
 
-#: cps/templates/read.html:153
+#: cps/templates/read.html
 msgid "Two columns"
 msgstr ""
 
-#: cps/templates/read.html:154
+#: cps/templates/read.html
 msgid "One column"
 msgstr ""
 
-#: cps/templates/read.html:161
+#: cps/templates/read.html
 msgid "Reflow text when sidebars are open."
 msgstr ""
 
-#: cps/templates/read.html:189
+#: cps/templates/read.html
 msgid "Note"
 msgstr ""
 
-#: cps/templates/read.html:190
+#: cps/templates/read.html
 msgid "Add a note (optional)"
 msgstr ""
 
-#: cps/templates/read.html:191
+#: cps/templates/read.html
 msgid "Select within a paragraph to highlight."
 msgstr ""
 
-#: cps/templates/readcbr.html:8
+#: cps/templates/readcbr.html
 msgid "Comic Reader"
 msgstr ""
 
-#: cps/templates/readcbr.html:76
+#: cps/templates/readcbr.html
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: cps/templates/readcbr.html:79
+#: cps/templates/readcbr.html
 msgid "Previous Page"
 msgstr ""
 
-#: cps/templates/readcbr.html:80 cps/templates/readcbr.html:160
+#: cps/templates/readcbr.html
 msgid "Next Page"
 msgstr ""
 
-#: cps/templates/readcbr.html:81
+#: cps/templates/readcbr.html
 msgid "Single Page Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:82
+#: cps/templates/readcbr.html
 msgid "Long Strip Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:83
+#: cps/templates/readcbr.html
 msgid "Scale to Best"
 msgstr ""
 
-#: cps/templates/readcbr.html:84
+#: cps/templates/readcbr.html
 msgid "Scale to Width"
 msgstr ""
 
-#: cps/templates/readcbr.html:85
+#: cps/templates/readcbr.html
 msgid "Scale to Height"
 msgstr ""
 
-#: cps/templates/readcbr.html:86
+#: cps/templates/readcbr.html
 msgid "Scale to Native"
 msgstr ""
 
-#: cps/templates/readcbr.html:87
+#: cps/templates/readcbr.html
 msgid "Rotate Right"
 msgstr ""
 
-#: cps/templates/readcbr.html:88
+#: cps/templates/readcbr.html
 msgid "Rotate Left"
 msgstr ""
 
-#: cps/templates/readcbr.html:89
+#: cps/templates/readcbr.html
 msgid "Flip Image"
 msgstr ""
 
-#: cps/templates/readcbr.html:111
+#: cps/templates/readcbr.html
 msgid "Display"
 msgstr ""
 
-#: cps/templates/readcbr.html:114
+#: cps/templates/readcbr.html
 msgid "Single Page"
 msgstr ""
 
-#: cps/templates/readcbr.html:115
+#: cps/templates/readcbr.html
 msgid "Long Strip"
 msgstr ""
 
-#: cps/templates/readcbr.html:120
+#: cps/templates/readcbr.html
 msgid "Scale"
 msgstr ""
 
-#: cps/templates/readcbr.html:123
+#: cps/templates/readcbr.html
 msgid "Best"
 msgstr ""
 
-#: cps/templates/readcbr.html:124
+#: cps/templates/readcbr.html
 msgid "Width"
 msgstr ""
 
-#: cps/templates/readcbr.html:125
+#: cps/templates/readcbr.html
 msgid "Height"
 msgstr ""
 
-#: cps/templates/readcbr.html:126
+#: cps/templates/readcbr.html
 msgid "Native"
 msgstr ""
 
-#: cps/templates/readcbr.html:131
+#: cps/templates/readcbr.html
 msgid "Rotate"
 msgstr ""
 
-#: cps/templates/readcbr.html:142
+#: cps/templates/readcbr.html
 msgid "Flip"
 msgstr ""
 
-#: cps/templates/readcbr.html:145
+#: cps/templates/readcbr.html
 msgid "Horizontal"
 msgstr ""
 
-#: cps/templates/readcbr.html:146
+#: cps/templates/readcbr.html
 msgid "Vertical"
 msgstr ""
 
-#: cps/templates/readcbr.html:151
+#: cps/templates/readcbr.html
 msgid "Direction"
 msgstr ""
 
-#: cps/templates/readcbr.html:154
+#: cps/templates/readcbr.html
 msgid "Left to Right"
 msgstr ""
 
-#: cps/templates/readcbr.html:155
+#: cps/templates/readcbr.html
 msgid "Right to Left"
 msgstr ""
 
-#: cps/templates/readcbr.html:163
+#: cps/templates/readcbr.html
 msgid "Reset to Top"
 msgstr ""
 
-#: cps/templates/readcbr.html:164
+#: cps/templates/readcbr.html
 msgid "Remember Position"
 msgstr ""
 
-#: cps/templates/readcbr.html:169
+#: cps/templates/readcbr.html
 msgid "Scrollbar"
 msgstr ""
 
-#: cps/templates/readcbr.html:172
+#: cps/templates/readcbr.html
 msgid "Show"
 msgstr ""
 
-#: cps/templates/readdjvu.html:5
+#: cps/templates/readdjvu.html
 msgid "DJVU Reader"
 msgstr ""
 
-#: cps/templates/readpdf.html:32
+#: cps/templates/readpdf.html
 msgid "PDF Reader"
 msgstr ""
 
-#: cps/templates/readtxt.html:6
+#: cps/templates/readtxt.html
 msgid "txt Reader"
 msgstr ""
 
-#: cps/templates/register.html:4
+#: cps/templates/register.html
 msgid "Register New Account"
 msgstr ""
 
-#: cps/templates/register.html:10
+#: cps/templates/register.html
 msgid "Choose a username"
 msgstr ""
 
-#: cps/templates/register.html:15
+#: cps/templates/register.html
 msgid "Your Email"
 msgstr ""
 
-#: cps/templates/remote_login.html:5
+#: cps/templates/remote_login.html
 msgid "Magic Link - Authorise New Device"
 msgstr ""
 
-#: cps/templates/remote_login.html:7
+#: cps/templates/remote_login.html
 msgid "On another device, login and visit:"
 msgstr ""
 
-#: cps/templates/remote_login.html:17
+#: cps/templates/remote_login.html
 msgid "Once verified, you will automatically be logged in on this device."
 msgstr ""
 
-#: cps/templates/remote_login.html:20
+#: cps/templates/remote_login.html
 msgid "This verification link will expire in 10 minutes."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:30
+#: cps/templates/schedule_edit.html
 msgid ""
 "Automatically refresh all thumbnails during scheduled maintenance. "
 "Thumbnails are always generated on-demand regardless of this setting."
 msgstr ""
 
-#: cps/templates/schedule_edit.html:34
+#: cps/templates/schedule_edit.html
 msgid "Generate Series Cover Thumbnails"
 msgstr ""
 
-#: cps/templates/search.html:7
+#: cps/templates/search.html
 msgid "No Results Found"
 msgstr ""
 
-#: cps/templates/search.html:8
+#: cps/templates/search.html
 msgid "Search Term:"
 msgstr ""
 
-#: cps/templates/search.html:10
+#: cps/templates/search.html
 msgid "Results for:"
 msgstr ""
 
-#: cps/templates/search_form.html:21
+#: cps/templates/search_form.html
 msgid "Published Date From"
 msgstr ""
 
-#: cps/templates/search_form.html:31
+#: cps/templates/search_form.html
 msgid "Published Date To"
 msgstr ""
 
-#: cps/templates/search_form.html:45 cps/templates/search_form.html:166
+#: cps/templates/search_form.html
 msgid "Empty"
 msgstr ""
 
-#: cps/templates/search_form.html:60
+#: cps/templates/search_form.html
 msgid "Exclude Tags"
 msgstr ""
 
-#: cps/templates/search_form.html:78
+#: cps/templates/search_form.html
 msgid "Exclude Series"
 msgstr ""
 
-#: cps/templates/search_form.html:96
+#: cps/templates/search_form.html
 msgid "Exclude Shelves"
 msgstr ""
 
-#: cps/templates/search_form.html:116
+#: cps/templates/search_form.html
 msgid "Exclude Languages"
 msgstr ""
 
-#: cps/templates/search_form.html:127
+#: cps/templates/search_form.html
 msgid "Extensions"
 msgstr ""
 
-#: cps/templates/search_form.html:135
+#: cps/templates/search_form.html
 msgid "Exclude Extensions"
 msgstr ""
 
-#: cps/templates/search_form.html:145
+#: cps/templates/search_form.html
 msgid "Rating Above"
 msgstr ""
 
-#: cps/templates/search_form.html:149
+#: cps/templates/search_form.html
 msgid "Rating Below"
 msgstr ""
 
-#: cps/templates/search_form.html:175 cps/templates/search_form.html:187
-#: cps/templates/search_form.html:201
+#: cps/templates/search_form.html
 msgid "From:"
 msgstr ""
 
-#: cps/templates/search_form.html:179 cps/templates/search_form.html:191
-#: cps/templates/search_form.html:211
+#: cps/templates/search_form.html
 msgid "To:"
 msgstr ""
 
-#: cps/templates/shelf.html:14
+#: cps/templates/shelf.html
 msgid "Delete this Shelf"
 msgstr ""
 
-#: cps/templates/shelf.html:15
+#: cps/templates/shelf.html
 msgid "Edit Shelf Properties"
 msgstr ""
 
-#: cps/templates/shelf.html:22
+#: cps/templates/shelf.html
 msgid "Add Books"
 msgstr ""
 
-#: cps/templates/shelf.html:25
+#: cps/templates/shelf.html
 msgid "Arrange books manually"
 msgstr ""
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Disable Change order"
 msgstr ""
 
-#: cps/templates/shelf.html:26
+#: cps/templates/shelf.html
 msgid "Enable Change order"
 msgstr ""
 
-#: cps/templates/shelf.html:101 cps/templates/shelf.html:124
+#: cps/templates/shelf.html
 #, python-format
 msgid "%(count)s selected"
 msgstr ""
 
-#: cps/templates/shelf.html:103
+#: cps/templates/shelf.html
 #, python-format
 msgid "Add %(count)s"
 msgstr ""
 
-#: cps/templates/shelf.html:104 cps/templates/shelf.html:120
+#: cps/templates/shelf.html
 msgid "No books found."
 msgstr ""
 
-#: cps/templates/shelf.html:105
+#: cps/templates/shelf.html
 msgid "Already on this shelf"
 msgstr ""
 
-#: cps/templates/shelf.html:106
+#: cps/templates/shelf.html
 msgid "Could not add the books. Please try again."
 msgstr ""
 
-#: cps/templates/shelf.html:111
+#: cps/templates/shelf.html
 msgid "Add books to"
 msgstr ""
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 msgid "Search your library…"
 msgstr ""
 
-#: cps/templates/shelf.html:117
+#: cps/templates/shelf.html
 msgid "Search your library"
 msgstr ""
 
-#: cps/templates/shelf_edit.html:14
+#: cps/templates/shelf_edit.html
 msgid "Share with Everyone"
 msgstr ""
 
-#: cps/templates/shelf_edit.html:21
+#: cps/templates/shelf_edit.html
 msgid "Sync this shelf with Kobo device"
 msgstr ""
 
-#: cps/templates/shelf_edit.html:28
+#: cps/templates/shelf_edit.html
 msgid "Expose this shelf in my OPDS feed"
 msgstr ""
 
-#: cps/templates/shelf_order.html:29
+#: cps/templates/shelf_order.html
 msgid "Drag a cover to its new spot — the order saves automatically."
 msgstr ""
 
-#: cps/templates/shelf_order.html:30
+#: cps/templates/shelf_order.html
 msgid "Keyboard: focus a cover with Tab, then move it with the arrow keys."
 msgstr ""
 
-#: cps/templates/shelf_order.html:34
+#: cps/templates/shelf_order.html
 msgid "Order saved"
 msgstr ""
 
-#: cps/templates/shelf_order.html:35
+#: cps/templates/shelf_order.html
 msgid "Could not save the order — click here to retry"
 msgstr ""
 
-#: cps/templates/shelf_order.html:36
+#: cps/templates/shelf_order.html
 #, python-format
 msgid "Moved to position %(num)s of %(total)s"
 msgstr ""
 
-#: cps/templates/shelf_order.html:39
+#: cps/templates/shelf_order.html
 msgid "Shelf order"
 msgstr ""
 
-#: cps/templates/shelf_order.html:44 cps/templates/shelf_order.html:49
-#: cps/templates/shelf_order.html:59
+#: cps/templates/shelf_order.html
 msgid "Hidden Book"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:12
+#: cps/templates/shelf_reorder.html
 msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:24
+#: cps/templates/shelf_reorder.html
 msgid "Drag to rearrange the order of your shelves in the sidebar."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:83
+#: cps/templates/shelf_reorder.html
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/stats.html:8
+#: cps/templates/stats.html
 msgid "Library Statistics"
 msgstr ""
 
-#: cps/templates/stats.html:13
+#: cps/templates/stats.html
 msgid "Books in this Library"
 msgstr ""
 
-#: cps/templates/stats.html:17
+#: cps/templates/stats.html
 msgid "Authors in this Library"
 msgstr ""
 
-#: cps/templates/stats.html:21
+#: cps/templates/stats.html
 msgid "Categories in this Library"
 msgstr ""
 
-#: cps/templates/stats.html:25
+#: cps/templates/stats.html
 msgid "Series in this Library"
 msgstr ""
 
-#: cps/templates/stats.html:30
+#: cps/templates/stats.html
 msgid "System Statistics"
 msgstr ""
 
-#: cps/templates/stats.html:34
+#: cps/templates/stats.html
 msgid "Program"
 msgstr ""
 
-#: cps/templates/stats.html:35
+#: cps/templates/stats.html
 msgid "Installed Version"
 msgstr ""
 
-#: cps/templates/tasks.html:8
+#: cps/templates/tasks.html
 msgid "Background Tasks Overview"
 msgstr ""
 
-#: cps/templates/tasks.html:18
+#: cps/templates/tasks.html
 msgid "Run Time"
 msgstr ""
 
-#: cps/templates/tasks.html:22 cps/templates/tasks.html:46
-#: cps/templates/tasks.html:68
+#: cps/templates/tasks.html
 msgid "Actions"
 msgstr ""
 
-#: cps/templates/tasks.html:33
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr ""
 
-#: cps/templates/tasks.html:44 cps/templates/tasks.html:66
+#: cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr ""
 
-#: cps/templates/tasks.html:45 cps/templates/tasks.html:67
+#: cps/templates/tasks.html
 msgid "State"
 msgstr ""
 
-#: cps/templates/tasks.html:50
+#: cps/templates/tasks.html
 msgid ""
 "Upcoming sends are persisted and will enqueue as tasks at the scheduled "
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html:55
+#: cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr ""
 
-#: cps/templates/tasks.html:63
+#: cps/templates/tasks.html
 msgid "Type"
 msgstr ""
 
-#: cps/templates/tasks.html:72
+#: cps/templates/tasks.html
 msgid ""
 "Convert Library and EPUB Fixer runs scheduled here will persist across "
 "restarts. Cancel to prevent them from triggering."
 msgstr ""
 
-#: cps/templates/tasks.html:88
+#: cps/templates/tasks.html
 msgid "This task will be cancelled. Any progress made by this task will be saved."
 msgstr ""
 
-#: cps/templates/tasks.html:89
+#: cps/templates/tasks.html
 msgid ""
 "If this is a scheduled task, it will be re-ran during the next scheduled "
 "time."
 msgstr ""
 
-#: cps/templates/tasks.html:192
+#: cps/templates/tasks.html
 msgid "Scheduled item cancelled successfully"
 msgstr ""
 
-#: cps/templates/tasks.html:197
+#: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:19
+#: cps/templates/update_now_modal.html
 msgid "Update Calibre-Web NextGen"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:22
+#: cps/templates/update_now_modal.html
 msgid ""
 "Updating pulls the new image and recreates the container. It is quick, "
 "and your library, settings and reading progress are safe — they live in "
 "your mounted volumes, not in the container."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:24
+#: cps/templates/update_now_modal.html
 msgid "How do you run Calibre-Web NextGen?"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:25
+#: cps/templates/update_now_modal.html
 msgid "Setup type"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:26
+#: cps/templates/update_now_modal.html
 msgid "Docker Compose"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:27
+#: cps/templates/update_now_modal.html
 msgid "docker run"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html
 msgid "Unraid"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:29
+#: cps/templates/update_now_modal.html
 msgid "Portainer / Synology"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:33
+#: cps/templates/update_now_modal.html
 msgid "Run this from the folder that holds your compose file:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:38
+#: cps/templates/update_now_modal.html
 msgid "Replace calibre-web-nextgen with your service name if it differs."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:42
+#: cps/templates/update_now_modal.html
 msgid ""
 "Pull the new image, then recreate your container with the same options "
 "you started it with:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:47
+#: cps/templates/update_now_modal.html
 msgid ""
 "Then stop and remove the old container and start a new one with your "
 "usual docker run command. Your mounted volumes keep all data."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:52
+#: cps/templates/update_now_modal.html
 msgid "Open the Docker tab in the Unraid web UI."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:53
+#: cps/templates/update_now_modal.html
 msgid ""
 "Click the Calibre-Web NextGen container icon and choose Force update "
 "(check for updates first if you want to see what changed)."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:55
+#: cps/templates/update_now_modal.html
 msgid ""
 "For hands-off updates, install the \"CA Auto Update Applications\" plugin"
 " from Community Applications."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid "Portainer:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:59
+#: cps/templates/update_now_modal.html
 msgid ""
 "Images → pull the image below, then Containers → select Calibre-Web "
 "NextGen → Recreate with \"Re-pull image\" enabled."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid "Synology Container Manager:"
 msgstr ""
 
-#: cps/templates/update_now_modal.html:60
+#: cps/templates/update_now_modal.html
 msgid ""
 "Registry → download the image below (tag: latest), then stop the "
 "container → Action → Reset to recreate it."
 msgstr ""
 
-#: cps/templates/update_now_modal.html:68
+#: cps/templates/update_now_modal.html
 msgid "Set up automatic updates"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "Your Profile"
 msgstr ""
 
-#: cps/templates/user_edit.html:173
+#: cps/templates/user_edit.html
 msgid "User Settings"
 msgstr ""
 
-#: cps/templates/user_edit.html:188
+#: cps/templates/user_edit.html
 msgid "Account Information"
 msgstr ""
 
-#: cps/templates/user_edit.html:197
+#: cps/templates/user_edit.html
 msgid "If you need to change your email address or password, you can do so here."
 msgstr ""
 
-#: cps/templates/user_edit.html:207
+#: cps/templates/user_edit.html
 msgid "Reset user Password"
 msgstr ""
 
-#: cps/templates/user_edit.html:219
+#: cps/templates/user_edit.html
 msgid "eReader Configuration"
 msgstr ""
 
-#: cps/templates/user_edit.html:222
+#: cps/templates/user_edit.html
 msgid "Send to eReader Email Address"
 msgstr ""
 
-#: cps/templates/user_edit.html:223
+#: cps/templates/user_edit.html
 msgid "Use comma to separate multiple addresses"
 msgstr ""
 
-#: cps/templates/user_edit.html:224
+#: cps/templates/user_edit.html
 msgid ""
 "Email address(es) for your eReader devices. Separate multiple addresses "
 "with commas."
 msgstr ""
 
-#: cps/templates/user_edit.html:235
+#: cps/templates/user_edit.html
 msgid "Enable Send-to-eReader Pop-up Modal"
 msgstr ""
 
-#: cps/templates/user_edit.html:237
+#: cps/templates/user_edit.html
 msgid ""
 "Enables or disables the Send-to-eReader Pop-up Modal that allows users to"
 " enter extra email addresses and only send to a selection of saved "
 "addresses when sending to eReader."
 msgstr ""
 
-#: cps/templates/user_edit.html:239
+#: cps/templates/user_edit.html
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
 
-#: cps/templates/user_edit.html:247
+#: cps/templates/user_edit.html
 msgid "Automatically send new books to my eReader(s)"
 msgstr ""
 
-#: cps/templates/user_edit.html:248
+#: cps/templates/user_edit.html
 msgid ""
 "When enabled, newly ingested books will be automatically sent to all "
 "configured eReader email addresses above."
 msgstr ""
 
-#: cps/templates/user_edit.html:256
+#: cps/templates/user_edit.html
 msgid "Language & Theme Preferences"
 msgstr ""
 
-#: cps/templates/user_edit.html:259
+#: cps/templates/user_edit.html
 msgid "Interface Language"
 msgstr ""
 
-#: cps/templates/user_edit.html:268 cps/templates/user_edit.html:290
+#: cps/templates/user_edit.html
 msgid "Language of Books"
 msgstr ""
 
-#: cps/templates/user_edit.html:275 cps/templates/user_edit.html:297
+#: cps/templates/user_edit.html
 msgid "Filter the library to only show books in a specific language."
 msgstr ""
 
-#: cps/templates/user_edit.html:287
+#: cps/templates/user_edit.html
 msgid "Book Language Filter"
 msgstr ""
 
-#: cps/templates/user_edit.html:305
+#: cps/templates/user_edit.html
 msgid "OAuth & API Integrations"
 msgstr ""
 
-#: cps/templates/user_edit.html:310
+#: cps/templates/user_edit.html
 msgid "OAuth Settings"
 msgstr ""
 
-#: cps/templates/user_edit.html:312
+#: cps/templates/user_edit.html
 msgid "Link"
 msgstr ""
 
-#: cps/templates/user_edit.html:314
+#: cps/templates/user_edit.html
 msgid "Unlink"
 msgstr ""
 
-#: cps/templates/user_edit.html:322
+#: cps/templates/user_edit.html
 msgid "Hardcover API Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:324
+#: cps/templates/user_edit.html
 msgid "API token for Hardcover metadata provider integration."
 msgstr ""
 
-#: cps/templates/user_edit.html:330
+#: cps/templates/user_edit.html
 msgid "Kobo Sync Token"
 msgstr ""
 
-#: cps/templates/user_edit.html:332
+#: cps/templates/user_edit.html
 msgid "Create/View"
 msgstr ""
 
-#: cps/templates/user_edit.html:336
+#: cps/templates/user_edit.html
 msgid "Force full kobo sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:340
+#: cps/templates/user_edit.html
 msgid "Resend one book to this Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:343
+#: cps/templates/user_edit.html
 msgid "Resend"
 msgstr ""
 
-#: cps/templates/user_edit.html:346
+#: cps/templates/user_edit.html
 msgid ""
 "Clears the sync record for one book so the device re-downloads it on next"
 " sync. Find the book ID in the book detail page URL."
 msgstr ""
 
-#: cps/templates/user_edit.html:354
+#: cps/templates/user_edit.html
 msgid "Sync only books in selected shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_edit.html:362
+#: cps/templates/user_edit.html
 msgid "OPDS Shelf Exposure"
 msgstr ""
 
-#: cps/templates/user_edit.html:367
+#: cps/templates/user_edit.html
 msgid "Expose only books in selected shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_edit.html:376
+#: cps/templates/user_edit.html
 msgid "Sidebar Display Settings"
 msgstr ""
 
-#: cps/templates/user_edit.html:377
+#: cps/templates/user_edit.html
 msgid "Choose which sections to display in your sidebar navigation."
 msgstr ""
 
-#: cps/templates/user_edit.html:402
+#: cps/templates/user_edit.html
 msgid "Add allowed/Denied Custom Column Values"
 msgstr ""
 
-#: cps/templates/user_edit.html:412
+#: cps/templates/user_edit.html
 msgid "OPDS Catalog Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:413
+#: cps/templates/user_edit.html
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want."
 " Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:421
+#: cps/templates/user_edit.html
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
 
-#: cps/templates/user_edit.html:430
+#: cps/templates/user_edit.html
 msgid "User Permissions"
 msgstr ""
 
-#: cps/templates/user_edit.html:431
+#: cps/templates/user_edit.html
 msgid "Configure what actions this user is allowed to perform."
 msgstr ""
 
-#: cps/templates/user_edit.html:486
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Order"
 msgstr ""
 
-#: cps/templates/user_edit.html:487
+#: cps/templates/user_edit.html
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
 
-#: cps/templates/user_edit.html:491
+#: cps/templates/user_edit.html
 msgid "Order Mode"
 msgstr ""
 
-#: cps/templates/user_edit.html:493
+#: cps/templates/user_edit.html
 msgid "Manual (drag to reorder)"
 msgstr ""
 
-#: cps/templates/user_edit.html:494
+#: cps/templates/user_edit.html
 msgid "Name (A-Z)"
 msgstr ""
 
-#: cps/templates/user_edit.html:495
+#: cps/templates/user_edit.html
 msgid "Name (Z-A)"
 msgstr ""
 
-#: cps/templates/user_edit.html:496
+#: cps/templates/user_edit.html
 msgid "Book count (high to low)"
 msgstr ""
 
-#: cps/templates/user_edit.html:497
+#: cps/templates/user_edit.html
 msgid "Book count (low to high)"
 msgstr ""
 
-#: cps/templates/user_edit.html:498
+#: cps/templates/user_edit.html
 msgid "Created (newest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:499
+#: cps/templates/user_edit.html
 msgid "Created (oldest first)"
 msgstr ""
 
-#: cps/templates/user_edit.html:500
+#: cps/templates/user_edit.html
 msgid "Recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:501
+#: cps/templates/user_edit.html
 msgid "Least recently modified"
 msgstr ""
 
-#: cps/templates/user_edit.html:512
+#: cps/templates/user_edit.html
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
 
-#: cps/templates/user_edit.html:518
+#: cps/templates/user_edit.html
 msgid "Magic Shelves Visibility"
 msgstr ""
 
-#: cps/templates/user_edit.html:519
+#: cps/templates/user_edit.html
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot"
 " be deleted, only hidden. Public shelves from other users can also be "
 "hidden."
 msgstr ""
 
-#: cps/templates/user_edit.html:523
+#: cps/templates/user_edit.html
 msgid "Default System Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:547
+#: cps/templates/user_edit.html
 msgid "Public Shelves:"
 msgstr ""
 
-#: cps/templates/user_edit.html:572
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s default shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:576
+#: cps/templates/user_edit.html
 #, python-format
 msgid "%(visible)s of %(total)s public shelves visible"
 msgstr ""
 
-#: cps/templates/user_edit.html:590 cps/templates/user_table.html:171
+#: cps/templates/user_edit.html cps/templates/user_table.html
 msgid "Delete User"
 msgstr ""
 
-#: cps/templates/user_edit.html:602
+#: cps/templates/user_edit.html
 msgid "App passwords for OPDS / KOReader Sync"
 msgstr ""
 
-#: cps/templates/user_edit.html:603
+#: cps/templates/user_edit.html
 msgid ""
 "OPDS readers and KOReader can't sign in through your IdP — they only "
 "support HTTP Basic auth. Create an app password here, label it for the "
@@ -11637,150 +11451,150 @@ msgid ""
 "session."
 msgstr ""
 
-#: cps/templates/user_edit.html:609
+#: cps/templates/user_edit.html
 msgid "New app password"
 msgstr ""
 
-#: cps/templates/user_edit.html:611
+#: cps/templates/user_edit.html
 #, python-format
 msgid ""
 "App password created for '%(label)s'. Copy it now — you won't see it "
 "again."
 msgstr ""
 
-#: cps/templates/user_edit.html:615
+#: cps/templates/user_edit.html
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:625
+#: cps/templates/user_edit.html
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
 
-#: cps/templates/user_edit.html:627
+#: cps/templates/user_edit.html
 msgid "Create app password"
 msgstr ""
 
-#: cps/templates/user_edit.html:635
+#: cps/templates/user_edit.html
 msgid "Label"
 msgstr ""
 
-#: cps/templates/user_edit.html:636
+#: cps/templates/user_edit.html
 msgid "Created"
 msgstr ""
 
-#: cps/templates/user_edit.html:637
+#: cps/templates/user_edit.html
 msgid "Last used"
 msgstr ""
 
-#: cps/templates/user_edit.html:646
+#: cps/templates/user_edit.html
 msgid "Never"
 msgstr ""
 
-#: cps/templates/user_edit.html:649
+#: cps/templates/user_edit.html
 msgid "Revoke this app password?"
 msgstr ""
 
-#: cps/templates/user_edit.html:669
+#: cps/templates/user_edit.html
 msgid "Generate Kobo Auth URL"
 msgstr ""
 
-#: cps/templates/user_edit.html:731
+#: cps/templates/user_edit.html
 msgid "Visible"
 msgstr ""
 
-#: cps/templates/user_table.html:80 cps/templates/user_table.html:103
+#: cps/templates/user_table.html
 msgid "Select..."
 msgstr ""
 
-#: cps/templates/user_table.html:124
+#: cps/templates/user_table.html
 msgid "Remove Selections"
 msgstr ""
 
-#: cps/templates/user_table.html:131
+#: cps/templates/user_table.html
 msgid "Edit User"
 msgstr ""
 
-#: cps/templates/user_table.html:134
+#: cps/templates/user_table.html
 msgid "Enter Username"
 msgstr ""
 
-#: cps/templates/user_table.html:135
+#: cps/templates/user_table.html
 msgid "Enter Email"
 msgstr ""
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "Enter eReader Email"
 msgstr ""
 
-#: cps/templates/user_table.html:136
+#: cps/templates/user_table.html
 msgid "eReader Email"
 msgstr ""
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 msgid "Enter eReader Email Subject"
 msgstr ""
 
-#: cps/templates/user_table.html:137
+#: cps/templates/user_table.html
 msgid "eReader Email Subject"
 msgstr ""
 
-#: cps/templates/user_table.html:138
+#: cps/templates/user_table.html
 msgid "Locale"
 msgstr ""
 
-#: cps/templates/user_table.html:139
+#: cps/templates/user_table.html
 msgid "Visible Book Languages"
 msgstr ""
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Edit Allowed Tags"
 msgstr ""
 
-#: cps/templates/user_table.html:140
+#: cps/templates/user_table.html
 msgid "Allowed Tags"
 msgstr ""
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Edit Denied Tags"
 msgstr ""
 
-#: cps/templates/user_table.html:141
+#: cps/templates/user_table.html
 msgid "Denied Tags"
 msgstr ""
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Edit Allowed Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:142
+#: cps/templates/user_table.html
 msgid "Allowed Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Edit Denied Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:143
+#: cps/templates/user_table.html
 msgid "Denied Column Values"
 msgstr ""
 
-#: cps/templates/user_table.html:145
+#: cps/templates/user_table.html
 msgid "Change Password"
 msgstr ""
 
-#: cps/templates/user_table.html:151
+#: cps/templates/user_table.html
 msgid "Edit Public Shelves"
 msgstr ""
 
-#: cps/templates/user_table.html:153
+#: cps/templates/user_table.html
 msgid "Sync selected Shelves with Kobo"
 msgstr ""
 
-#: cps/templates/user_table.html:155
+#: cps/templates/user_table.html
 msgid "Expose selected Shelves to OPDS"
 msgstr ""
 
-#: cps/templates/user_table.html:158
+#: cps/templates/user_table.html
 msgid "Show Read/Unread Section"
 msgstr ""
 

--- a/scripts/update_translations.sh
+++ b/scripts/update_translations.sh
@@ -49,7 +49,37 @@ if [ -f "$POT" ]; then
 fi
 
 # 1. Extract messages
+#
+# --add-location=file keeps the source FILENAME on each `#:` reference and drops
+# the line NUMBER. The filename is what a translator uses ("where does this
+# string appear?"); the line number is pure churn, and it is the largest
+# remaining conflict generator in this repo — 85,347 line-numbered `#:` lines
+# across the POT and 28 catalogs, every one of them a candidate conflict line.
+#
+# freeze_pot_creation_date.py (step 1c) already removed the header half of this
+# problem, and measured on PR #938 that location churn merged cleanly there. It
+# does — when only ONE side moved. The case that conflicts is when BOTH sides
+# shift line numbers on the SAME `#:` line, which is exactly what a feature
+# branch does: it adds strings to cps/spa_strings.py (shifting every later
+# anchor) while main independently edits another instrumented file, so both
+# rewrite `#: cps/cover_picker.py:138 cps/spa_strings.py:483`. Same line, two
+# edits, unavoidable conflict — no unchanged line exists to split the hunk.
+# Observed 2026-08-10 blocking fork PRs #1508 and #1515, both on nl/messages.po,
+# with zero translated content in dispute.
+#
+# Safe because nothing reads source locations. The three catalog readers in this
+# repo — cps/api/i18n.py (SPA catalog), cps/render_template.py (missing-string
+# notice) and scripts/generate_translation_status.py (status table) — use only
+# msgid/msgstr/flags/obsolete. Verified by control: extracting with and without
+# this flag and msgmerging both into nl/messages.po produced byte-identical
+# (msgid, msgstr) pairs. test_po_source_location_churn.py pins both halves.
+#
+# msgmerge takes locations from the POT, so this one flag fans out to all 28
+# locales; there is deliberately no second flag on the msgmerge call (the POT
+# stays the single control point, and `--add-location=TYPE` is not portable
+# across the gettext builds this runs on).
 "${PYBABEL_CMD[@]}" extract -F "$CONFIG" -o "$POT" \
+    --add-location=file \
     --project="Calibre-Web Automated" \
     --version="$VERSION" \
     --msgid-bugs-address="https://github.com/crocodilestick/Calibre-Web-Automated" \

--- a/tests/unit/test_po_source_location_churn.py
+++ b/tests/unit/test_po_source_location_churn.py
@@ -1,0 +1,145 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests: `#:` source-reference LINE NUMBERS must not reach the
+catalogs, because two branches that both shift them conflict on the same line.
+
+The symptom
+-----------
+A feature branch that adds SPA strings goes CONFLICTING against main within
+hours, on a ``.po`` file where not one translated word is in dispute. Observed
+2026-08-10 on fork PRs #1508 (reader notes) and #1515 (confirm destructive
+actions), both stuck on ``cps/translations/nl/LC_MESSAGES/messages.po``.
+
+Why the sibling fix did not cover this
+--------------------------------------
+``freeze_pot_creation_date.py`` removed the header half of this conflict class
+and measured, on #938, that the ~1345 lines of ``#:`` location churn in the same
+file "merged cleanly (unchanged msgid lines separate those hunks)". That is
+correct — for #938, where only ONE side moved locations (the bot) while the
+translator touched only ``msgstr``.
+
+The case it does not cover is both sides moving the SAME reference line::
+
+    base:   #: cps/cover_picker.py:138 cps/spa_strings.py:459
+    main:   #: cps/cover_picker.py:121 cps/spa_strings.py:459   (cover_picker edited)
+    branch: #: cps/cover_picker.py:138 cps/spa_strings.py:483   (spa_strings grew)
+
+One line, two different edits. No amount of separating context helps — git has
+nothing to choose between. Any branch adding SPA msgids shifts every later
+``cps/spa_strings.py`` anchor, so this fires on essentially every feature PR
+that touches user-visible strings, which is most of them.
+
+The fix
+-------
+``pybabel extract --add-location=file`` keeps the filename and drops the line
+number. ``#: cps/cover_picker.py cps/spa_strings.py`` is stable no matter where
+in either file the string lives; it changes only when the set of *files* using
+the string changes, which is rare and meaningful. ``msgmerge`` takes locations
+from the POT, so the one flag fans out to all 28 locales.
+
+Why dropping line numbers is safe
+---------------------------------
+Nothing in this repo reads source locations. The three catalog readers —
+``cps/api/i18n.py`` (SPA catalog), ``cps/render_template.py`` (missing-string
+notice) and ``scripts/generate_translation_status.py`` (status table) — use only
+msgid/msgstr/flags/obsolete. Verified by control on 2026-08-10: extracting the
+POT with and without the flag and msgmerging each into ``nl/messages.po`` gave
+byte-identical ``(msgid, msgstr)`` pairs; the only difference was the ``#:``
+comments. The filename is retained precisely because that half *is* useful to a
+translator — this drops the churn, not the provenance.
+
+``test_no_line_numbers_in_*`` is the red/green pin: before the fix there were
+85,347 line-numbered ``#:`` lines across the POT and 28 catalogs.
+``test_extract_passes_add_location_file`` pins the pipeline flag, so a future
+edit that drops it fails here rather than silently reintroducing 85k conflict
+candidates on the bot's next run.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+POT = REPO / "messages.pot"
+CATALOGS = sorted((REPO / "cps" / "translations").glob("*/LC_MESSAGES/messages.po"))
+UPDATE_SCRIPT = REPO / "scripts" / "update_translations.sh"
+
+# A reference carrying a line number: `#: some/path.py:123` (possibly several
+# space-separated refs on one line). Matching `:<digits>` at a word boundary
+# avoids tripping on a bare filename that happens to contain a digit.
+LINE_NUMBERED_REF = re.compile(r"^#:.*?\S:\d+(\s|$)", re.MULTILINE)
+
+
+def _line_numbered_refs(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    return [m.group(0).strip() for m in LINE_NUMBERED_REF.finditer(text)]
+
+
+def test_catalogs_exist():
+    """Guard against the glob silently matching nothing, which would make every
+    other assertion in this file vacuously true."""
+    assert POT.is_file(), f"{POT} missing"
+    assert len(CATALOGS) >= 20, f"expected the full locale set, found {len(CATALOGS)}"
+
+
+def test_no_line_numbers_in_pot():
+    offenders = _line_numbered_refs(POT)
+    assert not offenders, (
+        f"messages.pot carries {len(offenders)} line-numbered '#:' references, e.g. "
+        f"{offenders[:3]}. Re-run scripts/update_translations.sh — extract must pass "
+        "--add-location=file. Line numbers make two branches conflict on the same "
+        "reference line when both shift them."
+    )
+
+
+@pytest.mark.parametrize("po", CATALOGS, ids=lambda p: p.parts[-3])
+def test_no_line_numbers_in_catalog(po: Path):
+    offenders = _line_numbered_refs(po)
+    assert not offenders, (
+        f"{po.parts[-3]}/messages.po carries {len(offenders)} line-numbered '#:' "
+        f"references, e.g. {offenders[:3]}. msgmerge copies locations from the POT, "
+        "so regenerate via scripts/update_translations.sh rather than editing by hand."
+    )
+
+
+def test_filenames_are_retained():
+    """Dropping the line number must not drop the reference entirely.
+
+    ``--no-location`` would also make this file's other tests pass, while
+    throwing away the half a translator actually uses. Pin that we chose
+    ``file`` and not ``never``.
+    """
+    text = POT.read_text(encoding="utf-8")
+    refs = [ln for ln in text.splitlines() if ln.startswith("#: ")]
+    assert len(refs) > 1000, (
+        f"only {len(refs)} '#:' references in messages.pot — source filenames look "
+        "stripped. --add-location=file keeps them; --no-location would not."
+    )
+    assert any(ln.startswith("#: cps/") for ln in refs), (
+        "no cps/ source references in messages.pot"
+    )
+
+
+def test_extract_passes_add_location_file():
+    """Pin the pipeline flag itself.
+
+    Without this, a future edit could drop ``--add-location=file`` and the two
+    tests above would keep passing until the translation bot's next run
+    reintroduced every line number at once.
+    """
+    script = UPDATE_SCRIPT.read_text(encoding="utf-8")
+    extract_block = script.split("# 1b.")[0]
+    assert "--add-location=file" in extract_block, (
+        "scripts/update_translations.sh no longer passes --add-location=file to "
+        "pybabel extract; the bot's next run would restore ~85k line-numbered "
+        "references and with them the same-line conflict class."
+    )
+    assert "--no-location" not in extract_block, (
+        "--no-location drops source filenames too, which removes the provenance "
+        "translators rely on. Use --add-location=file."
+    )


### PR DESCRIPTION
## Why

Feature branches that touch user-visible strings go CONFLICTING against main within hours, on catalogs where not one translated word is in dispute. Right now that is blocking **#1508** (reader notes) and **#1515** (confirm destructive actions), both stuck on `cps/translations/nl/LC_MESSAGES/messages.po`.

## Root cause

`freeze_pot_creation_date.py` removed the header half of this conflict class, and measured on #938 that the `#:` location churn in the same file "merged cleanly (unchanged msgid lines separate those hunks)". That is correct — for #938, where only **one** side moved locations (the bot) while the translator touched only `msgstr`.

The case it does not cover is both sides rewriting the **same** reference line:

```
base:   #: cps/cover_picker.py:138 cps/spa_strings.py:459
main:   #: cps/cover_picker.py:121 cps/spa_strings.py:459   (cover_picker.py edited)
branch: #: cps/cover_picker.py:138 cps/spa_strings.py:483   (spa_strings.py grew)
```

One line, two different edits. No separating context can help — git has nothing to choose between. Any branch that adds SPA msgids shifts every later `cps/spa_strings.py` anchor, so this fires on most feature PRs that touch strings.

## Fix

`pybabel extract --add-location=file` keeps the source filename and drops the line number. `#: cps/cover_picker.py cps/spa_strings.py` is stable no matter where in either file the string lives; it changes only when the *set of files* using a string changes, which is rare and meaningful. `msgmerge` takes locations from the POT, so the one flag reaches all 28 locales — there is deliberately no second flag on the msgmerge call, both to keep the POT the single control point and because `--add-location=TYPE` is not portable across the gettext builds this runs on.

That removed **85,347** line-numbered references.

The filename is retained on purpose: that half is what a translator actually uses. `--no-location` would also make the new tests pass while throwing the provenance away, so the test pins `file` and rejects `never`.

## Validation

**Red/green.** `tests/unit/test_po_source_location_churn.py` — 29 failed before the regeneration (POT + 28 catalogs), 32 passed after.

**Nothing reads these locations.** The three catalog readers — `cps/api/i18n.py` (SPA catalog), `cps/render_template.py` (missing-string notice), `scripts/generate_translation_status.py` (status table) — use only msgid/msgstr/flags/obsolete.

**Control for the extraction change.** Extracted the POT with and without the flag and msgmerged each into `nl/messages.po`: byte-identical `(msgid, msgstr)` pairs; the only difference was the `#:` comments. The `1739 → 1738` translated-count delta appears in the control too — it is source drift on main, not this change.

**All 28 catalogs semantically identical.** Parsed every catalog before and after and compared `(msgid, msgstr, flags)` sets for non-obsolete entries: no locale changed. The 165k-line diff is `#:` lines plus gettext re-wrapping the same text at different column points.

**The conflict class is actually gone — A/B with a positive control.** Two branches off a common base, one making a main-side edit that shifts an instrumented file's line numbers, the other adding SPA string anchors (i.e. exactly the #1508 shape):

| Arm | Base | Result |
|---|---|---|
| Control | pre-fix, line numbers present | **29 conflicted files** (POT + all 28 catalogs) |
| Treatment | post-fix, file-only locations | **clean merge, 0 conflicts** |

A first attempt at this experiment normalized *both* sides independently from a shared pre-fix base and reported 29 conflicts for the treatment arm. That rig was wrong — it modelled a world where the change never lands on main — and is recorded here rather than dropped.

**Suites.** `test_po_source_location_churn` (32), `test_translations_compile`, `test_po_wrapped_string_convention`, `test_pot_creation_date_freeze`, `test_generate_translation_status`, `test_615_residual_i18n`, `test_615_mark_as_read_inversion` — 154 passed, 1 skipped. The fr and nl SPA-fully-translated gates are in that set and stay green.

## Blast radius

- **In-flight PRs touching a `.po` conflict once against this**, then never again for this reason: #1503 (community, Traditional Chinese), #1508, #1515. Resolution is mechanical — take main's catalogs and re-run `scripts/update_translations.sh`. The one-time cost buys the class.
- **`.mo` output is unaffected** — locations are comments and never reach the compiled catalog.
- No dependency, license, or external-URL change (rule 6 clear).
- Not `/security-review` class: no auth/session/CSRF, crypto, user-controlled path, or new route. The one shell-script edit adds a static flag with no untrusted input.

## No CHANGELOG entry

Deliberate — this changes no user-visible behaviour. It is contributor/translator-facing tooling. Adding an entry would also add a `CHANGELOG.md` conflict to the three PRs above for no reader's benefit.
